### PR TITLE
plasmidfinder task bugfix and updates

### DIFF
--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -4,10 +4,10 @@ task plasmidfinder {
   input {
     File assembly
     String samplename
-    Int cpu = 8
-    Int memory = 16
+    Int cpu = 2
+    Int memory = 8
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/plasmidfinder:2.1.6"
-    Int disk_size = 100
+    Int disk_size = 50
     String? database
     String? database_path
     String? method_path
@@ -41,15 +41,15 @@ task plasmidfinder {
   if [ ! -f results_tab.tsv ]; then
     PF="No plasmids detected in database"
   else
-    PF="$(tail -n +2 results_tab.tsv | cut -f 2 | sort | uniq -u | paste -s -d, - )"
+    PF="$(tail -n +2 results_tab.tsv | uniq | cut -f 2 | sort | paste -s -d, - )"
       if [ "$PF" == "" ]; then
         PF="No plasmids detected in database"
       fi  
   fi
-  echo $PF | tee PLASMIDS
+  echo "$PF" | tee PLASMIDS
 
-  mv results_tab.tsv ~{samplename}_results.tsv
-  mv Hit_in_genome_seq.fsa ~{samplename}_seqs.fsa
+  mv -v results_tab.tsv ~{samplename}_results.tsv
+  mv -v Hit_in_genome_seq.fsa ~{samplename}_seqs.fsa
 
   >>>
   output {


### PR DESCRIPTION
TY @erikwolfsohn for reporting this bug!

## :hammer_and_wrench: Changes Being Made

- decrease cpus to 2, 
- decrease memory to 8
- decrease disk_size to 50
- Fixed bug with output string of plasmid replicons identified 
- Also made some `mv` commands verbose

## :brain: Context and Rationale

Previously, if plasmidfinder identified 2 identical plasmid replicon genes, those genes would not appear in the `plasmidfinder_plasmids` output string. Example:
```
Database	Plasmid	Identity	Query / Template length	Contig	Position in contig	Note	Accession number
Rep1	rep21	100.0	763 / 996	contig00175 len=3332 cov=1724.3 corr=0 origname=Contig_2_1724.33_Circ_pilon sw=shovill-skesa/1.1.0 date=20230728	2570..3332	rep(pSA1308)	AB254848
Rep1	rep21	100.0	763 / 996	contig00175 len=3332 cov=1724.3 corr=0 origname=Contig_2_1724.33_Circ_pilon sw=shovill-skesa/1.1.0 date=20230728	2570..3332	rep(CN1	plasmid2)NC022227
```

Would results in an output string of `No plasmids detected in database` due to the `sort | uniq -u` piping on line 44.

After the change, this string now correctly reports all plasmid replicon genes, regardless if they are unique or not. We would prefer our users to quickly see all matches (even if they appear twice/more than once in the assembly)

Also, plasmidfinder essentially runs blast, so it does not need 8 cpus and 16 GBs of RAM.

This applies to all TheiaProk workflows that utilize this task (so all of them)

## :clipboard: Workflow/Task Steps

N/A

### Inputs

N/A

### Outputs

N/A

## :test_tube: Testing

### Locally

Only tested in Terra.

### Terra



## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [ ] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)