### PR TITLE
update default docker for busco to GAR docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Public Health Bioinformatics (PHB)
+
 Bioinformatics workflows for characterization, epidemiology and sharing of pathogen genomes.
 
 **More information about the steps undertaken in these workflows is available via the [Theiagen Public Resources Documentation](https://theiagen.notion.site/Theiagen-Public-Health-Resources-a4bd134b0c5c4fe39870e21029a30566).**

--- a/tasks/quality_control/task_busco.wdl
+++ b/tasks/quality_control/task_busco.wdl
@@ -7,7 +7,9 @@ task busco {
   input {
     File assembly
     String samplename
-    String docker = "ezlabgva/busco:v5.3.2_cv1" # not available on us-docker.pkg.dev/general-theiagen
+    String docker = "us-docker.pkg.dev/general-theiagen/ezlabgva/busco:v5.3.2_cv1"
+    Int memory = 8
+    Int cpu = 2
     Int disk_size = 100
     Boolean eukaryote = false
   }
@@ -50,8 +52,8 @@ task busco {
   }
   runtime {
     docker: "~{docker}"
-    memory: "8 GB"
-    cpu: 2
+    memory: "~{memory} GB"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     preemptible: 0

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -566,7 +566,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/task_bbduk.wdl
       md5sum: 90e49f4e4568393cf8d1f8720a4772ad
     - path: miniwdl_run/wdl/tasks/quality_control/task_busco.wdl
-      md5sum: eba8518737396c0655e390a49c0a5a55
+      md5sum: 0f8b3fbca316cb940a61b2c3cdf6ebab
     - path: miniwdl_run/wdl/tasks/quality_control/task_cg_pipeline.wdl
       md5sum: c8e7ae1ed0fff7b14731228db80c6b30
     - path: miniwdl_run/wdl/tasks/quality_control/task_fastp.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -536,7 +536,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/task_bbduk.wdl
       md5sum: 90e49f4e4568393cf8d1f8720a4772ad
     - path: miniwdl_run/wdl/tasks/quality_control/task_busco.wdl
-      md5sum: eba8518737396c0655e390a49c0a5a55
+      md5sum: 0f8b3fbca316cb940a61b2c3cdf6ebab
     - path: miniwdl_run/wdl/tasks/quality_control/task_cg_pipeline.wdl
       md5sum: c8e7ae1ed0fff7b14731228db80c6b30
     - path: miniwdl_run/wdl/tasks/quality_control/task_fastp.wdl


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

This PR updates the default docker image for BUSCO to `us-docker.pkg.dev/general-theiagen/ezlabgva/busco:v5.3.2_cv1`. Must have missed that when we switched to all the GAR-hosted images.

I've double checked that the GAR docker image repo is public, as `allUsers` can read the artifact registry repo

This also exposes optional Int inputs `cpu` and `memory` in case it's ever necessary for the user

## :brain: Context and Rationale

So that we are not relying upon an docker image & repo that we do not maintain or have control over.

## :clipboard: Workflow/Task Steps

NA

### Inputs

NA

### Outputs

NA

## :test_tube: Testing

### Locally

Did not test locally, this is a simple PR

### Terra

Tested with TheiaProk_Illumina_PE_PHB here, ~~I expect it to run successfully~~ it ran successfully: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/6427308f-7659-48d6-97db-932431df1610

## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)