### PR TITLE
Correct C. auris reference files

### DIFF
--- a/tasks/assembly/task_shovill.wdl
+++ b/tasks/assembly/task_shovill.wdl
@@ -7,6 +7,8 @@ task shovill_pe {
     String samplename
     String docker = "quay.io/staphb/shovill:1.1.0"
     Int disk_size = 100
+    Int cpu = 4
+    Int memory = 16
 
     ## SHOVILL optional parameters
     ##  --depth [INT]           Sub-sample --R1/--R2 to this depth. Disable with --depth 0 (default: 150)
@@ -71,8 +73,8 @@ task shovill_pe {
   }
   runtime {
     docker: "~{docker}"
-    memory: "16 GB"
-    cpu: 4
+    memory: "~{memory} GB"
+    cpu: "~{cpu}"
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/quality_control/task_cg_pipeline.wdl
+++ b/tasks/quality_control/task_cg_pipeline.wdl
@@ -6,9 +6,11 @@ task cg_pipeline {
     File? read2
     String samplename
     String docker = "quay.io/staphb/lyveset:1.1.4f"
-    Int disk_size = 100
     String cg_pipe_opts = "--fast"
     Int genome_length
+    Int disk_size = 100
+    Int memory = 8 # added a default value here
+    Int cpu = 4 # added a default value here
   }
   command <<<
     # date and version control
@@ -96,8 +98,8 @@ task cg_pipeline {
   }
   runtime {
     docker: "~{docker}"
-    memory: "8 GB"
-    cpu: 4
+    memory: "~{memory} GB"
+    cpu: "~{cpu}"
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/quality_control/task_quast.wdl
+++ b/tasks/quality_control/task_quast.wdl
@@ -6,6 +6,8 @@ task quast {
     String samplename
     String docker = "quay.io/staphb/quast:5.0.2"
     Int disk_size = 100
+    Int memory = 2 # added default value
+    Int cpu = 2 # added default value
   }
   command <<<
     # capture date and version
@@ -48,8 +50,8 @@ task quast {
   }
   runtime {
     docker:  "~{docker}"
-    memory:  "2 GB"
-    cpu:   2
+    memory:  "~{memory} GB"
+    cpu:   "~{cpu}"
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/species_typing/task_cauris_cladetyper.wdl
+++ b/tasks/species_typing/task_cauris_cladetyper.wdl
@@ -8,17 +8,17 @@ task cauris_cladetyper {
     String docker_image = "quay.io/biocontainers/hesslab-gambit:0.5.1--py37h8902056_0"
     Int memory = 16
     Int cpu = 8
-    File ref_clade1 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade1_reference.fasta"
+    File ref_clade1 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade1_GCA_002759435.2_Cand_auris_B8441_V2_genomic.fasta"
     String ref_clade1_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade1_GCA_002759435_Cauris_B8441_V2_genomic.gbff"
-    File ref_clade2 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade2_reference.fasta"
-    String ref_clade2_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade2_CP043531.1.B11220.gb"
+    File ref_clade2 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade2_GCA_003013715.2_ASM301371v2_genomic.fasta"
+    String ref_clade2_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade2_GCA_003013715.2_ASM301371v2_genomic.gbff"
     File ref_clade3 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade3_reference.fasta"
     String ref_clade3_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade3_GCF_002775015.1_Cand_auris_B11221_V1_genomic.gbff"
     File ref_clade4 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade4_reference.fasta"
-    String ref_clade4_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade4_PYGM01000135.1.B11243.gb"
-    File ref_clade5 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade5_reference.fasta"
-    String ref_clade5_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade5_CP050673.1.IFRC2087.gb"
-  }
+    String ref_clade4_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade4_GCA_003014415.1_Cand_auris_B11243_genomic.gbff"
+    File ref_clade5 = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade5_GCA_016809505.1_ASM1680950v1_genomic.fasta"
+    String ref_clade5_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade5_GCA_016809505.1_ASM1680950v1_genomic.gbff"
+    }
   command <<<
     # date and version control
     date | tee DATE

--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -5,9 +5,11 @@ task gambit {
     File assembly
     String samplename
     String docker = "quay.io/staphb/gambit:0.5.0"
-    Int disk_size = 100
     File? gambit_db_genomes
     File? gambit_db_signatures
+    Int disk_size = 100
+    Int memory = 16 # set default
+    Int cpu = 8 # set default
   }
   # If "File" type is used Cromwell attempts to localize it, which fails because it doesn't exist yet.
   String report_path = "~{samplename}_gambit.json"
@@ -192,8 +194,8 @@ task gambit {
   }
   runtime {
     docker:  "~{docker}"
-    memory:  "16 GB"
-    cpu:   8
+    memory:  "~{memory} GB"
+    cpu:   "~{cpu}"
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -27,6 +27,9 @@ workflow theiaeuk_illumina_pe {
     Int min_coverage = 10
     Int min_proportion = 50
     Boolean skip_screen = false 
+    # default gambit outputs
+    File gambit_db_genomes = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.db"
+    File gambit_db_signatures = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.h5"
   }
   call versioning.version_capture{
     input:
@@ -85,8 +88,8 @@ workflow theiaeuk_illumina_pe {
         input:
           assembly = shovill_pe.assembly_fasta,
           samplename = samplename,
-          gambit_db_genomes = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.db",
-          gambit_db_signatures = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.h5" 
+          gambit_db_genomes = gambit_db_genomes,
+          gambit_db_signatures = gambit_db_signatures 
       }
       call ts_mlst_task.ts_mlst {
         input: 

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -7,7 +7,7 @@ import "../../tasks/quality_control/task_quast.wdl" as quast_task
 import "../../tasks/quality_control/task_cg_pipeline.wdl" as cg_pipeline_task
 import "../../tasks/quality_control/task_screen.wdl" as screen
 import "../../tasks/taxon_id/task_gambit.wdl" as gambit_task
-import "../../tasks/species_typing/task_ts_mlst.wdl" as ts_mlst_task
+# import "../../tasks/species_typing/task_ts_mlst.wdl" as ts_mlst_task
 import "../../tasks/task_versioning.wdl" as versioning
 
 workflow theiaeuk_illumina_pe {
@@ -27,9 +27,11 @@ workflow theiaeuk_illumina_pe {
     Int min_coverage = 10
     Int min_proportion = 50
     Boolean skip_screen = false 
+    Int cpu = 8
+    Int memory = 16
     # default gambit outputs
-    File gambit_db_genomes = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.db"
-    File gambit_db_signatures = "gs://theiagen-public-files/terra/candida_auris_refs/221006-theiagen-fungal-v0.1.h5"
+    File gambit_db_genomes = "gs://theiagen-public-files-rp/terra/theiaeuk-files/gambit/221130-theiagen-fungal-v0.2.db"
+    File gambit_db_signatures = "gs://theiagen-public-files-rp/terra/theiaeuk-files/gambit/221130-theiagen-fungal-v0.2.h5"
   }
   call versioning.version_capture{
     input:
@@ -70,32 +72,40 @@ workflow theiaeuk_illumina_pe {
         input:
           samplename = samplename,
           read1_cleaned = read_QC_trim.read1_clean,
-          read2_cleaned = read_QC_trim.read2_clean
+          read2_cleaned = read_QC_trim.read2_clean,
+          cpu = cpu,
+          memory = memory
       }
       call quast_task.quast {
         input:
           assembly = shovill_pe.assembly_fasta,
-          samplename = samplename
+          samplename = samplename,
+          cpu = cpu,
+          memory = memory
       }
       call cg_pipeline_task.cg_pipeline {
         input:
           read1 = read1_raw,
           read2 = read2_raw,
           samplename = samplename,
-          genome_length = clean_check_reads.est_genome_length
+          genome_length = clean_check_reads.est_genome_length,
+          cpu = cpu,
+          memory = memory
       }
       call gambit_task.gambit {
         input:
           assembly = shovill_pe.assembly_fasta,
           samplename = samplename,
           gambit_db_genomes = gambit_db_genomes,
-          gambit_db_signatures = gambit_db_signatures 
+          gambit_db_signatures = gambit_db_signatures,
+          cpu = cpu,
+          memory = memory
       }
-      call ts_mlst_task.ts_mlst {
-        input: 
-          assembly = shovill_pe.assembly_fasta,
-          samplename = samplename
-      }
+      # call ts_mlst_task.ts_mlst {
+      #   input: 
+      #     assembly = shovill_pe.assembly_fasta,
+      #     samplename = samplename
+      # }
       call merlin_magic_workflow.merlin_magic {
         input:
           merlin_tag = gambit.merlin_tag,
@@ -153,10 +163,10 @@ workflow theiaeuk_illumina_pe {
     String? gambit_db_version = gambit.gambit_db_version
     String? gambit_docker = gambit.gambit_docker
     # MLST Typing
-    File? ts_mlst_results = ts_mlst.ts_mlst_results
-    String? ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st
-    String? ts_mlst_version = ts_mlst.ts_mlst_version
-    String? ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme
+    # File? ts_mlst_results = ts_mlst.ts_mlst_results
+    # String? ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st
+    # String? ts_mlst_version = ts_mlst.ts_mlst_version
+    # String? ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme
     # Cladetyper Outputs
     String? clade_type = merlin_magic.clade_type
     String? cladetyper_analysis_date = merlin_magic.cladetyper_analysis_date

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -221,7 +221,7 @@ workflow merlin_magic {
             reference = cladetyper.clade_spec_ref,
             read1 = select_first([read1]),
             read2 = read2,
-            query_gene = "FKS1,ERG11,FUR1",
+            query_gene = "FKS1,'lanosterol 14-alpha demethylase','lanosterol_14-alpha_demethylase',FUR1,'uracil_phosphoribosyltransferase','uracil phosphoribosyltransferase'",
             samplename = samplename
         }
       }
@@ -233,7 +233,7 @@ workflow merlin_magic {
             reference = "gs://theiagen-public-files/terra/theiaeuk_files/Candida_albicans_GCF_000182965.3_ASM18296v3_genomic.gbff",
             read1 = select_first([read1]),
             read2 = read2,
-            query_gene = "ERG11,FKS1,FUR1,RTA2",
+            query_gene = "'lanosterol 14-alpha demethylase','lanosterol_14-alpha_demethylase',FKS1,FUR1,'uracil_phosphoribosyltransferase',RTA2",
             samplename = samplename
         }
       }


### PR DESCRIPTION
### This PR:

- Exposes runtime parameters for the the TheiaEuk, Nullarbor and MycoSNP workflows to allow apples-to-apples comparison

- Updates fungal GAMBIT database files to v0.2 and updates the file locations to the rp bucket

- Adds the product name for ERG11 to the resistance gene query because the "ERG11" gene name is not found in all reference genome files for Candida auris

- Additionally updates have been made to the reference files used in the C. auris cladetyper task and the subsequent snippy task. 

The reference files are available here:
ref_clade1_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade1_GCA_002759435_Cauris_B8441_V2_genomic.gbff"
ref_clade2_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade2_GCA_003013715.2_ASM301371v2_genomic.gbff"
ref_clade3_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade3_GCF_002775015.1_Cand_auris_B11221_V1_genomic.gbff"
ref_clade4_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade4_GCA_003014415.1_Cand_auris_B11243_genomic.gbff"
ref_clade5_annotated = "gs://theiagen-public-files/terra/candida_auris_refs/Cauris_Clade5_GCA_016809505.1_ASM1680950v1_genomic.gbff"
