### PR TITLE
summarize_data task bug fix: -z bash conditional

### DIFF
--- a/tasks/utilities/task_summarize_data.wdl
+++ b/tasks/utilities/task_summarize_data.wdl
@@ -30,7 +30,7 @@ task summarize_data {
     fi
 
     # indicate if a different id_column should be used than the default
-    if [[ -z ~{id_column_name} ]]; then
+    if [[ -z "~{id_column_name}" ]]; then
       export default_column="true"
     else
       export default_column="false"


### PR DESCRIPTION

## :hammer_and_wrench: Changes Being Made

- bugfix: Added double quotes around a WDL variable in the `tasks/utilities/task_summarize_data.wdl` that is an optional component of Mashtree_fasta_PHB workflow.

## :brain: Context and Rationale

Prior to this change, if the optional `summarize_data` task was turned on by the user defined input of `data_summary_column_names` optional String AND if the user left the optional string input `id_column_name` blank/null, then the task would fail with an error like so:
```
/cromwell_root/script: line 37: unexpected argument `]]' to conditional unary operator
/cromwell_root/script: line 37: syntax error near `;'
/cromwell_root/script: line 37: `  if [[ -z  ]]; then'
```

When the double quotes are included in that line (see file changes), the bash conditional is evaluated to `true` (as the input was not given by the user), and it correctly sets the bash variable `default_column` to `true`. This is the intended behavior.

## :clipboard: Workflow/Task Steps


### Inputs


### Outputs


## :test_tube: Testing

### Locally

difficult to test locally due to google permissions and data export, only ran in Terra

### Terra

- Successful workflow here: [Terra job submission](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/ed925e42-2b19-4e89-9d72-2709127e071a)

For the above mentioned workflow, `id_column_name` was left blank and the other optional `data_summary_<>` inputs were filled out to trigger the optional `summarize_data` task

- 2nd successful workflow here: [Terra job submission](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/155b95dc-f91e-459c-9133-67c1dee6f9a7)

For completeness I tested the use of this optional variable `id_column_name`, here's another successful workflow, where a non-default column was used for the `id_column_name` and where the `sample_names` input was also non-default. The non-default ID column is called `WGS_id`: [Terra job submission](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/155b95dc-f91e-459c-9133-67c1dee6f9a7)

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)