### PR TITLE
SRA_fetch workflow & `fastq-dl` task improvements

### DIFF
--- a/tasks/utilities/task_sra_fetch.wdl
+++ b/tasks/utilities/task_sra_fetch.wdl
@@ -4,15 +4,30 @@ version 1.0
 task fastq_dl_sra {
   input {
     String sra_accession
-    String docker = "us-docker.pkg.dev/general-theiagen/biocontainers/fastq-dl:2.0.1--pyhdfd78af_0"
+    String docker = "us-docker.pkg.dev/general-theiagen/biocontainers/fastq-dl:2.0.3--pyhdfd78af_0"
     Int disk_size = 100
     Int cpus = 2
     Int memory = 8
-    String? fastq_dl_opts
+    # default set to force the use of SRA instead of ENA due to SRA Lite FASTQ file format issues
+    String fastq_dl_opts = "--provider sra --only-provider"
+  }
+  meta {
+    # so that call caching is always turned off
+    volatile: true
   }
   command <<<
+    # capture version
     fastq-dl --version | tee VERSION
-    fastq-dl -a ~{sra_accession} ~{fastq_dl_opts}
+
+    # capture date in UTC timezone
+    date -u | tee DATE
+
+    # download fastq files
+    fastq-dl \
+      --verbose \
+      -a ~{sra_accession} \
+      --cpus ~{cpus} \
+      ~{fastq_dl_opts}
 
     # tag single-end reads with _1
     if [ -f "~{sra_accession}.fastq.gz" ] && [ ! -f "~{sra_accession}_1.fastq.gz" ]; then
@@ -22,6 +37,9 @@ task fastq_dl_sra {
   output {
     File read1 = "~{sra_accession}_1.fastq.gz"
     File? read2 = "~{sra_accession}_2.fastq.gz"
+    String fastq_dl_version = read_string("VERSION")
+    String fastq_dl_docker = docker
+    String fastq_dl_date = read_string("DATE")
   }
   runtime {
     docker: docker
@@ -30,5 +48,6 @@ task fastq_dl_sra {
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB" # TES
     preemptible:  1
+    maxRetries: 3
   }
 }

--- a/tasks/utilities/task_sra_fetch.wdl
+++ b/tasks/utilities/task_sra_fetch.wdl
@@ -33,10 +33,14 @@ task fastq_dl_sra {
     if [ -f "~{sra_accession}.fastq.gz" ] && [ ! -f "~{sra_accession}_1.fastq.gz" ]; then
       mv "~{sra_accession}.fastq.gz" "~{sra_accession}_1.fastq.gz"
     fi
+
+    # rename FASTQ metadata file to include SRR accession
+    mv -v fastq-run-info.tsv ~{sra_accession}.fastq-run-info.tsv
   >>>
   output {
     File read1 = "~{sra_accession}_1.fastq.gz"
     File? read2 = "~{sra_accession}_2.fastq.gz"
+    File fastq_metadata = "~{sra_accession}.fastq-run-info.tsv"
     String fastq_dl_version = read_string("VERSION")
     String fastq_dl_docker = docker
     String fastq_dl_date = read_string("DATE")

--- a/workflows/utilities/data_import/wf_sra_fetch.wdl
+++ b/workflows/utilities/data_import/wf_sra_fetch.wdl
@@ -23,5 +23,8 @@ workflow fetch_sra_to_fastq {
   output {
     File read1 = fastq_dl_sra.read1
     File? read2 = fastq_dl_sra.read2
+    String fastq_dl_version = fastq_dl_sra.fastq_dl_version
+    String fastq_dl_docker = fastq_dl_sra.fastq_dl_docker
+    String fastq_dl_date = fastq_dl_sra.fastq_dl_date
   }
 }

--- a/workflows/utilities/data_import/wf_sra_fetch.wdl
+++ b/workflows/utilities/data_import/wf_sra_fetch.wdl
@@ -23,6 +23,7 @@ workflow fetch_sra_to_fastq {
   output {
     File read1 = fastq_dl_sra.read1
     File? read2 = fastq_dl_sra.read2
+    File fastq_dl_fastq_metadata = fastq_dl_sra.fastq_metadata
     String fastq_dl_version = fastq_dl_sra.fastq_dl_version
     String fastq_dl_docker = fastq_dl_sra.fastq_dl_docker
     String fastq_dl_date = fastq_dl_sra.fastq_dl_date


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

### `tasks/utilities/task_sra_fetch.wdl` 
- upgraded to v2.0.3 and default docker is now `us-docker.pkg.dev/general-theiagen/biocontainers/fastq-dl:2.0.3--pyhdfd78af_0`
- set default for String input `fastq_dl_opts` to `"--provider sra --only-provider"` so that the default of the workflow is to only download from SRA. If the user wants to use ENA instead, they can use `""` or `"--provider ena"` to revert.
- added `meta` block and set `volatile` to true so that call caching is always off.
- broke `fastq-dl` cmd into multiple lines
- added `--cpus` option to cmd
- added `--verbose` option to cmd so it's always chatty 🗣️ 
- added new File output `fastq_metadata` which is the `fastq-run-info.tsv` produced by fastq-dl that contains metadata about the Run that was downloaded.
- added new String output for capturing `fastq-dl` version used
- added new String output for capturing docker image used
- added new String output `fastq_dl_date` to capture when files were downloaded

### `workflows/utilities/data_import/wf_sra_fetch.wdl`

- added 4 new required outputs (4 new output columns in Terra):

```WDL
    File fastq_dl_fastq_metadata = fastq_dl_sra.fastq_metadata
    String fastq_dl_version = fastq_dl_sra.fastq_dl_version
    String fastq_dl_docker = fastq_dl_sra.fastq_dl_docker
    String fastq_dl_date = fastq_dl_sra.fastq_dl_date
```

## :brain: Context and Rationale

The main motivation for this PR is because of a somewhat-rare issue/bug when using `fastq-dl`'s default provider, ENA, to download FASTQ files.

ENA regularly "syncs" data with NCBI SRA (and DDBJ), turns out sometimes (not sure how frequently) they have started syncing SRA Lite formatted FASTQ files (all Qscores=Q30) instead of the original FASTQ files with all original Qscores (AKA SRA Normalized format)

It doesn't happen for all SRR accessions, just the accessions that ENA has synced in SRA Lite format.

So the new default should pull directly from SRA, in SRA Normalized format (where available). I have only run into 1 SRR where the original FASTQ files were unavailable so you can only download the SRA Lite formatted FASTQ files. For these rare occurrences, the SRA helpdesk should be contacted.

## :clipboard: Workflow/Task Steps


### Inputs



### Outputs

see above as well as the WDL files

## :test_tube: Testing

### Locally

Tested locally with `miniwdl` 

### Terra

Tested successfully with 57 different SRR/ERR/DRR accessions here: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/afffe21b-51a5-42db-9075-44d7fe707c8b

I also ran TheiaProk_Illumina_PE to verify that Qscores averages are not exactly Q30 to show that these FASTQs are in SRA Normalized format (original Qscores).

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [ ] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)