### PR TITLE
Fix snp_sites in snippy_tree workflow

### DIFF
--- a/workflows/phylogenetics/wf_snippy_tree.wdl
+++ b/workflows/phylogenetics/wf_snippy_tree.wdl
@@ -43,7 +43,8 @@ workflow snippy_tree_wf {
         input:
           msa_fasta = gubbins.gubbins_polymorphic_fasta,
           output_name = tree_name,
-          output_multifasta = true
+          output_multifasta = true,
+          allow_wildcard_bases = false
       }
     }
   }
@@ -53,7 +54,8 @@ workflow snippy_tree_wf {
         input:
           msa_fasta = snippy_core.snippy_full_alignment_clean,
           output_name = tree_name,
-          output_multifasta = true
+          output_multifasta = true,
+          allow_wildcard_bases = false
       }
     }
   }


### PR DESCRIPTION
This PR adds the -c param to snp_sites in snippy_tree to obtain a true core genome alignment