### PR TITLE
Fix merlin_magic_euk when merlin_tag is "None"

### DIFF
--- a/workflows/wf_merlin_magic_euk.wdl
+++ b/workflows/wf_merlin_magic_euk.wdl
@@ -63,6 +63,11 @@ workflow merlin_magic {
         samplename = samplename
     }
   }
+  if (merlin_tag == "None") {
+    String snippy_variants_none = "No matching taxon detected"
+    File snippy_variants_none_file = "gs://theiagen-public-files/terra/theiaeuk_files/no_match_detected.txt"
+    Array[File] snippy_outputs_none = []
+        }
   output {
   # Typing
   String? clade_type = cladetyper.gambit_cladetype
@@ -70,14 +75,14 @@ workflow merlin_magic {
   String? cladetyper_version = cladetyper.version
   String? cladetyper_docker_image = cladetyper.gambit_cladetyper_docker_image
   String? cladetype_annotated_ref = cladetyper.clade_spec_ref
-  String? snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version, snippy_crypto.snippy_variants_version])
-  String? snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query, snippy_crypto.snippy_variants_query])
-  String? snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits, snippy_crypto.snippy_variants_hits])
-  File? snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results, snippy_crypto.snippy_variants_gene_query_results])
-  Array[File]? snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs, snippy_crypto.snippy_outputs])
-  File? snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results])
-  File? snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam, snippy_crypto.snippy_variants_bam])
-  File? snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai, snippy_crypto.snippy_variants_bai])
-  File? snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary, snippy_crypto.snippy_variants_summary])
+  String snippy_variants_version = select_first([snippy_cauris.snippy_variants_version, snippy_calbicans.snippy_variants_version, snippy_afumigatus.snippy_variants_version, snippy_crypto.snippy_variants_version, snippy_variants_none])
+  String snippy_variants_query = select_first([snippy_cauris.snippy_variants_query, snippy_calbicans.snippy_variants_query, snippy_afumigatus.snippy_variants_query, snippy_crypto.snippy_variants_query, snippy_variants_none])
+  String snippy_variants_hits = select_first([snippy_cauris.snippy_variants_hits, snippy_calbicans.snippy_variants_hits, snippy_afumigatus.snippy_variants_hits, snippy_crypto.snippy_variants_hits, snippy_variants_none])
+  File snippy_variants_gene_query_results = select_first([snippy_cauris.snippy_variants_gene_query_results, snippy_calbicans.snippy_variants_gene_query_results, snippy_afumigatus.snippy_variants_gene_query_results, snippy_crypto.snippy_variants_gene_query_results, snippy_variants_none_file])
+  Array[File] snippy_outputs = select_first([snippy_cauris.snippy_outputs, snippy_calbicans.snippy_outputs, snippy_afumigatus.snippy_outputs, snippy_crypto.snippy_outputs, snippy_outputs_none])
+  File snippy_variants_results = select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results, snippy_variants_none_file])
+  File snippy_variants_bam = select_first([snippy_cauris.snippy_variants_bam, snippy_calbicans.snippy_variants_bam, snippy_afumigatus.snippy_variants_bam, snippy_crypto.snippy_variants_bam, snippy_variants_none_file])
+  File snippy_variants_bai = select_first([snippy_cauris.snippy_variants_bai, snippy_calbicans.snippy_variants_bai, snippy_afumigatus.snippy_variants_bai, snippy_crypto.snippy_variants_bai, snippy_variants_none_file])
+  File snippy_variants_summary = select_first([snippy_cauris.snippy_variants_summary, snippy_calbicans.snippy_variants_summary, snippy_afumigatus.snippy_variants_summary, snippy_crypto.snippy_variants_summary, snippy_variants_none_file])
  }
 }

--- a/workflows/wf_merlin_magic_euk.wdl
+++ b/workflows/wf_merlin_magic_euk.wdl
@@ -56,7 +56,7 @@ workflow merlin_magic {
   if (merlin_tag == "Cryptococcus neoformans") {
     call snippy.snippy_variants as snippy_crypto {
       input:
-        reference = "gs://theiagen-public-files/terra/theiaeuk_files/Aspergillus_fumigatus_GCF_000002655.1_ASM265v1_genomic.gbff",
+        reference = "gs://theiagen-public-files/terra/theiaeuk_files/Cryptococcus_neoformans_GCF_000091045.1_ASM9104v1_genomic.gbff",
         read1 = read1,
         read2 = read2,
         query_gene = "ERG11",


### PR DESCRIPTION
This PR addresses an issue in which samples where the gambit_predicted_taxon results in a merlin_tag of "None" fail the wf_merlin_magic_euk.wdl workflow. This can occur when gambit fails to predict a taxon or when the predicted taxon does not match a merlin_tag. This issue is described in issue https://github.com/theiagen/public_health_bioinformatics/issues/16. 

The failure occurs because several of the merlin_magic_euk outputs are files produced by the snippy variants task, and select_first is used to select the correct output file for the sample's taxon. Currently, when merlin_tag == "None", the merlin magic euk workflow creates an empty string variable called "snippy_variant_none" that it attempts to use for these outputs. However, a string cannot be coerced to a file, causing the following error:

`"Failed to evaluate 'merlin_magic.snippy_variants_results' (reason 1 of 1): Evaluating select_first([snippy_cauris.snippy_variants_results, snippy_calbicans.snippy_variants_results, snippy_afumigatus.snippy_variants_results, snippy_crypto.snippy_variants_results, snippy_variants_none]) failed: Cannot coerce the empty String value "" into a File."`

This PR substitutes the "snippy_variants_none" file for a dummy text file, which allows the workflow to proceed. It is not an ideal solution because this text file shows up in the user's data table, but it does minimize the number of output columns.

This PR also fixes the Cryptococcus neoformans reference genome passed to snippy variants as described in issue https://github.com/theiagen/public_health_bioinformatics/issues/17.
