### PR TITLE
Prevent assemblies & ONT data from Vibrio submodules

### DIFF
--- a/tasks/species_typing/task_srst2_vibrio.wdl
+++ b/tasks/species_typing/task_srst2_vibrio.wdl
@@ -5,8 +5,8 @@ task srst2_vibrio {
     description: "Use of SRST2 to identify sequences of interest from a database of curated Vibrio sequences"
   }
   input {
-    File reads1
-    File? reads2
+    File read1
+    File? read2
     String samplename
     Int srst2_min_cov
     Int srst2_max_divergence
@@ -18,12 +18,12 @@ task srst2_vibrio {
     Int cpu = 4
   }
   command <<<
-    if [ -z "~{reads2}" ] ; then
-      INPUT_READS="--input_se ~{reads1}"
+    if [ -z "~{read2}" ] ; then
+      INPUT_READS="--input_se ~{read1}"
     else
       # This task expects/requires that input FASTQ files end in "_1.clean.fastq.gz" and "_2.clean.fastq.gz"
       # which is the syntax from TheiaProk read cleaning tasks
-      INPUT_READS="--input_pe ~{reads1} ~{reads2} --forward _1.clean --reverse _2.clean"
+      INPUT_READS="--input_pe ~{read1} ~{read2} --forward _1.clean --reverse _2.clean"
     fi
 
     srst2 --version 2>&1 | tee VERSION

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -636,7 +636,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: 1c4612fefeb332a035b7c16a834fbc5a
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 18a88b11ff96b9040aca299004a7aeb5
+      md5sum: 8e3be8f1fadbb14d1992d8d98f57b1cb
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       md5sum: 40d4e09a82030c8219b37f883cddaca4
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -602,7 +602,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: f38861b5c78e4a5b759da6b9599b140e
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 18a88b11ff96b9040aca299004a7aeb5
+      md5sum: 8e3be8f1fadbb14d1992d8d98f57b1cb
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 53d322d895837c0bcb049786572e944d
     - path: miniwdl_run/workflow.log

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -321,7 +321,7 @@ workflow merlin_magic {
     }
   }
   if (merlin_tag == "Vibrio") {
-    if (!assembly_only) {
+    if (!assembly_only && !ont_data) {
       call srst2_vibrio_task.srst2_vibrio {
         input:
           read1 = select_first([read1]),

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -321,16 +321,18 @@ workflow merlin_magic {
     }
   }
   if (merlin_tag == "Vibrio") {
-    call srst2_vibrio_task.srst2_vibrio {
-      input:
-        reads1 = select_first([read1]),
-        reads2 = read2,
-        samplename = samplename,
-        srst2_min_cov = srst2_min_cov,
-        srst2_max_divergence = srst2_max_divergence,
-        srst2_min_depth = srst2_min_depth,
-        srst2_min_edge_depth = srst2_min_edge_depth,
-        srst2_gene_max_mismatch = srst2_gene_max_mismatch
+    if (!assembly_only) {
+      call srst2_vibrio_task.srst2_vibrio {
+        input:
+          read1 = select_first([read1]),
+          read2 = read2,
+          samplename = samplename,
+          srst2_min_cov = srst2_min_cov,
+          srst2_max_divergence = srst2_max_divergence,
+          srst2_min_depth = srst2_min_depth,
+          srst2_min_edge_depth = srst2_min_edge_depth,
+          srst2_gene_max_mismatch = srst2_gene_max_mismatch
+      }
     }
   }
   


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

Adds some logic flags to prevent assemblies & ont data from being run on Illumina-specific Vibrio task.

## :brain: Context and Rationale

Also changed reads1 and reads2 to read1 and read2

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)