### PR TITLE
shigeifinder 1.3.5 updates

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -62,10 +62,14 @@ jobs:
           auto-activate-base: false
 
       # Depends and env info (mostly for debug)
-      - name: Install Dependencies
+      # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Install Dependencies and create storage space
         run: |
           conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
+          conda clean -a -y
           uname -a && env
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Test ${{ matrix.tag }}
         run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes

--- a/tasks/species_typing/task_shigeifinder.wdl
+++ b/tasks/species_typing/task_shigeifinder.wdl
@@ -4,15 +4,17 @@ task shigeifinder {
   input {
     File assembly
     String samplename
-    String docker = "quay.io/staphb/shigeifinder:1.3.3"
+    String docker = "staphb/shigeifinder:1.3.5"
     Int disk_size = 100
     Int cpu = 2
+    Int memory = 8
   }
   command <<<
     # capture date
     date | tee DATE
-    # shigeifinder does not have a --version flag, relying upon the docker image tag for the version - which StaPH-B/Curtis maintains
-    echo "~{docker}" | sed 's|staphb/shigeifinder:||' | tee VERSION.txt
+
+    # version flag added in v1.3.5, so not backwards compatible with older versions
+    shigeifinder --version | tee VERSION.txt
 
     # ShigEiFinder checks that all dependencies are installed before running
     echo "checking for shigeifinder dependencies and running ShigEiFinder..."
@@ -70,7 +72,7 @@ task shigeifinder {
   }
   runtime {
     docker: "~{docker}"
-    memory: "8 GB"
+    memory: "~{memory} GB"
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
@@ -83,16 +85,18 @@ task shigeifinder_reads {
     File read1
     File? read2
     String samplename
-    String docker = "quay.io/staphb/shigeifinder:1.3.3"
+    String docker = "staphb/shigeifinder:1.3.5"
     Int disk_size = 100
     Int cpu = 4
+    Int memory = 8
     Boolean paired_end = true
   }
   command <<<
     # capture date
     date | tee DATE
-    # shigeifinder does not have a --version flag, relying upon the docker image tag for the version - which StaPH-B/Curtis maintains
-    echo "~{docker}" | sed 's|staphb/shigeifinder:||' | tee VERSION.txt
+
+    # version flag added in v1.3.5, so not backwards compatible with older versions
+   shigeifinder --version | tee VERSION.txt
 
     # ShigEiFinder checks that all dependencies are installed before running
     echo "checking for shigeifinder dependencies and running ShigEiFinder..."
@@ -151,7 +155,7 @@ task shigeifinder_reads {
   }
   runtime {
     docker: "~{docker}"
-    memory: "8 GB"
+    memory: "~{memory} GB"
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -30,9 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 6d6543d3aacc310fe866c5e90d1dff77
+      md5sum: 2323ca08d3132d198a68e637becea3db
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: 6206889552f40d7ea91f1d9ae025f23d
+      md5sum: df6b62b3e5679b365be6644e8b4882d3
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -550,9 +550,9 @@
     - path: miniwdl_run/wdl/tasks/assembly/task_shovill.wdl
       md5sum: 85e702088edcfe8ce8fead6c42158f51
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
-      md5sum: d8e4646c2780945c7a10674e7f748a65
+      md5sum: c903bd663f831d44897b1003e259b81b
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 7678439e06ac720a26ec8229377ce5c9
+      md5sum: 340aacc58f5ed1aa8af8c697bab98e66
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: a25a79957f3c51a46a698171ab5b9f9b
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -614,7 +614,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigatyper.wdl
       md5sum: f1a95ab2881ca3911b8773ffb81b2883
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigeifinder.wdl
-      md5sum: fd62e12a2e124eab61c2ff64d3a85186
+      md5sum: fd7f4dbd824d09d69c78cc24c7fb935b
     - path: miniwdl_run/wdl/tasks/species_typing/task_sistr.wdl
       md5sum: 2294dfcb4accdb7cde2fcc64a2da5810
     - path: miniwdl_run/wdl/tasks/species_typing/task_sonneityping.wdl
@@ -624,7 +624,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: e7608e57ea41f8d0921618c8d168ae09
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: c56fb29430dbc7d5f42d10b34c1802a6
+      md5sum: 0700ec2fe03ba61c41aacee093028ca3
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 939f3ea920e49661390ec1005b080513
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -30,9 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_se", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 6d6543d3aacc310fe866c5e90d1dff77
+      md5sum: 2323ca08d3132d198a68e637becea3db
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: 6206889552f40d7ea91f1d9ae025f23d
+      md5sum: df6b62b3e5679b365be6644e8b4882d3
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -518,9 +518,9 @@
     - path: miniwdl_run/wdl/tasks/assembly/task_shovill.wdl
       md5sum: 85e702088edcfe8ce8fead6c42158f51
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
-      md5sum: d8e4646c2780945c7a10674e7f748a65
+      md5sum: c903bd663f831d44897b1003e259b81b
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 7678439e06ac720a26ec8229377ce5c9
+      md5sum: 340aacc58f5ed1aa8af8c697bab98e66
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: a25a79957f3c51a46a698171ab5b9f9b
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -580,7 +580,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigatyper.wdl
       md5sum: f1a95ab2881ca3911b8773ffb81b2883
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigeifinder.wdl
-      md5sum: fd62e12a2e124eab61c2ff64d3a85186
+      md5sum: fd7f4dbd824d09d69c78cc24c7fb935b
     - path: miniwdl_run/wdl/tasks/species_typing/task_sistr.wdl
       md5sum: 2294dfcb4accdb7cde2fcc64a2da5810
     - path: miniwdl_run/wdl/tasks/species_typing/task_sonneityping.wdl
@@ -590,7 +590,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: e7608e57ea41f8d0921618c8d168ae09
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: c56fb29430dbc7d5f42d10b34c1802a6
+      md5sum: 0700ec2fe03ba61c41aacee093028ca3
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 939f3ea920e49661390ec1005b080513
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl


### PR DESCRIPTION
Closes #100

~~Set as a draft until the `staphb/shigeifinder:1.3.5` docker image is available ➡️  https://github.com/StaPH-B/docker-builds/pull/687~~ Docker image is now available 

## :hammer_and_wrench: Changes Being Made

- updated default docker to `staphb/shigeifinder:1.3.5`
  - ⚠️ ~~This docker image is not yet available, but should be soon. Waiting for review over on StaPH-B/docker-builds before making this PR ready for review (and merging the PR of course).~~
- updated version capture line to use new option `shigeifinder --version`
  - ⚠️ These changes will be incompatible with shigeifinder v1.3.4 and older. Users must use 1.3.5 or newer in order for this task to run successfully
- exposed memory as optional input String for both shigeifinder WDL tasks (asm input and reads input tasks)

## :brain: Context and Rationale

Version capture for shigeifinder was  previously done via the docker image string, which is not optimal and led to issues when non-dockerhub images were used. This PR allows for the use of the new option, `shigeifinder --version` which is the best way to truly track the shigeifinder version used for analysis.

## :clipboard: Workflow/Task Steps


### Inputs

### Outputs

## :test_tube: Testing

### Locally

Passed `miniwdl check`. Did not run workflow locally.

### Terra

Tested in Terra with docker image `kapsakcj/shigeifinder:1.3.5`, ran successfully and version was captured appropriately.

Terra workflow: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/a52f7405-194f-4fed-a9a3-99e3cd3e7707

Tested again in Terra with default docker image `staphb/shigeifinder:1.3.5` and everything ran as expected: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/02718ded-db6c-4220-952e-e933fa2baa2b

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)