### PR TITLE
BaseSpace_Fetch: convert periods to dashes

### DIFF
--- a/workflows/utilities/data_import/wf_basespace_fetch.wdl
+++ b/workflows/utilities/data_import/wf_basespace_fetch.wdl
@@ -99,7 +99,7 @@ task fetch_bs {
     # rename FASTQ files to add back in underscores that Illumina/Basespace changed into hyphens
     echo "Concatenating and renaming FASTQ files to add back underscores in basespace_sample_name"
     # setting a new bash variable to use for renaming during concatenation of FASTQs
-    SAMPLENAME_HYPHEN_INSTEAD_OF_UNDERSCORES=$(echo $sample_identifier | sed 's|_|-|g')
+    SAMPLENAME_HYPHEN_INSTEAD_OF_UNDERSCORES=$(echo $sample_identifier | sed 's|_|-|g' | sed 's|\.|-|g')
 
     #Combine non-empty read files into single file without BaseSpace filename cruft
     ##FWD Read


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

I added a brief `sed` statement to convert periods to dashes so that the downloaded read file can be identified. This is similar to  the previous issue we had in BaseSpace_Fetch with underscores turning into dashes.

## :brain: Context and Rationale

<!--What's the context of the changes? Where there any trade-offs you had to consider?-->

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

Tests succeeded in the PR-SCITRUST workspace.

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)