### PR TITLE
make assembly_fasta optional

### DIFF
--- a/workflows/phylogenetics/wf_snippy_streamline.wdl
+++ b/workflows/phylogenetics/wf_snippy_streamline.wdl
@@ -11,7 +11,7 @@ workflow snippy_streamline {
   input {
     Array[File] read1
     Array[File] read2
-    Array[File] assembly_fasta
+    Array[File]? assembly_fasta
     Array[String] samplenames
     String tree_name
     # this input file can be a FASTA or GBK
@@ -21,7 +21,7 @@ workflow snippy_streamline {
   if (! defined(reference_genome_file)) {
     call centroid_task.centroid {
       input:
-        assembly_fasta = assembly_fasta
+        assembly_fasta = select_first([assembly_fasta])
     }
     call referenceseeker_task.referenceseeker {
       input:


### PR DESCRIPTION
Closes #88 
## :hammer_and_wrench: Changes Being Made

`assembly_fasta` is a required input for Snippy_Streamline; however, if a reference is provided, `assembly_fasta` is not used but still considered required. I have changed assembly_fasta to be optional. 

## :brain: Context and Rationale

## :clipboard: Workflow/Task Steps

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)