### PR TITLE
Skip extra headers in Concatenate_Column_Content

### DIFF
--- a/tasks/utilities/task_file_handling.wdl
+++ b/tasks/utilities/task_file_handling.wdl
@@ -5,6 +5,7 @@ task cat_files {
     Array[File] files_to_cat
     String concatenated_file_name
     String docker_image = "us-docker.pkg.dev/general-theiagen/theiagen/utility:1.1"
+    Boolean skip_extra_headers = false
   }
   meta {
     # added so that call caching is always turned off
@@ -17,7 +18,15 @@ task cat_files {
     # cat files one by one and store them in the concatenated_files file
     for index in ${!file_array[@]}; do
       file=${file_array[$index]}
-      cat ${file} >> ~{concatenated_file_name}
+      if ! ~{skip_extra_headers} ; then # act as if the first line of all files is not a header
+        cat ${file} >> ~{concatenated_file_name}
+      else # you want to skip the first line of all files except the first one
+        if [ $index == 0 ]; then # if its the first file, cat the entire thing
+          cat ${file} >> ~{concatenated_file_name}
+        else # otherwise, skip the first line
+          tail -n +2 ${file} >> ~{concatenated_file_name}
+        fi
+      fi
     done
   >>>
   output {


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

I add a "skip_extra_headers" Boolean to the concatenate_column_content workflow that will skip any extra headers in the case of concatenating files with redundant headers.

## :brain: Context and Rationale

<!--What's the context of the changes? Where there any trade-offs you had to consider?-->

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

New optional Boolean input that is defaulted to false: `skip_extra_headers`

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

Not locally tested.

### Terra

Success: https://app.terra.bio/#workspaces/cdc-terra-resources/Theiagen_Wright_SC2_Sandbox/job_history/ff9994f6-2234-41b8-89a7-54b9a94ab365

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)