### PR TITLE
Output Dragonflye GFA & modify read screen in TheiaProk_ONT

### DIFF
--- a/tasks/assembly/task_dragonflye.wdl
+++ b/tasks/assembly/task_dragonflye.wdl
@@ -73,9 +73,12 @@ task dragonflye {
 
     # rename final output file to have .fasta ending instead of .fa
     mv dragonflye/contigs.fa ~{samplename}.fasta
+
+    mv dragonflye/contigs.gfa ~{samplename}_contigs.gfa
   >>>
   output {
     File assembly_fasta = "~{samplename}.fasta"
+    File contigs_gfa = "~{samplename}_contigs.gfa"
     String dragonflye_version = read_string("VERSION")
   }
   runtime {

--- a/tasks/assembly/task_dragonflye.wdl
+++ b/tasks/assembly/task_dragonflye.wdl
@@ -73,8 +73,7 @@ task dragonflye {
 
     # rename final output file to have .fasta ending instead of .fa
     mv dragonflye/contigs.fa ~{samplename}.fasta
-
-    mv dragonflye/contigs.gfa ~{samplename}_contigs.gfa
+    mv dragonflye/*.gfa ~{samplename}_contigs.gfa
   >>>
   output {
     File assembly_fasta = "~{samplename}.fasta"

--- a/tasks/quality_control/task_screen.wdl
+++ b/tasks/quality_control/task_screen.wdl
@@ -136,7 +136,7 @@ task check_reads {
           else # they provided 0 for estimated_genome_size, nice
             estimated_coverage=0
           fi
-        else # workflow series was not provided; default to fail
+        else # workflow series was not provided or no est genome size was provided; default to fail
           estimated_genome_size=0
           estimated_coverage=0
         fi
@@ -184,6 +184,7 @@ task check_reads_se {
     Int max_genome_size 
     Int min_coverage
     Boolean skip_screen 
+    Boolean skip_mash
     String workflow_series = "theiaprok" # default to theiaprok so we don't have to change those workflows
     String? organism
     Int? expected_genome_size
@@ -235,7 +236,7 @@ task check_reads_se {
       fi
 
       #checks four and five: estimated genome size and coverage
-      if [ "${flag}" = "PASS" ]; then
+      if [ "${flag}" == "PASS" ] && [ "~{skip_mash}" == "false" ]; then
         # estimate genome size if theiaprok AND expected_genome_size was not provided
         if [ "~{workflow_series}" == "theiaprok" ] && [[ -z "~{expected_genome_size}" ]]; then            
           # First Pass; assuming average depth

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -141,7 +141,7 @@
       md5sum: 897316929176464ebc9ad085f31e7284
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command
-      md5sum: 7b889616aa2220b8c7f8413cc59a8c73
+      md5sum: 38e0fccd1a5689a1c19c4dfe3826f854
     - path: miniwdl_run/call-clean_check_reads/inputs.json
       contains: ["read1", "read2", "organism"]
     - path: miniwdl_run/call-clean_check_reads/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -96,7 +96,7 @@
       md5sum: 7e4fc05efbbc3937b99420e6193be061
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command
-      md5sum: cfcacb6a4fc055fcd794ed60e161db3f
+      md5sum: cc696fd41c7d4c73e329e153c6b5b285
     - path: miniwdl_run/call-clean_check_reads/inputs.json
       contains: ["read1", "organism"]
     - path: miniwdl_run/call-clean_check_reads/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -18,7 +18,7 @@
     - wf_theiacov_ont_miniwdl
   files:
     - path: miniwdl_run/call-clean_check_reads/command
-      md5sum: 1330a5740e4ecab6d65e1d54983d0ed7
+      md5sum: 3b1ec8ea1879fc101d233f552fa4419f
     - path: miniwdl_run/call-clean_check_reads/inputs.json
     - path: miniwdl_run/call-clean_check_reads/outputs.json
     - path: miniwdl_run/call-clean_check_reads/stderr.txt
@@ -336,7 +336,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/ont.pangolin_report.csv
     - path: miniwdl_run/call-raw_check_reads/command
-      md5sum: 539522601b488d7fd02ca529d869abb7
+      md5sum: 5a9ed8f4856b36fd75d3e83dbde4ecfd
     - path: miniwdl_run/call-raw_check_reads/inputs.json
     - path: miniwdl_run/call-raw_check_reads/outputs.json
     - path: miniwdl_run/call-raw_check_reads/stderr.txt

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -47,6 +47,7 @@ workflow theiacov_illumina_se {
     Int max_genome_size = 2673870 # size of Pandoravirus salinus + 200 kb
     Int min_coverage = 10
     Boolean skip_screen = false
+    Boolean skip_mash = false
     # qc check parameters
     File? qc_check_table
   }
@@ -61,6 +62,7 @@ workflow theiacov_illumina_se {
       skip_screen = skip_screen,
       workflow_series = "theiacov",
       organism = organism,
+      skip_mash = skip_mash,
       expected_genome_size = genome_length
   }
   if (raw_check_reads.read_screen == "PASS") {
@@ -86,6 +88,7 @@ workflow theiacov_illumina_se {
         skip_screen = skip_screen,
         workflow_series = "theiacov",
         organism = organism,
+        skip_mash = skip_mash,
         expected_genome_size = genome_length
     }
     if (clean_check_reads.read_screen == "PASS") {

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -47,6 +47,7 @@ workflow theiacov_ont {
     Int max_genome_size = 2673870 # size of Pandoravirus salinus + 200 kb
     Int min_coverage = 10
     Boolean skip_screen = false
+    Boolean skip_mash = false
     # qc check parameters
     File? qc_check_table
   }
@@ -62,6 +63,7 @@ workflow theiacov_ont {
       max_genome_size = max_genome_size,
       min_coverage = min_coverage,
       skip_screen = skip_screen,
+      skip_mash = skip_mash,
       workflow_series = "theiacov",
       organism = organism,
       expected_genome_size = genome_length
@@ -89,6 +91,7 @@ workflow theiacov_ont {
         max_genome_size = max_genome_size,
         min_coverage = min_coverage,
         skip_screen = skip_screen,
+        skip_mash = skip_mash,
         workflow_series = "theiacov",
         organism = organism,
         expected_genome_size = genome_length

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -40,6 +40,7 @@ workflow theiaprok_illumina_se {
     String terra_workspace="NA"
     # read screen paramaters
     Boolean skip_screen = false 
+    Boolean skip_mash = false
     Int min_reads = 7472
     Int min_basepairs = 2241820
     Int min_genome_size = 100000
@@ -69,6 +70,7 @@ workflow theiaprok_illumina_se {
       max_genome_size = max_genome_size,
       min_coverage = min_coverage,
       skip_screen = skip_screen,
+      skip_mash = skip_mash,
       expected_genome_size = genome_size
   }
   if (raw_check_reads.read_screen == "PASS") {
@@ -89,6 +91,7 @@ workflow theiaprok_illumina_se {
         max_genome_size = max_genome_size,
         min_coverage = min_coverage,
         skip_screen = skip_screen,
+        skip_mash = skip_mash,
         expected_genome_size = genome_size
     }
     if (clean_check_reads.read_screen == "PASS") {

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -40,6 +40,7 @@ workflow theiaprok_ont {
     String terra_workspace = "NA"
     # read screen parameters
     Boolean skip_screen = false 
+    Boolean skip_mash = true
     Int min_reads = 5000 # reduced from 7472 because less reads are needed to get to higher coverage due to longer read length
     Int min_basepairs = 2241820
     Int min_genome_size = 100000
@@ -65,6 +66,7 @@ workflow theiaprok_ont {
       max_genome_size = max_genome_size,
       min_coverage = min_coverage,
       skip_screen = skip_screen,
+      skip_mash = skip_mash,
       expected_genome_size = genome_size
   }
   if (raw_check_reads.read_screen == "PASS") {
@@ -83,6 +85,7 @@ workflow theiaprok_ont {
         max_genome_size = max_genome_size,
         min_coverage = min_coverage,
         skip_screen = skip_screen,
+        skip_mash = skip_mash,
         expected_genome_size = genome_size
     }
     if (clean_check_reads.read_screen == "PASS") {

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -233,6 +233,7 @@ workflow theiaprok_ont {
             tiptoft_plasmid_replicon_genes = read_QC_trim.tiptoft_plasmid_replicon_genes,
             tiptoft_version = read_QC_trim.tiptoft_version,
             assembly_fasta = dragonflye.assembly_fasta,
+            contigs_gfa = dragonflye.contigs_gfa,
             dragonflye_version = dragonflye.dragonflye_version,
             quast_report = quast.quast_report,
             quast_version = quast.version,
@@ -493,6 +494,7 @@ workflow theiaprok_ont {
     Float? r1_mean_readlength_raw = cg_pipeline_raw.r1_mean_readlength
     # Assembly - dragonflye outputs
     File? assembly_fasta = dragonflye.assembly_fasta
+    File? contigs_gfa = dragonflye.contigs_gfa
     String? dragonflye_version = dragonflye.dragonflye_version
     # Assembly QC - quast outputs
     File? quast_report = quast.quast_report


### PR DESCRIPTION
Closes #158 and #157 

## :hammer_and_wrench: Changes Being Made

- Outputs the GFA from Dragonflye
- Introduces new optional Boolean variable `skip_mash` which will skip the mash sketch genome size estimation in the read screen

## :brain: Context and Rationale

<!--What's the context of the changes? Where there any trade-offs you had to consider?-->

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [ ] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)