### PR TITLE
add optional String input `fastq_dl_opts` for sra_fetch workflow

### DIFF
--- a/workflows/utilities/data_import/wf_sra_fetch.wdl
+++ b/workflows/utilities/data_import/wf_sra_fetch.wdl
@@ -7,6 +7,7 @@ workflow fetch_sra_to_fastq {
     Int? disk_size
     Int? memory
     Int? cpus
+    String? fastq_dl_opts
   }
   call fastq_dl_sra {
     input:
@@ -14,7 +15,8 @@ workflow fetch_sra_to_fastq {
       docker = docker,
       disk_size = disk_size,
       cpus = cpus,
-      memory = memory
+      memory = memory,
+      fastq_dl_opts = fastq_dl_opts
   }
   output {
     File read1 = fastq_dl_sra.read1
@@ -29,10 +31,11 @@ task fastq_dl_sra {
     Int disk_size = 100
     Int cpus = 2
     Int memory = 8
+    String? fastq_dl_opts
   }
   command <<<
     fastq-dl --version | tee VERSION
-    fastq-dl -a ~{sra_accession}
+    fastq-dl -a ~{sra_accession} ~{fastq_dl_opts}
 
     # tag single-end reads with _1
     if [ -f "~{sra_accession}.fastq.gz" ] && [ ! -f "~{sra_accession}_1.fastq.gz" ]; then


### PR DESCRIPTION
Allows user to pass in `fastq-dl` options as a string.

Example, passing in `--provder sra` to download data from SRA instead of the default, ENA. 

Useful in rare scenarios where ENA only has 1 of 2 FASTQ files (odd scenario where the 2 databases are not in sync). example: SRR13302127

Tested fine in Terra, as long as you don't make typos!