### PR TITLE
TBProfiler: Fix minor bug; output median cov, % unmapped

### DIFF
--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -89,6 +89,12 @@ task tbprofiler {
             res_genes.append(tsv_dict[i])
         res_genes_string=';'.join(res_genes)
         Resistance_Genes.write(res_genes_string)
+      with open ("MEDIAN_COVERAGE", 'wt') as Median_Coverage:
+        median_coverage=tsv_dict['median_coverage']
+        Median_Coverage.write(median_coverage)
+      with open ("PCT_READS_MAPPED", 'wt" as Pct_Reads_Mapped:
+        pct_reads_mapped=tsv_dict['pct_reads_mapped']
+        Pct_Reads_Mapped.write(pct_reads_mapped)
     CODE
   >>>
   output {
@@ -104,6 +110,8 @@ task tbprofiler {
     String tbprofiler_num_dr_variants = read_string("NUM_DR_VARIANTS")
     String tbprofiler_num_other_variants = read_string("NUM_OTHER_VARIANTS")
     String tbprofiler_resistance_genes = read_string("RESISTANCE_GENES")
+    Int tbprofiler_median_coverage = read_int("MEDIAN_COVERAGE")
+    Float tbprofiler_pct_reads_mapped = read_float("PCT_READS_MAPPED")
   }
   runtime {
     docker: "~{tbprofiler_docker_image}"

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -22,7 +22,7 @@ task tbprofiler {
     date | tee DATE
 
     # Print and save version
-    tb-profiler --version > VERSION && sed -i -e 's/^/TBProfiler version /' VERSION
+    tb-profiler version > VERSION && sed -i -e 's/^/TBProfiler version /' VERSION
     
     if [ -z "~{read2}" ] ; then
       INPUT_READS="-1 ~{read1}"
@@ -92,7 +92,7 @@ task tbprofiler {
       with open ("MEDIAN_COVERAGE", 'wt') as Median_Coverage:
         median_coverage=tsv_dict['median_coverage']
         Median_Coverage.write(median_coverage)
-      with open ("PCT_READS_MAPPED", 'wt" as Pct_Reads_Mapped:
+      with open ("PCT_READS_MAPPED", 'wt') as Pct_Reads_Mapped:
         pct_reads_mapped=tsv_dict['pct_reads_mapped']
         Pct_Reads_Mapped.write(pct_reads_mapped)
     CODE


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made
All changes to task_tbprofiler.wdl, im-tbprofiler branch.

* Fixes the way TBProfiler's version is called 
  * The regex might need further adjustment, since the output file reads `TBProfiler version \nTBProfiler version TBProfiler version 4.4.2`, but since I'm not sure what the intended output is I've left it
* Output median coverage
* Output percent unmapped
 
## :brain: Context and Rationale
I've been tasked with CDPH to integrate this version of TBProfiler into a TB pipeline, along with CDC QC metrics. CDC QC metrics look for percent unmapped r/e whether or not a sample should be thrown out. Median coverage isn't one of those metrics, but it's a great way to catch low-coverage samples early on.

## :clipboard: Workflow/Task Steps
Unchanged.

### Inputs
Unchanged.

### Outputs
Adds:
* Int tbprofiler_median_coverage
  * Integer representing what tbprofiler considers the median coverage of the sample. Not affected by tbprofiler input min_depth. I've run tbprofiler on over 60,000 samples and it's never been a float, even if the sample is below 1x, so we can count on read_int() not breaking.
* Float tbprofiler_pct_reads_mapped
  * Float between 0 and 100 representing what percentage of fastq reads that tbprofiler was able to align to the H37Rv reference genome. tbprofiler seems to round to the nearest hundredth but will truncate to tenth if the hundredth is 0:
    * example outputs I've seen: 99.1, 98.99, 0.01<sup>*</sup>, 98.02

<sup>*</sup>SAMEA7547876 is doing its best, alas, but currently serves as an example of why CDPH wants me to start filtering samples. This PR doesn't add any filtering, it just exposes outputs so filtering can be done by my other WDLs.

## :test_tube: Testing

### Locally
Passes wrapped in the aforementioned TB workflow.
<img width="1186" alt="Screenshot 2023-08-29 at 3 57 04 PM" src="https://github.com/theiagen/public_health_bioinformatics/assets/27784612/54581312-6a83-4960-988e-0bdd53176511">

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)

