### PR TITLE
small shigella updates, take 2

### DIFF
--- a/tasks/species_typing/task_shigatyper.wdl
+++ b/tasks/species_typing/task_shigatyper.wdl
@@ -8,9 +8,10 @@ task shigatyper {
     File read1 
     File? read2
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/shigatyper:2.0.3"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/shigatyper:2.0.5"
     Int disk_size = 100
     Int cpus = 4
+    Int memory = 16
     Boolean read1_is_ont = false
   }
   command <<<
@@ -63,7 +64,7 @@ task shigatyper {
   }
   runtime {
     docker: "~{docker}"
-    memory: "16 GB"
+    memory: "~{memory} GB"
     cpu: cpus
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -612,7 +612,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_serotypefinder.wdl
       md5sum: 44e3a5c984b653ed61e2bcba0ff054e7
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigatyper.wdl
-      md5sum: b8d9c2a54bca3fe8161d77c704b8f8e9
+      md5sum: 7d39c9c0539ca2e70a14f889201452b4
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigeifinder.wdl
       md5sum: 5a24623416f2ac9a0a177c01c5db2501
     - path: miniwdl_run/wdl/tasks/species_typing/task_sistr.wdl
@@ -636,7 +636,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: e98bdaa0c00d01b5e77859713ab91689
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 33f917eae3094f0c74ba895b3b1d4c9d
+      md5sum: ce89635c57ef1bd84a07af59948e80ea
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       md5sum: 40d4e09a82030c8219b37f883cddaca4
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -580,7 +580,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_serotypefinder.wdl
       md5sum: 44e3a5c984b653ed61e2bcba0ff054e7
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigatyper.wdl
-      md5sum: b8d9c2a54bca3fe8161d77c704b8f8e9
+      md5sum: 7d39c9c0539ca2e70a14f889201452b4
     - path: miniwdl_run/wdl/tasks/species_typing/task_shigeifinder.wdl
       md5sum: 5a24623416f2ac9a0a177c01c5db2501
     - path: miniwdl_run/wdl/tasks/species_typing/task_sistr.wdl
@@ -604,7 +604,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 17be58829cc4e6a1780cf227a2ec99ac
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 33f917eae3094f0c74ba895b3b1d4c9d
+      md5sum: ce89635c57ef1bd84a07af59948e80ea
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 53d322d895837c0bcb049786572e944d
     - path: miniwdl_run/workflow.log

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -52,6 +52,7 @@ workflow merlin_magic {
     String? pasty_docker_image
     String? emmtypingtool_docker_image
     String? shigeifinder_docker_image
+    String? shigatyper_docker_image
     String? staphopia_sccmec_docker_image
     String? agrvate_docker_image
     String? virulencefinder_docker_image
@@ -107,7 +108,8 @@ workflow merlin_magic {
           read1 = select_first([read1]),
           read2 = read2,
           samplename = samplename,
-          read1_is_ont = ont_data
+          read1_is_ont = ont_data,
+          docker = shigatyper_docker_image
       }
     }
     call shigeifinder_task.shigeifinder {


### PR DESCRIPTION
Opened a new PR so I don't pollute the commit history with my old PR and failed attempt at rebasing. 

Need to update CI and test once more in Terra, but should be ready for review shortly

## :hammer_and_wrench: Changes Being Made

- updated default shigatyper docker image to v2.0.5 (from 2.0.3) hosted on GAR
- added optional Integer input `memory` for shigatyper task. 
- exposed optional String input `shigatyper_docker_image` in merlin_magic subwf so that user has the ability to change via TheiaProk workflows in Terra

## :brain: Context and Rationale

Previously the user was not able to adjust the shigatyper docker image, meaning they were stuck with the previous version that had a bug with Shigella flexneri serotyping. The updated version 2.0.5 fixes this bug. 

## :clipboard: Workflow/Task Steps

The usual TheiaProk workflow

### Inputs


### Outputs

## :test_tube: Testing

### Locally

only tested on Terra, these are minor changes

### Terra

Successful workflow: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/83e40c1c-125c-4515-931b-5f5496a731d6 with data table called `linlin_shigella_core_sample`

## :microscope: Quality checks



Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)