### PR TITLE
update ncbi-scrub task (version 2.2.1)

### DIFF
--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -1,0 +1,59 @@
+version 1.0
+
+task hostile {
+  input {
+    File read1
+    File? read2
+    String samplename
+    String docker = "quay.io/biocontainers/hostile:0.3.0--pyhdfd78af_0"
+    String seq_method
+
+    Int disk_size = 100
+    Int cpu = 4
+    Int mem = 16
+  }
+  command <<<
+    # date and version control
+    date | tee DATE
+    hostile --version | tee VERSION
+
+    # dehost reads based on sequencing method
+    if [[ "~{seq_method}" == "OXFORD_NANOPORE" ]]; then
+      hostile clean \
+        --fastq1 ~{read1} \
+        --aligner "minimap2" \
+        --threads ~{cpu} > decontamination-log.json
+      
+      mv ./*.clean.fastq.gz "~{samplename}_R1_dehosted.fastq.gz"
+    else
+      hostile clean \
+        --fastq1 ~{read1} \
+        --fastq2 ~{read2} \
+        --aligner "bowtie2" \
+        --threads ~{cpu} > decontamination-log.json
+      
+      mv ./*.clean_1.fastq.gz "~{samplename}_R1_dehosted.fastq.gz"
+      mv ./*.clean_2.fastq.gz "~{samplename}_R2_dehosted.fastq.gz"
+    fi
+    # extract the number of removed human reads
+    grep '"reads_removed":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' > HUMANREADS
+    grep '"reads_removed_proportion":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' > HUMANREADS_PROP
+  >>>
+  output {
+    String hostile_version = read_string("VERSION")
+    File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
+    File? read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
+    Int? human_reads_removed = read_int("HUMANREADS")
+    Float? human_reads_removed_proportion = read_float("HUMANREADS_PROP")
+    String hostile_docker = docker
+  }
+  runtime {
+      docker: docker
+      memory: "~{mem} GB"
+      cpu: cpu
+      disks:  "local-disk " + disk_size + " SSD"
+      disk: disk_size + " GB" # TES
+      preemptible: 0
+      maxRetries: 3
+  }
+}

--- a/tasks/quality_control/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/task_ncbi_scrub.wdl
@@ -5,53 +5,30 @@ task ncbi_scrub_pe {
     File read1
     File read2
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:1.0.2021-05-05"
+    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
   }
-  String r1_filename = basename(read1)
-  String r2_filename = basename(read2)
   command <<<
     # date and version control
     date | tee DATE
 
-    # unzip fwd file as scrub tool does not take in .gz fastq files
-    if [[ "~{read1}" == *.gz ]]
-    then
-      gunzip -c ~{read1} > r1.fastq
-      read1_unzip=r1.fastq
-    else
-      read1_unzip=~{read1}
-    fi
+    # unzip read files as scrub tool does not take in .gz fastq files, and interleave them
+    paste <(zcat ~{read1} | paste - - - -) <(zcat ~{read2} | paste - - - -) | tr '\t' '\n' > interleaved.fastq
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -i ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
+    /opt/scrubber/scripts/scrub.sh -i interleaved.fastq |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
 
-    # gzip dehosted reads
-    gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
+    # split interleaved reads and compress files
+    paste - - - - - - - - < interleaved.fastq.clean \
+      | tee >(cut -f 1-4 | tr '\t' '\n' | gzip > ~{samplename}_R1_dehosted.fastq.gz) \
+      | cut -f 5-8 | tr '\t' '\n' | gzip > ~{samplename}_R2_dehosted.fastq.gz
 
-    # do the same on read
-    # unzip file if necessary
-    if [[ "~{read2}" == *.gz ]]
-    then
-      gunzip -c ~{read2} > r2.fastq
-      read2_unzip=r2.fastq
-    else
-      read2_unzip=~{read2}
-    fi
-
-    # dehost reads
-    /opt/scrubber/scripts/scrub.sh -i ${read2_unzip} |& tail -n1 | awk -F" " '{print $1}' > REV_SPOTS_REMOVED
-
-    # gzip dehosted reads
-    gzip ${read2_unzip}.clean -c > ~{samplename}_R2_dehosted.fastq.gz
   >>>
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
-    Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
-    Int read2_human_spots_removed = read_int("REV_SPOTS_REMOVED")
+    Int human_spots_removed = read_int("SPOTS_REMOVED")
     String ncbi_scrub_docker = docker
-
   }
   runtime {
       docker: "~{docker}"
@@ -68,10 +45,9 @@ task ncbi_scrub_se {
   input {
     File read1
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.1.0"
+    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
   }
-  String r1_filename = basename(read1)
   command <<<
     # date and version control
     date | tee DATE

--- a/workflows/theiacov/updates/wf_ncbi_scrub_pe.wdl
+++ b/workflows/theiacov/updates/wf_ncbi_scrub_pe.wdl
@@ -30,8 +30,7 @@ workflow dehost_pe {
     String ncbi_scrub_pe_analysis_date = version_capture.date
     File read1_dehosted = ncbi_scrub_pe.read1_dehosted
     File read2_dehosted = ncbi_scrub_pe.read2_dehosted
-    Int read1_human_spots_removed = ncbi_scrub_pe.read1_human_spots_removed
-    Int read2_human_spots_removed = ncbi_scrub_pe.read2_human_spots_removed
+    Int human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
     Float kraken_human_dehosted = kraken2.percent_human
     Float kraken_sc2_dehosted = kraken2.percent_sc2

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -28,6 +28,8 @@ workflow theiacov_illumina_pe {
     File? primer_bed
     File? adapters
     File? phix
+    # Human reads removal (dehosting) tool
+    String dehosting_tool = "ncbi_scrub" # options: "ncbi_scrub", "hostile"
     # reference values
     File? reference_gff
     File? reference_genome
@@ -91,7 +93,9 @@ workflow theiacov_illumina_pe {
         workflow_series = "theiacov",
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        dehosting_tool = dehosting_tool,
+        seq_method = seq_method
     }
     call screen.check_reads as clean_check_reads {
       input:

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -91,7 +91,8 @@ workflow theiacov_ont {
         max_length = max_length,
         run_prefix = run_prefix,
         target_org = target_org,
-        workflow_series = "theiacov"
+        workflow_series = "theiacov",
+        seq_method = seq_method
     }
     call screen.check_reads_se as clean_check_reads {
       input:

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -40,6 +40,8 @@ workflow theiaprok_illumina_pe {
     File? taxon_tables
     String terra_project = "NA"
     String terra_workspace = "NA"
+    # Human reads removal (dehosting) tool
+    String dehosting_tool = "ncbi_scrub" # options: "ncbi_scrub", "hostile"
     # read screen parameters
     Boolean skip_screen = false 
     Int min_reads = 7472
@@ -84,7 +86,8 @@ workflow theiaprok_illumina_pe {
         read2_raw = read2_raw,
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        dehosting_tool = dehosting_tool
 
     }
     call screen.check_reads as clean_check_reads {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -87,8 +87,8 @@ workflow theiaprok_illumina_pe {
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
         trim_window_size = trim_window_size,
-        dehosting_tool = dehosting_tool
-
+        dehosting_tool = dehosting_tool,
+        seq_method = seq_method
     }
     call screen.check_reads as clean_check_reads {
       input:

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -118,8 +118,7 @@ workflow read_QC_trim_pe {
     # NCBI scrubber
     File? read1_dehosted = ncbi_scrub_pe.read1_dehosted
     File? read2_dehosted = ncbi_scrub_pe.read2_dehosted
-    Int? read1_human_spots_removed = ncbi_scrub_pe.read1_human_spots_removed
-    Int? read2_human_spots_removed = ncbi_scrub_pe.read2_human_spots_removed
+    Int? ncbi_scrub_human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String? ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
 
     # bbduk

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -128,8 +128,8 @@ workflow read_QC_trim_pe {
   }
   output {
     # NCBI scrubber and HOSTILE
-    File? read1_dehosted = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted])
-    File? read2_dehosted = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted])
+    String read1_dehosted = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted, ""])
+    String read2_dehosted = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted, ""])
     Int? ncbi_scrub_human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String? ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
     Int? hostile_human_reads_removed = hostile.human_reads_removed

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "../../tasks/quality_control/task_fastq_scan.wdl" as fastq_scan
 import "../../tasks/quality_control/task_trimmomatic.wdl" as trimmomatic
 import "../../tasks/quality_control/task_ncbi_scrub.wdl" as ncbi_scrub
+import "../../tasks/quality_control/task_hostile.wdl" as hostile_task
 import "../../tasks/quality_control/task_bbduk.wdl" as bbduk_task
 import "../../tasks/quality_control/task_readlength.wdl" as readlength_task
 import "../../tasks/quality_control/task_fastp.wdl" as fastp_task
@@ -30,13 +31,24 @@ workflow read_QC_trim_pe {
     String read_processing = "trimmomatic"
     String? trimmomatic_args
     String fastp_args = "--detect_adapter_for_pe -g -5 20 -3 20"
+    String dehosting_tool
+    String seq_method
   }
-  if (("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) {
+  if ((("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) && (dehosting_tool == "ncbi_scrub")) {
     call ncbi_scrub.ncbi_scrub_pe {
       input:
         samplename = samplename,
         read1 = read1_raw,
         read2 = read2_raw
+    }
+  }
+  if ((("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) && (dehosting_tool == "hostile")) {
+    call hostile_task.hostile {
+      input:
+        samplename = samplename,
+        read1 = read1_raw,
+        read2 = read2_raw,
+        seq_method = seq_method
     }
   }
   if ("~{workflow_series}" == "theiacov") {
@@ -50,8 +62,8 @@ workflow read_QC_trim_pe {
     call kraken.kraken2_theiacov as kraken2_theiacov_dehosted {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted]),
-        read2 = ncbi_scrub_pe.read2_dehosted,
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted]),
         target_org = target_org
     }
   }
@@ -59,8 +71,8 @@ workflow read_QC_trim_pe {
     call trimmomatic.trimmomatic_pe {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted, read1_raw]),
-        read2 = select_first([ncbi_scrub_pe.read2_dehosted, read2_raw]),
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted, read1_raw]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted, read2_raw]),
         trimmomatic_window_size = trim_window_size,
         trimmomatic_quality_trim_score = trim_quality_trim_score,
         trimmomatic_minlen = trim_minlen,
@@ -71,8 +83,8 @@ workflow read_QC_trim_pe {
     call fastp_task.fastp_pe as fastp {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted, read1_raw]),
-        read2 = select_first([ncbi_scrub_pe.read2_dehosted, read2_raw]),
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted, read1_raw]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted, read2_raw]),
         fastp_window_size = trim_window_size,
         fastp_quality_trim_score = trim_quality_trim_score,
         fastp_minlen = trim_minlen,
@@ -115,11 +127,13 @@ workflow read_QC_trim_pe {
     }
   }
   output {
-    # NCBI scrubber
-    File? read1_dehosted = ncbi_scrub_pe.read1_dehosted
-    File? read2_dehosted = ncbi_scrub_pe.read2_dehosted
+    # NCBI scrubber and HOSTILE
+    File? read1_dehosted = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted])
+    File? read2_dehosted = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted])
     Int? ncbi_scrub_human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String? ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
+    Int? hostile_human_reads_removed = hostile.human_reads_removed
+    String? hostile_docker = hostile.hostile_docker
 
     # bbduk
     File read1_clean = bbduk.read1_clean


### PR DESCRIPTION
<!--
Thank your for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes <Issue number>

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->

- `ncbi_scrub`
  - Update docker container to `us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1`
  - Update task so paired-end reads are processed as interleaved files


## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->

For `ncbi_scrub`, the latest version solves the issue of paired reads not being correctly masked, according to their [documentation ](https://github.com/ncbi/sra-human-scrubber/releases/tag/2.2.1). ~~The reads are still processed individually in the task, so the phenomenon might still persist if we do not change the tasks to first interleave the reads, then process them using ncbi-scrub, and then split them again.~~

I've also altered the ncbi_scrub_pe task to first interleave the reads for processing with HRRT, and then split the resulting file back to forward and reverse read files. 


## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

N/A

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

N/A

### Outputs

<!--What are the outputs of your workflow/task?-->

- `read1_human_spots_removed` and `read2_human_spots_removed` were removed (this isn't actually a final output of any of the workflows)
- `human_spots_removed` was added with the stats containing the number of spots removed for the interleaved files

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

Tests passed locally with `miniwdl` for the individual task.

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

Tests under way... 

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)