### PR TITLE
add nanoplot to wf_read_QC_trim_ont.wdl

### DIFF
--- a/tasks/quality_control/task_nanoplot.wdl
+++ b/tasks/quality_control/task_nanoplot.wdl
@@ -1,0 +1,44 @@
+version 1.0
+
+task nanoplot {
+  input {
+    File reads
+    String samplename
+    Int max_length = 100000
+    Int disk_size = 100
+  }
+  command <<<
+    # get version
+    NanoPlot --version | tee "VERSION"
+
+    # run nanoplot
+    # --prefix for output file tag
+    # --threads for number of threads allowed
+    # --N50 to display N50 mark in read length histogram
+    # --loglength to show logarithmic scaling of lengths
+    # --tsv_stats to output the stats file in TSV format
+    # --maxlength to hide reads longer than this
+    NanoPlot \
+      --fastq ~{reads} \
+      --prefix "~{samplename}_" \
+      --threads 4 \
+      --N50 \
+      --loglength \
+      --tsv_stats \
+      --maxlength ~{max_length}
+   
+  >>>
+  output {
+    File nanoplot_html = "~{samplename}_NanoPlot-report.html"
+    String nanoplot_version = read_string("VERSION")
+  }
+  runtime {
+    docker: "staphb/nanoplot:1.40.0"
+    memory: "16 GB"
+    cpu: 4
+    disks: "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    preemptible: 0
+    maxRetries: 3
+  }
+}

--- a/tasks/quality_control/task_nanoq.wdl
+++ b/tasks/quality_control/task_nanoq.wdl
@@ -18,7 +18,7 @@ task nanoq {
     nanoq -i ~{reads} --min-len ~{min_read_length} --max-len ~{max_read_length} --min-qual ~{min_read_qual} --max-qual ~{max_read_qual} -o ~{samplename}_reads.fastq.gz
   >>>
   output {
-    File filtered_reads = "${samplename}_reads.fq.gz"
+    File filtered_reads = "${samplename}_reads.fastq.gz"
     String version = read_string("VERSION")
   }
   runtime {

--- a/tasks/quality_control/task_nanoq.wdl
+++ b/tasks/quality_control/task_nanoq.wdl
@@ -15,7 +15,7 @@ task nanoq {
     # capture date and version
     nanoq --version | grep nanoq | tee VERSION
 
-    nanoq -i ~{reads} --min-len ~{min_read_length} --max-len ~{max_read_length} --min-qual ~{min_read_qual} --max-qual ~{max_read_qual} -o ~{samplename}_reads.fq.gz
+    nanoq -i ~{reads} --min-len ~{min_read_length} --max-len ~{max_read_length} --min-qual ~{min_read_qual} --max-qual ~{max_read_qual} -o ~{samplename}_reads.fastq.gz
   >>>
   output {
     File filtered_reads = "${samplename}_reads.fq.gz"

--- a/tasks/quality_control/task_screen.wdl
+++ b/tasks/quality_control/task_screen.wdl
@@ -278,6 +278,8 @@ task check_reads_ont { # placeholder task
   command <<<
     flag="PASS"
 
+    # add KMC for estimated_genome_size
+
     # estimated_genome_size=0
     # if [[ "~{skip_screen}" = "false" ]] ; then
       

--- a/workflows/utilities/wf_read_QC_trim_ont.wdl
+++ b/workflows/utilities/wf_read_QC_trim_ont.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
 import "../../tasks/quality_control/task_fastq_scan.wdl" as fastq_scan
+import "../../tasks/quality_control/task_nanoplot.wdl" as nanoplot_task
 # import "../../tasks/utilities/task_rasusa.wdl" as rasusa_task
 
 workflow read_QC_trim_ont {
@@ -18,9 +19,11 @@ workflow read_QC_trim_ont {
       read1_name = samplename
   }
   # nanoplot
-  # call nanoplot_task.nanplot {
-
-  # }
+  call nanoplot_task.nanoplot {
+    input:
+      reads = reads,
+      samplename = samplename
+  }
   # tiptoft
   # call tiptoft_task.tiptoft {
 
@@ -54,6 +57,8 @@ workflow read_QC_trim_ont {
     File fastq_scan_report = fastq_scan_clean.fastq_scan_report
     String fastq_scan_version = fastq_scan_clean.version
     Int number_clean_reads = fastq_scan_clean.read1_seq
+    File nanoplot_html = nanoplot.nanoplot_html
+    String nanoplot_version = nanoplot.nanoplot_version
     # String rasusa_version = rasusa.rasusa_version
   }
 }


### PR DESCRIPTION
This introduces a task file that will produce an html file containing plots summarizing basic statistics of the nanopore raw reads.