### PR TITLE
basespace_fetch_PHB: account for underscores in sample name

### DIFF
--- a/workflows/utilities/data_import/wf_basespace_fetch.wdl
+++ b/workflows/utilities/data_import/wf_basespace_fetch.wdl
@@ -40,7 +40,7 @@ task fetch_bs {
     String basespace_collection_id
     String api_server
     String access_token
-    Int mem_size_gb=8
+    Int mem_size_gb = 8
     Int CPUs = 2
     Int disk_size = 100
     Int Preemptible = 1
@@ -93,7 +93,7 @@ task fetch_bs {
       mkdir ./dataset_${dataset_id} && cd ./dataset_${dataset_id}
       echo "dataset download: ${bs_command} download dataset -i ${dataset_id} -o . --retry"
       ${bs_command} download dataset -i ${dataset_id} -o . --retry && cd ..
-      echo -e "downladed data: \n $(ls ./dataset_*/*)"
+      echo -e "downloaded data: \n $(ls ./dataset_*/*)"
     done
 
     # rename FASTQ files to add back in underscores that Illumina/Basespace changed into hyphens


### PR DESCRIPTION
Setting as a draft for now until further testing is completed in Terra with a variety datasets

The purpose of this PR is to account for when Illumina/Basespace/`bs` CLI tool converts underscores `_` in samples names to hyphens `-` in basepace-downloaded FASTQ files.

For example the sample name `133_121308_G_086`, contains underscores and thus the FASTQ files downloaded via basespace will be named like so, where all underscores in the sample name are converted to hyphens:

```
133-121308-G-086_S95_L001_R1_001.fastq.gz
133-121308-G-086_S95_L001_R2_001.fastq.gz
```

So this PR does the following:
- uses `sed` to take the sample name as entered by the user & specified in the Illumina `SampleSheet.csv` file 
- converts underscores into hyphens and stores that new sample name in the bash variable `SAMPLENAME_HYPHEN_INSTEAD_OF_UNDERSCORES`
- then, this bash variable is used during FASTQ concatenation step and the final resulting FASTQ files are name after the user-defined `~{sample_name}` WDL variable (which may or may not contain underscores)

I've tested on a dataset that previous failed basespace_fetch due to this error and it ran successfully, but would like to test with datasets that were NOT affected by this issue before too, to ensure that functionality is not lost
