### PR TITLE
Fix default trimming parameters 

### DIFF
--- a/tasks/assembly/task_shovill.wdl
+++ b/tasks/assembly/task_shovill.wdl
@@ -105,7 +105,7 @@ task shovill_se {
     String? genome_size
     Int min_contig_length = 200
     Float? min_coverage
-    String assembler = "spades"
+    String assembler = "skesa"
     String? assembler_options
     String? kmers
     Boolean trim = false

--- a/tasks/assembly/task_shovill.wdl
+++ b/tasks/assembly/task_shovill.wdl
@@ -38,20 +38,20 @@ task shovill_pe {
   command <<<
     shovill --version | head -1 | tee VERSION
     shovill \
-    --outdir out \
-    --R1 ~{read1_cleaned} \
-    --R2 ~{read2_cleaned} \
-    --minlen ~{min_contig_length} \
-    ~{'--depth ' + depth} \
-    ~{'--gsize ' + genome_size} \
-    ~{'--mincov ' + min_coverage} \
-    ~{'--assembler ' + assembler} \
-    ~{'--opts ' + assembler_options} \
-    ~{'--kmers ' + kmers} \
-    ~{true='--trim' false='' trim} \
-    ~{true='--noreadcorr' false='' noreadcorr} \
-    ~{true='--nostitch' false='' nostitch} \
-    ~{true='--nocorr' false='' nocorr}
+      --outdir out \
+      --R1 ~{read1_cleaned} \
+      --R2 ~{read2_cleaned} \
+      --minlen ~{min_contig_length} \
+      ~{'--depth ' + depth} \
+      ~{'--gsize ' + genome_size} \
+      ~{'--mincov ' + min_coverage} \
+      ~{'--assembler ' + assembler} \
+      ~{'--opts ' + assembler_options} \
+      ~{'--kmers ' + kmers} \
+      ~{true='--trim' false='' trim} \
+      ~{true='--noreadcorr' false='' noreadcorr} \
+      ~{true='--nostitch' false='' nostitch} \
+      ~{true='--nocorr' false='' nocorr}
 
     mv out/contigs.fa out/~{samplename}_contigs.fasta
 
@@ -62,7 +62,6 @@ task shovill_pe {
     elif [ "~{assembler}" == "velvet" ] ; then
       mv out/contigs.LastGraph out/~{samplename}_contigs.LastGraph
     fi
-    
   >>>
   output {
     File assembly_fasta = "out/~{samplename}_contigs.fasta"
@@ -115,18 +114,18 @@ task shovill_se {
   command <<<
     shovill-se --version | head -1 | tee VERSION
     shovill-se \
-    --outdir out \
-    --se ~{read1_cleaned} 
-    --minlen ~{min_contig_length} \
-    ~{'--depth ' + depth} \
-    ~{'--gsize ' + genome_size} \
-    ~{'--mincov ' + min_coverage} \
-    ~{'--assembler ' + assembler} \
-    ~{'--opts ' + assembler_options} \
-    ~{'--kmers ' + kmers} \
-    ~{true='--trim' false='' trim} \
-    ~{true='--noreadcorr' false='' noreadcorr} \
-    ~{true='--nocorr' false='' nocorr}
+      --outdir out \
+      --se ~{read1_cleaned} 
+      --minlen ~{min_contig_length} \
+      ~{'--depth ' + depth} \
+      ~{'--gsize ' + genome_size} \
+      ~{'--mincov ' + min_coverage} \
+      ~{'--assembler ' + assembler} \
+      ~{'--opts ' + assembler_options} \
+      ~{'--kmers ' + kmers} \
+      ~{true='--trim' false='' trim} \
+      ~{true='--noreadcorr' false='' noreadcorr} \
+      ~{true='--nocorr' false='' nocorr}
 
     mv out/contigs.fa out/~{samplename}_contigs.fasta
 

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -30,6 +30,9 @@ workflow theiacov_illumina_pe {
     Int min_depth = 100
     String organism = "sars-cov-2"
     Boolean trim_primers = true
+    Int trim_minlen = 75
+    Int trim_quality_trim_score = 30
+    Int trim_window_size = 4
     File? adapters
     File? phix
     String nextclade_flu_h1n1_ha_tag = "2023-01-27T12:00:00Z"
@@ -46,6 +49,9 @@ workflow theiacov_illumina_pe {
       samplename = samplename,
       read1_raw = read1_raw,
       read2_raw = read2_raw,
+      trim_minlen = trim_minlen,
+      trim_quality_trim_score = trim_quality_trim_score,
+      trim_window_size = trim_window_size
       adapters = adapters,
       phix = phix,
       workflow_series = "theiacov"

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -51,7 +51,7 @@ workflow theiacov_illumina_pe {
       read2_raw = read2_raw,
       trim_minlen = trim_minlen,
       trim_quality_trim_score = trim_quality_trim_score,
-      trim_window_size = trim_window_size
+      trim_window_size = trim_window_size,
       adapters = adapters,
       phix = phix,
       workflow_series = "theiacov"

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -25,6 +25,9 @@ workflow theiacov_illumina_se {
     Int min_depth = 100
     String organism = "sars-cov-2"
     Boolean trim_primers = true
+    Int trim_minlen = 25
+    Int trim_quality_trim_score = 30
+    Int trim_window_size = 4
     File? adapters
     File? phix
   }
@@ -32,6 +35,9 @@ workflow theiacov_illumina_se {
     input:
       samplename = samplename,
       read1_raw = read1_raw,
+      trim_minlen = trim_minlen,
+      trim_quality_trim_score = trim_quality_trim_score,
+      trim_window_size = trim_window_size,
       adapters = adapters,
       phix = phix,
       workflow_series = "theiacov"

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -21,11 +21,11 @@ workflow theiaeuk_illumina_pe {
     File read2_raw
     Int min_reads = 30000
     # Edited default values
-    Int min_basepairs = 90000000
+    Int min_basepairs = 45000000
     Int min_genome_size = 9000000
     Int max_genome_size = 178000000
     Int min_coverage = 10
-    Int min_proportion = 50
+    Int min_proportion = 40
     Int trim_minlen = 75
     Int trim_quality_trim_score = 20
     Int trim_window_size = 10

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -26,6 +26,9 @@ workflow theiaeuk_illumina_pe {
     Int max_genome_size = 178000000
     Int min_coverage = 10
     Int min_proportion = 50
+    Int trim_minlen = 75
+    Int trim_quality_trim_score = 20
+    Int trim_window_size = 10
     Boolean skip_screen = false 
     Int cpu = 8
     Int memory = 16
@@ -53,7 +56,10 @@ workflow theiaeuk_illumina_pe {
       input:
         samplename = samplename,
         read1_raw = read1_raw,
-        read2_raw = read2_raw
+        read2_raw = read2_raw,
+        trim_minlen = trim_minlen,
+        trim_quality_trim_score = trim_quality_trim_score,
+        trim_window_size = trim_window_size
     }
     call screen.check_reads as clean_check_reads {
       input:

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -46,6 +46,9 @@ workflow theiaprok_illumina_pe {
     Int max_genome_size = 18040666
     Int min_coverage = 10
     Int min_proportion = 40
+    Int trim_minlen = 75
+    Int trim_quality_trim_score = 20
+    Int trim_window_size = 10
     Boolean call_resfinder = false
     Boolean skip_screen = false 
     String genome_annotation = "prokka"
@@ -72,7 +75,11 @@ workflow theiaprok_illumina_pe {
       input:
         samplename = samplename,
         read1_raw = read1_raw,
-        read2_raw = read2_raw
+        read2_raw = read2_raw,
+        trim_minlen = trim_minlen,
+        trim_quality_trim_score = trim_quality_trim_score,
+        trim_window_size = trim_window_size
+
     }
     call screen.check_reads as clean_check_reads {
       input:

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -43,6 +43,9 @@ workflow theiaprok_illumina_se {
     Int min_genome_size = 100000
     Int max_genome_size = 18040666
     Int min_coverage = 10
+    Int trim_minlen = 25
+    Int trim_quality_trim_score = 30
+    Int trim_window_size = 4
     Boolean call_resfinder = false
     Boolean skip_screen = false 
     String genome_annotation = "prokka"
@@ -64,7 +67,10 @@ workflow theiaprok_illumina_se {
     call read_qc.read_QC_trim_se as read_QC_trim {
       input:
         samplename = samplename,
-        read1_raw = read1_raw
+        read1_raw = read1_raw,
+        trim_minlen = trim_minlen,
+        trim_quality_trim_score = trim_quality_trim_score,
+        trim_window_size = trim_window_size
     }
     call screen.check_reads_se as clean_check_reads {
       input:


### PR DESCRIPTION
This PR:

- Makes default trimming parameters inputs at the workflow level (TheiaCoV, TheiaProk, TheiaEuk) to fix issue where PHVG parameters were used for TheiaProk and TheiaEuk
- Lowers min_proportion read screen in TheiaEuk from 50 to 40
- Lowers min_basepairs read screen in TheiaEuk from 90000000 to 45000000 because it assesses the nucleotides in only one read file
- Modifies shovill_se task to use SKESA rather than SPAdes