### PR TITLE
updated SRA_Fetch_PHB workflow to use fastq-dl v2.0.1

### DIFF
--- a/workflows/utilities/data_import/wf_sra_fetch.wdl
+++ b/workflows/utilities/data_import/wf_sra_fetch.wdl
@@ -3,10 +3,18 @@ version 1.0
 workflow fetch_sra_to_fastq {
   input {
     String sra_accession
+    String? docker
+    Int? disk_size
+    Int? memory
+    Int? cpus
   }
   call fastq_dl_sra {
     input:
-      sra_accession=sra_accession
+      sra_accession = sra_accession,
+      docker = docker,
+      disk_size = disk_size,
+      cpus = cpus,
+      memory = memory
   }
   output {
     File read1 = fastq_dl_sra.read1
@@ -17,10 +25,14 @@ workflow fetch_sra_to_fastq {
 task fastq_dl_sra {
   input {
     String sra_accession
+    String docker = "quay.io/biocontainers/fastq-dl:2.0.1--pyhdfd78af_0"
+    Int disk_size = 100
+    Int cpus = 2
+    Int memory = 8
   }
   command <<<
     fastq-dl --version | tee VERSION
-    fastq-dl ~{sra_accession} SRA
+    fastq-dl -a ~{sra_accession}
 
     # tag single-end reads with _1
     if [ -f "~{sra_accession}.fastq.gz" ] && [ ! -f "~{sra_accession}_1.fastq.gz" ]; then
@@ -32,10 +44,11 @@ task fastq_dl_sra {
     File? read2 = "~{sra_accession}_2.fastq.gz"
   }
   runtime {
-    docker: "quay.io/biocontainers/fastq-dl:1.1.0--hdfd78af_0"
-    memory:"8 GB"
-    cpu: 2
-    disks: "local-disk 100 SSD"
+    docker: docker
+    memory: memory + " GB"
+    cpu: cpus
+    disks:  "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB" # TES
     preemptible:  1
   }
 }


### PR DESCRIPTION
also exposed optional inputs for docker, disk_size, memory, cpus. 

tested fine with miniwdl and on Terra (but only in cases where data is available on ENA).

2 tests on Terra:
1. https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_PulseNet/job_history/c1e1c9a1-698a-4794-8fa5-2ba6af7c5ccd
2. The failures for this submission are due to data not being available on ENA, safe to ignore for now. https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_PulseNet/job_history/81e35181-03cd-4841-b0bf-4b498257f5fd

If data is not available on ENA, the workflow will fail, but this is a rare scenario where either the SRA accession is incorrect or the data was only recently (last1-2 weeks) uploaded to SRA (and thus not yet synced to ENA).

`fastq-dl` will soon be updated to query SRA when data is not available on ENA, so that scenario can be eliminated with a simple version upgrade.