### PR TITLE
Fja antifungal dev

### DIFF
--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -318,6 +318,8 @@ task gambit_euk {
       merlin_tag="Candida albicans"
     elif [[ ${predicted_taxon} == *"Aspergillus fumigatus"* ]] ; then 
       merlin_tag="Aspergillus fumigatus"
+    elif [[ ${predicted_taxon} == *"Cryptococcus neoformans"* ]] ; then
+      merlin_tag="Cryptococcus neoformans"
     else 
       merlin_tag="None"
     fi

--- a/workflows/wf_merlin_magic_euk.wdl
+++ b/workflows/wf_merlin_magic_euk.wdl
@@ -70,14 +70,14 @@ workflow merlin_magic {
   String? cladetyper_version = cladetyper.version
   String? cladetyper_docker_image = cladetyper.gambit_cladetyper_docker_image
   String? cladetype_annotated_ref = cladetyper.clade_spec_ref
-  String snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version])
-  String snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query])
-  String snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits])
-  File snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results])
-  Array[File] snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs])
-  File snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results])
-  File snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam])
-  File snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai])
-  File snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary])
+  String snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version, snippy_crypto.snippy_variants_version])
+  String snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query, snippy_crypto.snippy_variants_query])
+  String snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits, snippy_crypto.snippy_variants_hits])
+  File snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results, snippy_crypto.snippy_variants_gene_query_results])
+  Array[File] snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs, snippy_crypto.snippy_outputs])
+  File snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results])
+  File snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam, snippy_crypto.snippy_variants_bam])
+  File snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai, snippy_crypto.snippy_variants_bai])
+  File snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary, snippy_crypto.snippy_variants_summary])
  }
 }

--- a/workflows/wf_merlin_magic_euk.wdl
+++ b/workflows/wf_merlin_magic_euk.wdl
@@ -53,7 +53,6 @@ workflow merlin_magic {
         samplename = samplename
         }
     }
-
   if (merlin_tag == "Cryptococcus neoformans") {
     call snippy.snippy_variants as snippy_crypto {
       input:
@@ -65,14 +64,9 @@ workflow merlin_magic {
     }
   }
   if (merlin_tag == "None") {
-    call snippy.snippy_variants as snippy_none {
-      input:
-        reference = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade1_reference.fasta",
-        read1 = read1,
-        read2 = read2,
-        samplename = samplename
+    String snippy_variants_none = ""
+    Array[File] snippy_outputs_none = []
         }
-    }
   output {
   # Typing
   String? clade_type = cladetyper.gambit_cladetype
@@ -80,14 +74,14 @@ workflow merlin_magic {
   String? cladetyper_version = cladetyper.version
   String? cladetyper_docker_image = cladetyper.gambit_cladetyper_docker_image
   String? cladetype_annotated_ref = cladetyper.clade_spec_ref
-  String snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version, snippy_crypto.snippy_variants_version, snippy_none.snippy_variants_version])
-  String snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query, snippy_crypto.snippy_variants_query, snippy_none.snippy_variants_query])
-  String snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits, snippy_crypto.snippy_variants_hits, snippy_none.snippy_variants_hits])
-  File snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results, snippy_crypto.snippy_variants_gene_query_results, snippy_none.snippy_variants_gene_query_results])
-  Array[File] snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs, snippy_crypto.snippy_outputs, snippy_none.snippy_outputs])
-  File snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results, snippy_none.snippy_variants_results])
-  File snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam, snippy_crypto.snippy_variants_bam, snippy_none.snippy_variants_bam])
-  File snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai, snippy_crypto.snippy_variants_bai, snippy_none.snippy_variants_bai])
-  File snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary, snippy_crypto.snippy_variants_summary, snippy_none.snippy_variants_summary])
+  String snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version, snippy_crypto.snippy_variants_version, snippy_variants_none])
+  String snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query, snippy_crypto.snippy_variants_query, snippy_variants_none])
+  String snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits, snippy_crypto.snippy_variants_hits, snippy_variants_none])
+  File snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results, snippy_crypto.snippy_variants_gene_query_results, snippy_variants_none])
+  Array[File] snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs, snippy_crypto.snippy_outputs, snippy_outputs_none])
+  File snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results, snippy_variants_none])
+  File snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam, snippy_crypto.snippy_variants_bam, snippy_variants_none])
+  File snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai, snippy_crypto.snippy_variants_bai, snippy_variants_none])
+  File snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary, snippy_crypto.snippy_variants_summary, snippy_variants_none])
  }
 }

--- a/workflows/wf_merlin_magic_euk.wdl
+++ b/workflows/wf_merlin_magic_euk.wdl
@@ -29,7 +29,7 @@ workflow merlin_magic {
         reference = cladetyper.clade_spec_ref,
         read1 = read1,
         read2 = read2,
-        query_gene = "FKS1",
+        query_gene = "FKS1,ERG11,FUR1",
         samplename = samplename
         }
     }
@@ -39,7 +39,7 @@ workflow merlin_magic {
         reference = "gs://theiagen-public-files/terra/theiaeuk_files/Candida_albicans_GCF_000182965.3_ASM18296v3_genomic.gbff",
         read1 = read1,
         read2 = read2,
-        query_gene = "ERG11",
+        query_gene = "ERG11,FKS1,FUR1,RTA2",
         samplename = samplename
         }
     }
@@ -49,10 +49,20 @@ workflow merlin_magic {
         reference = "gs://theiagen-public-files/terra/theiaeuk_files/Aspergillus_fumigatus_GCF_000002655.1_ASM265v1_genomic.gbff",
         read1 = read1,
         read2 = read2,
-        query_gene = "CYP51a",
+        query_gene = "CYP51a,HAPE,COX10",
         samplename = samplename
         }
     }
+  if (merlin_tag == "Cryptococcus neoformans") {
+    call snippy.snippy_variants as snippy_crypto {
+      input:
+        reference = "gs://theiagen-public-files/terra/theiaeuk_files/Aspergillus_fumigatus_GCF_000002655.1_ASM265v1_genomic.gbff",
+        read1 = read1,
+        read2 = read2,
+        query_gene = "ERG11",
+        samplename = samplename
+    }
+  }
   output {
   # Candida Typing
   String? clade_type = cladetyper.gambit_cladetype

--- a/workflows/wf_theiaeuk_pe.wdl
+++ b/workflows/wf_theiaeuk_pe.wdl
@@ -19,11 +19,11 @@ workflow theiaeuk_illumina_pe {
     String seq_method = "ILLUMINA"
     File read1_raw
     File read2_raw
-    Int min_reads = 10000
+    Int min_reads = 30000
     #Edited default values
-    Int min_basepairs = 2241820
-    Int min_genome_size = 100000
-    Int max_genome_size = 50000000
+    Int min_basepairs = 90000000
+    Int min_genome_size = 9000000
+    Int max_genome_size = 178000000
     Int min_coverage = 10
     Int min_proportion = 50
     Boolean skip_screen = false 


### PR DESCRIPTION
This PR does the following:

- adds support for Cryptococcus neoformans
- adds complete list of genes containing known resistance conferring mutations for all organism-specific antifungal resistance detection modules
- modifies default screening parameters based on known max and min sizes of pathogenic fungal genomes