### PR TITLE
minor mashtree improvements

### DIFF
--- a/tasks/phylogenetic_inference/task_mashtree.wdl
+++ b/tasks/phylogenetic_inference/task_mashtree.wdl
@@ -40,6 +40,7 @@ task mashtree_fasta {
   output {
     String date = read_string("DATE")
     String version = read_string("VERSION")
+    String mashtree_docker = docker
     File mashtree_matrix = "~{cluster_name}.tsv"
     File mashtree_tree = "~{cluster_name}.nwk"
   }

--- a/tasks/phylogenetic_inference/task_mashtree.wdl
+++ b/tasks/phylogenetic_inference/task_mashtree.wdl
@@ -13,6 +13,7 @@ task mashtree_fasta {
     Int cpu = 16
     Int memory = 64
     Int disk_size = 100
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mashtree:1.2.0"
   }
   command <<<
     # date and version control
@@ -43,7 +44,7 @@ task mashtree_fasta {
     File mashtree_tree = "~{cluster_name}.nwk"
   }
   runtime {
-    docker: "us-docker.pkg.dev/general-theiagen/staphb/mashtree:1.2.0"
+    docker: docker
     memory: "~{memory} GB"
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"

--- a/workflows/phylogenetics/wf_mashtree_fasta.wdl
+++ b/workflows/phylogenetics/wf_mashtree_fasta.wdl
@@ -48,6 +48,7 @@ workflow mashtree_fasta {
     File mashtree_matrix = reorder_matrix.ordered_matrix
     File mashtree_tree = reorder_matrix.tree
     String mashtree_version = mashtree_task.version
+    String mashtree_docker = mashtree_task.mashtree_docker
     # Data Summary Out
     File? mashtree_summarized_data = summarize_data.summarized_data
     File? mashtree_filtered_metadata = summarize_data.filtered_metadata


### PR DESCRIPTION
~~Setting as draft until I test in Terra.~~ Just noticed that the user cannot alter the docker image used for mashtree and there is no `docker` output string.

## :hammer_and_wrench: Changes Being Made

- expose optional string input `docker` for mashtree task
- added new String output `docker` for mashtree task & `mashtree_docker` String output for the mashtree workflow

## :brain: Context and Rationale

More flexibility

## :clipboard: Workflow/Task Steps


### Inputs


### Outputs

## :test_tube: Testing

### Locally

Did not test locally, this is a simple change

### Terra

[Tested successfully in Terra](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/41f361e5-6f05-46ed-8cf0-2f400ca2ee2b). Was able to pass in an optional docker input string, which was used correctly. Also produced the correct output string/column for `mashtree_docker`

## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)