### PR TITLE
New metadata output on summarize_data task for phylogenetic workflows

### DIFF
--- a/tasks/utilities/task_summarize_data.wdl
+++ b/tasks/utilities/task_summarize_data.wdl
@@ -60,7 +60,10 @@ task summarize_data {
   columns = "~{column_names}".split(",")
 
   temporarylist = []
-  temporarylist.append("~{terra_table}_id")
+  if (os.environ["default_column"] == "true"):
+    temporarylist.append("~{terra_table}_id")
+  else:
+    temporarylist.append("~{id_column_name}")
   temporarylist += columns
 
   table = table[temporarylist].copy()
@@ -68,7 +71,11 @@ task summarize_data {
 
   # create a table to search through containing only columns of interest
   searchtable = table[columns].copy()
-  filteredmetadata = searchtable.set_index(table["~{terra_table}_id"])
+
+  if (os.environ["default_column"] == "true"):
+    filteredmetadata = searchtable.set_index(table["~{terra_table}_id"])
+  else:
+    filteredmetadata = searchtable.set_index(table["~{id_column_name}"])
   filteredmetadata.to_csv("~{output_prefix}_filtered_metadata.tsv", sep='\t', index=True)
 
   # iterate through the columns of interest and combine into a single list

--- a/tasks/utilities/task_summarize_data.wdl
+++ b/tasks/utilities/task_summarize_data.wdl
@@ -42,6 +42,9 @@ task summarize_data {
   # extract the samples for upload from the entire table
   table = table[table["~{terra_table}_id"].isin("~{sep='*' sample_names}".split("*"))]
 
+  # cast entire table as str
+  table = table.astype(str)
+  
   # split comma-separated column list into an array
   columns = "~{column_names}".split(",")
 
@@ -70,7 +73,7 @@ task summarize_data {
       if (i < 10):
         newgroup = [] # create a new temporary sublist
         for item in group: # for every item in a column, 
-          newitem = item + ":o" + str(i) # add a unique :o coloring (as indicated by the str(i))
+          newitem = str(item) + ":o" + str(i) # add a unique :o coloring (as indicated by the str(i))
           newgroup.append(newitem) # add phandango-suffixed item to the new sublist
         newgenes.append(newgroup) # add the new sublist to the new list
         i += 1 # increment the i value so each column gets its own coloring     


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

This PR adds several changes to the `summarize_data` task:
- the ability to specify a different column to use as samplenames
- prevents failures due to variable typing
- adds a new output that consists of the "filtered" metadata -- only the columns of interest

## :brain: Context and Rationale

As per request

## :clipboard: Workflow/Task Steps

### Inputs

New optional input: `id_column_name` which should be filled with the name of the "samplename" column in the case where samplename is not the root entity column.

### Outputs

New output: the filtered metadata tsv

## :test_tube: Testing

### Locally

Local tests worked.

### Terra

Test peformed here: https://app.terra.bio/#workspaces/theiagen-sphl-nevada/dataAnalysis_BACT_NV_PHL/job_history/84ee85ec-96fe-4200-91c2-f50e5ca63821

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)