### PR TITLE
switch default docker image for version_capture to GAR-hosted image

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -69,21 +69,7 @@ jobs:
       # attempting micromamba install instead of miniconda3 in order to save on disk space
       - uses: mamba-org/setup-micromamba@v1
         with:
-          # the create command looks like this:
-          # `micromamba create -n test-env python=3.10 numpy`
-          environment-name: pytest-env
-          condarc: |
-            channels:
-              - conda-forge
-              - bioconda
-              - defaults
-          create-args: >-
-            'python>=3.7'
-            cromwell
-            miniwdl=1.5.2
-            pytest
-            pytest-workflow
-            'importlib-metadata<=4.13.0'
+          environment-file: test/config/environment.yml
 
       # # Depends and env info (mostly for debug)
       # # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -69,7 +69,7 @@ jobs:
       # attempting micromamba install instead of miniconda3 in order to save on disk space
       - uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: test/config/environment.yml
+          environment-file: tests/config/environment.yml
 
       # # Depends and env info (mostly for debug)
       # # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -77,7 +77,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Test ${{ matrix.tag }}
-        run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes
+        run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes --git-aware
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           # the create command looks like this:
           # `micromamba create -n test-env python=3.10 numpy`
-          environment-name: base
+          environment-name: pytest-env
           condarc: |
             channels:
               - conda-forge

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -92,6 +92,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/local/lib/android
           df -h
 
       - name: Test ${{ matrix.tag }}

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -90,6 +90,8 @@ jobs:
           uname -a && env
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+          du -sch /*
 
       - name: Test ${{ matrix.tag }}
         run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -89,6 +89,8 @@ jobs:
           micromamba clean -a -y
           uname -a && env
           sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
           du -sch /*

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -77,7 +77,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Test ${{ matrix.tag }}
-        run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes --git-aware
+        run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -59,19 +59,48 @@ jobs:
           repository: bactopia/bactopia-tests
           path: bactopia-tests
 
-      # Setup Miniconda3
-      - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: actions
-          auto-activate-base: false
+      # # Setup Miniconda3
+      # - name: Setup miniconda
+      #   uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     activate-environment: actions
+      #     auto-activate-base: false
 
-      # Depends and env info (mostly for debug)
+      # attempting micromamba install instead of miniconda3 in order to save on disk space
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          # the create command looks like this:
+          # `micromamba create -n test-env python=3.10 numpy`
+          environment-name: base
+          condarc: |
+            channels:
+              - conda-forge
+              - bioconda
+              - defaults
+          create-args: >-
+            'python>=3.7'
+            cromwell
+            miniwdl=1.5.2
+            pytest
+            pytest-workflow
+            'importlib-metadata<=4.13.0'
+
+      # # Depends and env info (mostly for debug)
+      # # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      # - name: Install Dependencies and create storage space
+      #   run: |
+      #     conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
+      #     conda clean -a -y
+      #     uname -a && env
+      #     sudo rm -rf /usr/share/dotnet
+      #     sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      # env info (mostly for debug)
       # rm -rf commands as recommended here: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-      - name: Install Dependencies and create storage space
+      - name: Env info and create storage space
         run: |
-          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
-          conda clean -a -y
+          micromamba list
+          micromamba clean -a -y
           uname -a && env
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -93,7 +93,6 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
-          du -sch /*
 
       - name: Test ${{ matrix.tag }}
         run: TMPDIR=~ pytest --tag ${{ matrix.tag }}_${{ matrix.engine }} --symlink --kwdof --color=yes

--- a/tasks/task_versioning.wdl
+++ b/tasks/task_versioning.wdl
@@ -3,6 +3,7 @@ version 1.0
 task version_capture {
   input {
     String? timezone
+    String docker = "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
   }
   meta {
     volatile: true
@@ -20,7 +21,7 @@ task version_capture {
   runtime {
     memory: "1 GB"
     cpu: 1
-    docker: "ubuntu:jammy"
+    docker: docker
     disks: "local-disk 10 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2" 
   }

--- a/tests/config/environment.yml
+++ b/tests/config/environment.yml
@@ -1,0 +1,12 @@
+name: pytest-env-CI
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python >=3.7
+  - cromwell
+  - miniwdl=1.5.2
+  - pytest
+  - pytest-workflow
+  - importlib-metadata <=4.13.0

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -624,7 +624,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: c178145bad99e3858a1327b3774177f3
+      md5sum: 2ed48e1b2d6e69fac4b2888f18b3c0c8
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -592,7 +592,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: c178145bad99e3858a1327b3774177f3
+      md5sum: 2ed48e1b2d6e69fac4b2888f18b3c0c8
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

Updated `/tasks/task_versioning.wdl` which is used in many of the WDL workflows in PHB. This is a small but impactful change.
- exposed docker image as an optional input - just in case the user ever needs to change the docker (hopefully never)
- set default to GAR-hosted docker image `us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816`
  - Original image is `ubuntu:jammy-20230816` downloaded from dockerhub on 2023-09-28

## :brain: Context and Rationale

Doesn't happen often, but occaisionally we see errors in Terra related to pulling docker images from dockerhub. It is said to be one of the least reliable docker image repo's as per the Broad developers.

This would update nearly all WDL workflows to pull from Theiagen's google artifact registry instead of dockerhub, in an attempt to reduce or eliminate the transient errors in Terra.

## :clipboard: Workflow/Task Steps

N/A

### Inputs

N/A

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

The WDL task ran successfully with miniwdl:

```
$ miniwdl run -v tasks/task_versioning.wdl 
2023-09-28 18:01:45.539 miniwdl-run read configuration file :: path: "/home/curtis_kapsak/.config/miniwdl.cfg"
2023-09-28 18:01:46.072 wdl.t:version_capture task setup :: name: "version_capture", source: "tasks/task_versioning.wdl", line: 3, column: 1, dir: "/home/curtis_kapsak/github/public_health_bioinformatics/20230928_180145_version_capture", thread: 139949331470144
2023-09-28 18:01:46.074 miniwdl-run.CallCache call cache miss :: cache_file: "/home/curtis_kapsak/.cache/miniwdl/version_capture/fskwfl44k5x66o66bxxrwqlcgcrucu4t/iqjw7i2vwntyuekgvulpp2det2kpwt6c.json"
2023-09-28 18:01:46.280 wdl.t:version_capture docker swarm resources :: workers: 1, max_cpus: 8, max_mem_bytes: 33648046080, total_cpus: 8, total_mem_bytes: 33648046080
2023-09-28 18:01:46.281 wdl.t:version_capture eval :: name: "timezone", value: null
2023-09-28 18:01:46.281 wdl.t:version_capture eval :: name: "docker", value: "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
2023-09-28 18:01:46.282 wdl.t:version_capture effective runtime :: docker: "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816", cpu: 1, memory_reservation: 1000000000
2023-09-28 18:01:46.282 wdl.t:version_capture ignored runtime settings :: keys: ["disks", "dx_instance_type"]
2023-09-28 18:01:46.295 wdl.t:version_capture docker image :: tag: "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816", id: "sha256:c6b84b685f35f1a5d63661f5d4aa662ad9b7ee4f4b8c394c022f25023c907b65", RepoDigest: "ubuntu@sha256:aabed3296a3d45cede1dc866a24476c4d7e093aa806263c27ddaadbdce3c1054"
2023-09-28 18:01:47.604 wdl.t:version_capture docker task complete :: service: "86h1keh8mf", task: "brnrcdji2o", node: "is3ehuh1yr", message: "finished"
2023-09-28 18:01:47.605 wdl.t:version_capture docker task exit :: state: "complete", exit_code: 0
2023-09-28 18:01:48.129 wdl.t:version_capture output :: name: "date", value: "2023-09-28"
2023-09-28 18:01:48.130 wdl.t:version_capture output :: name: "phb_version", value: "PHB v1.1.0"
2023-09-28 18:01:48.133 wdl.t:version_capture done
2023-09-28 18:01:48.137 miniwdl-run.CallCache call cache insert :: cache_file: "/home/curtis_kapsak/.cache/miniwdl/version_capture/fskwfl44k5x66o66bxxrwqlcgcrucu4t/iqjw7i2vwntyuekgvulpp2det2kpwt6c.json"
{
  "dir": "/home/curtis_kapsak/github/public_health_bioinformatics/20230928_180145_version_capture",
  "outputs": {
    "version_capture.date": "2023-09-28",
    "version_capture.phb_version": "PHB v1.1.0"
  }
}
```
### Terra

TheiaCov_FASTA ran successfully on Terra: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/1cdd9c35-ba44-4855-9a19-2c928b946dd9

## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)