### PR TITLE
Add preemptibles, shorter version string

### DIFF
--- a/tasks/species_typing/task_tbp_parser.wdl
+++ b/tasks/species_typing/task_tbp_parser.wdl
@@ -50,6 +50,7 @@ task tbp_parser {
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 3 
+    maxRetries: 3
+    preemptible: 1
   }
 }

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -22,7 +22,7 @@ task tbprofiler {
     date | tee DATE
 
     # Print and save version
-    tb-profiler version > VERSION && sed -i -e 's/^/TBProfiler version /' VERSION
+    tb-profiler version > VERSION && sed -i -e 's/TBProfiler version //' VERSION && sed -n -i '$p' VERSION
     
     if [ -z "~{read2}" ] ; then
       INPUT_READS="-1 ~{read1}"
@@ -119,6 +119,7 @@ task tbprofiler {
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 3 
+    maxRetries: 3
+    preemptible: 1
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made
* Default to running the two modified task on [preemptible instances](https://cloud.google.com/compute/docs/instances/preemptible), iff running on GCP
  * Will only attempt preemptibles once, and if the task fails on the preemptible, it will try a non-preemptible.
* TBProfiler version string is now just the version as float, with no newlines

## :brain: Context and Rationale
The preemptible runtime attribute makes running short-lived tasks significantly (~50-80%) cheaper on GCP, including Terra. [miniwdl](https://github.com/chanzuckerberg/miniwdl/blob/6052fa836ea0cd91c7a07a6a2766b6cf44c0afe0/WDL/Lint.py#L1072) and [Cromwell](https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#preemptible) will both ignore this runtime attribute if not running on a GCP backend, so this won't cause compatibility issues.

Considerations:
* These tasks do not take a long time to run, so they are well-suited to running on a preemptible instance -- tasks expected to take several hours would be less suited to this sort of change
* preemptible = 1 and max_retries = 3 effectively means a doomed task will retry four times, not three -- even if the first failure was not due to the preemptible instance being preempted

The TBProfiler version string was also updated to what I think was the intended output. Removing the newline from the output file can also avoid some uncommon bugs with WDL built-in read_string(). However, I am keeping the task-level output as WDL type String rather than Float in case TBProfiler ever releases something like `4.5.9c`

## :clipboard: Workflow/Task Steps

### Inputs

Unchanged

### Outputs

`tbprofiler.version` is now of general format `4.4.2` rather than `TBProfiler version \nTBProfiler version TBProfiler version 4.4.2`

## :test_tube: Testing

### Locally

~In-progress~ My local machine is having some issues with Docker right now, but I have confirmed the script runs on Terra and passes `miniwdl check`

### Terra
Passes wrapped in [TBfastProfiler](https://github.com/aofarrel/TBfastProfiler). (No value for resistance genes, as this particular sample is sensitive to most everything.)
<img width="1720" alt="Screenshot 2023-09-13 at 10 53 49 AM" src="https://github.com/theiagen/public_health_bioinformatics/assets/27784612/63a345c6-2487-44da-bb24-3c05a8e0951c">


## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)