### PR TITLE
Update Nextclade Parsing

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -6,6 +6,9 @@
 name: Pytest Workflows
 on:
   push:
+    # remove this section once the miniwdl test is reinstated for TheiaCoV_Illumina_PE/_SE
+    paths-ignore:
+      - 'workflows/theiacov/theiacov_illumina_**'
     branches: [main]
   pull_request:
     branches: [main]

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -6,9 +6,6 @@
 name: Pytest Workflows
 on:
   push:
-    # remove this section once the miniwdl test is reinstated for TheiaCoV_Illumina_PE/_SE
-    paths-ignore:
-      - 'workflows/theiacov/theiacov_illumina_**'
     branches: [main]
   pull_request:
     branches: [main]
@@ -41,6 +38,11 @@ jobs:
         # For every workflow, test it with MiniWDL and Cromwell
         tag: ["${{ fromJson(needs.changes.outputs.workflows) }}"]
         engine: ["miniwdl", "cromwell"]
+        exclude:
+          - tag: wf_theiacov_illumina_pe
+            engine: miniwdl
+          - tag: wf_theiacov_illumina_se
+            engine: miniwdl
     defaults:
       run:
         # Play nicely with miniconda
@@ -65,14 +67,10 @@ jobs:
           auto-activate-base: false
 
       # Depends and env info (mostly for debug)
-      # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-      - name: Install Dependencies and create storage space
+      - name: Install Dependencies
         run: |
           conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
-          conda clean -a -y
           uname -a && env
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Test ${{ matrix.tag }}
         run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -39,10 +39,10 @@ jobs:
         tag: ["${{ fromJson(needs.changes.outputs.workflows) }}"]
         engine: ["miniwdl", "cromwell"]
         exclude:
-          - tag: wf_theiacov_illumina_pe
-            engine: miniwdl
-          - tag: wf_theiacov_illumina_se
-            engine: miniwdl
+          - tag: "wf_theiacov_illumina_pe"
+            engine: "miniwdl"
+          - tag: "wf_theiacov_illumina_se"
+            engine: "miniwdl"
     defaults:
       run:
         # Play nicely with miniconda

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -67,10 +67,14 @@ jobs:
           auto-activate-base: false
 
       # Depends and env info (mostly for debug)
-      - name: Install Dependencies
+      # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Install Dependencies and create storage space
         run: |
           conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
+          conda clean -a -y
           uname -a && env
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Test ${{ matrix.tag }}
         run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes

--- a/tasks/phylogenetic_inference/task_lyveset.wdl
+++ b/tasks/phylogenetic_inference/task_lyveset.wdl
@@ -6,7 +6,7 @@ task lyveset {
     Array[File] read2
     File reference_genome
     String dataset_name
-    String docker_image = "quay.io/staphb/lyveset:1.1.4f"
+    String docker_image = "staphb/lyveset:1.1.4f"
     Int memory = 64
     Int cpu = 16
     Int disk_size = 100

--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -107,14 +107,12 @@ task nextclade_output_parser {
         # combine 'clade_nextstrain' and 'clade_who' column if sars-cov-2, if false then parse 'clade' column
         if ("~{organism}" == "sars-cov-2"):
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
-            nextstrain_clade = tsv_dict['clade_nextstrain']
+            nc_clade = tsv_dict['clade_nextstrain']
             who_clade = tsv_dict['clade_who']
-            if nextclade_clade != who_clade:
-              nc_clade = nextclade_clade + " (" + who_clade + ")"
-              if nc_clade == '':
-                nc_clade = 'NA'
-            else:  # in the case where both are "recombinant," only print the first
-              nc_clade = nextclade_clade
+            if nc_clade != who_clade:
+              nc_clade = nc_clade + " (" + who_clade + ")"
+            if nc_clade == '':
+              nc_clade = 'NA'
             Nextclade_Clade.write(nc_clade)
         else:
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:

--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -109,7 +109,7 @@ task nextclade_output_parser {
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
             nc_clade = tsv_dict['clade_nextstrain']
             who_clade = tsv_dict['clade_who']
-            if nc_clade != who_clade:
+            if (nc_clade != who_clade) and (nc_clade != ''):
               nc_clade = nc_clade + " (" + who_clade + ")"
             if nc_clade == '':
               nc_clade = 'NA'

--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -91,45 +91,43 @@ task nextclade_output_parser {
 
       tamiflu_aa_subs = tamiflu_aa_subs + "~{tamiflu_aa_substitutions}".split(',')
 
-      print(tamiflu_aa_subs)
-
       def intersection(lst1, lst2):
         # returns intersection between nextclade identified aa substitutions and
         # tamiflu associated aa substitutions
         return list(set(lst1) & set(lst2))
 
       with codecs.open("./input.tsv",'r') as tsv_file:
-        tsv_reader=csv.reader(tsv_file, delimiter="\t")
-        tsv_data=list(tsv_reader)
+        tsv_reader = csv.reader(tsv_file, delimiter="\t")
+        tsv_data = list(tsv_reader)
 
-        if len(tsv_data)==1:
+        if len(tsv_data) == 1:
           tsv_data.append(['NA']*len(tsv_data[0]))
-        tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))
+        tsv_dict = dict(zip(tsv_data[0], tsv_data[1]))
 
-        # parse 'clade_legacy' column if sars-cov-2, if false then parse 'clade' column
+        # combine 'clade_nextstrain' and 'clade_who' column if sars-cov-2, if false then parse 'clade' column
         if ("~{organism}" == "sars-cov-2"):
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
-            nc_clade=tsv_dict['clade_legacy']
-            if nc_clade=='':
-              nc_clade='NA'
-            else:
-              nc_clade=nc_clade
+            nextstrain_clade = tsv_dict['clade_nextstrain']
+            who_clade = tsv_dict['clade_who']
+            if nextclade_clade != who_clade:
+              nc_clade = nextclade_clade + " (" + who_clade + ")"
+              if nc_clade == '':
+                nc_clade = 'NA'
+            else:  # in the case where both are "recombinant," only print the first
+              nc_clade = nextclade_clade
             Nextclade_Clade.write(nc_clade)
         else:
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
-            nc_clade=tsv_dict['clade']
-            if nc_clade=='':
-              nc_clade='NA'
-            else:
-              nc_clade=nc_clade
+            nc_clade = tsv_dict['clade']
+            if nc_clade == '':
+              nc_clade = 'NA'
             Nextclade_Clade.write(nc_clade)
 
         with codecs.open("NEXTCLADE_AASUBS", 'wt') as Nextclade_AA_Subs:
-          nc_aa_subs=tsv_dict['aaSubstitutions']
-          if nc_aa_subs=='':
-            nc_aa_subs='NA'
+          nc_aa_subs = tsv_dict['aaSubstitutions']
+          if nc_aa_subs == '':
+            nc_aa_subs = 'NA'
           else:
-            nc_aa_subs=nc_aa_subs
             # if organism is flu, return list of aa subs associated with tamiflu resistance
             if ("~{organism}" == "flu" and "~{NA_segment}" == "true"):
               tamiflu_subs = intersection(tamiflu_aa_subs, nc_aa_subs.split(','))
@@ -138,22 +136,18 @@ task nextclade_output_parser {
           Nextclade_AA_Subs.write(nc_aa_subs)
 
         with codecs.open("NEXTCLADE_AADELS", 'wt') as Nextclade_AA_Dels:
-          nc_aa_dels=tsv_dict['aaDeletions']
-          if nc_aa_dels=='':
-            nc_aa_dels='NA'
-          else:
-            nc_aa_dels=nc_aa_dels
+          nc_aa_dels = tsv_dict['aaDeletions']
+          if nc_aa_dels == '':
+            nc_aa_dels = 'NA'
           Nextclade_AA_Dels.write(nc_aa_dels)
 
         with codecs.open("NEXTCLADE_LINEAGE", 'wt') as Nextclade_Lineage:
           if 'lineage' in tsv_dict:
-            nc_lineage=tsv_dict['lineage']
+            nc_lineage = tsv_dict['lineage']
             if nc_lineage is None:
-              nc_lineage=""
-            else:
-              nc_lineage=nc_lineage
+              nc_lineage = ""
           else:
-            nc_lineage=""
+            nc_lineage = ""
           Nextclade_Lineage.write(nc_lineage)
       CODE
     >>>

--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -109,7 +109,7 @@ task nextclade_output_parser {
           with codecs.open("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
             nc_clade = tsv_dict['clade_nextstrain']
             who_clade = tsv_dict['clade_who']
-            if (nc_clade != who_clade) and (nc_clade != ''):
+            if (nc_clade != who_clade) and (nc_clade != '') and (who_clade != ''):
               nc_clade = nc_clade + " (" + who_clade + ")"
             if nc_clade == '':
               nc_clade = 'NA'

--- a/tests/config/pytest_filter.yml
+++ b/tests/config/pytest_filter.yml
@@ -75,10 +75,6 @@ wf_theiacov_ont:
   - tasks/gene_typing/task_sc2_gene_coverage.wdl
   - tasks/task_versioning.wdl
 
-wf_theiacov_validate:
-  - tasks/utilities/task_validate.wdl
-  - tasks/task_versioning.wdl
-
 wf_theiaprok_illumina_pe:
   - workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
   - tasks/assembly/task_shovill.wdl

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -224,9 +224,9 @@
     - path: miniwdl_run/call-nextclade/task.log
       contains: ["wdl", "theiacov_clearlabs", "nextclade", "done"]
     - path: miniwdl_run/call-nextclade/work/NEXTCLADE_VERSION
-      md5sum: d5f4e83525024cba7eb7489cd5209e7d
-    - path: miniwdl_run/call-nextclade/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
       md5sum: 91a455762183b41af0d8de5596e28e7f
+    - path: miniwdl_run/call-nextclade/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
+      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.auspice.json
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.tsv
@@ -276,7 +276,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_S.translation.fasta
       md5sum: 0ce44a0a8e2784ca4b3e8d8f03211813
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 8bab8bc62cb16fff613907f34c54ec51
+      md5sum: a01b0a826425399bc59854b7c74acb1e
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -226,7 +226,7 @@
     - path: miniwdl_run/call-nextclade/work/NEXTCLADE_VERSION
       md5sum: d5f4e83525024cba7eb7489cd5209e7d
     - path: miniwdl_run/call-nextclade/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+      md5sum: 91a455762183b41af0d8de5596e28e7f
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.auspice.json
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade/work/clearlabs.medaka.consensus.nextclade.tsv
@@ -276,7 +276,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_S.translation.fasta
       md5sum: 0ce44a0a8e2784ca4b3e8d8f03211813
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 15e4d72fff3a4e2b81ce30a4668266f0
+      md5sum: 8bab8bc62cb16fff613907f34c54ec51
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -46,7 +46,7 @@
     - path: miniwdl_run/call-nextclade/stdout.txt
     - path: miniwdl_run/call-nextclade/task.log
     - path: miniwdl_run/call-nextclade/work/NEXTCLADE_VERSION
-      md5sum: d5f4e83525024cba7eb7489cd5209e7d
+      md5sum: 91a455762183b41af0d8de5596e28e7f
     - path: miniwdl_run/call-nextclade/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-nextclade/work/clearlabs.fasta.gz.nextclade.auspice.json
     - path: miniwdl_run/call-nextclade/work/clearlabs.fasta.gz.nextclade.json
@@ -100,7 +100,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_S.translation.fasta
       md5sum: e630a638abbb2c8ab4a8b74455e9668f
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 632edfc9ac20d8134d3e22f507de1e08
+      md5sum: 8bab8bc62cb16fff613907f34c54ec51
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json
     - path: miniwdl_run/call-nextclade_output_parser/stderr.txt

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -235,7 +235,7 @@
     - path: miniwdl_run/call-nextclade/task.log
       contains: ["wdl", "theiacov_ont", "done"]
     - path: miniwdl_run/call-nextclade/work/NEXTCLADE_VERSION
-      md5sum: d5f4e83525024cba7eb7489cd5209e7d
+      md5sum: 91a455762183b41af0d8de5596e28e7f
     - path: miniwdl_run/call-nextclade/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade/work/nextclade.aligned.fasta
@@ -285,7 +285,7 @@
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 65e8a95529a0466257beed44ec71d2ca
+      md5sum: 8bab8bc62cb16fff613907f34c54ec51
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -285,7 +285,7 @@
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 8bab8bc62cb16fff613907f34c54ec51
+      md5sum: 5354c0f11f6f2301ce6f0a07dc3b3aca
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

Updates to the Nextclade output parsing.

## :brain: Context and Rationale

The latest Nextclade dataset tag (`2023-06-16T12:00:00Z`) removes the `clade_legacy` output column> Because of this, in order to maintain continuity with existing dashboards, we have decided to concatenate the `clade_nextstrain` and `clade_who` columns to mimic the content of the original `clade_legacy` output column. 

I also went through and adjusted formatting to match the style guide and removed unnecessary else statements.

## :test_tube: Testing

### Terra

https://app.terra.bio/#workspaces/cdc-terra-resources/Theiagen_Wright_SC2_Sandbox/job_history/2f4c5c0f-a9da-4c50-badf-acd2e46b7e8d

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)