### PR TITLE
updated VCF output file renaming in kSNP3 task

### DIFF
--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -71,7 +71,15 @@ task ksnp3 {
     echo "The core SNP matrix could not be produced" | tee SKIP_SNP_DIST # otherwise, skip
   fi
 
-  mv -v ksnp3/VCF.*.vcf ksnp3/~{cluster_name}_core.vcf
+  # rename the 2 vcf files by appending ~{cluster_name}; use bash shell expansion to rename VCF file, but keep the ref genome samplename
+  # I think the for loop is required because the bash variable is necessary for parameter expansion
+  for file in ksnp3/VCF.*; do
+    mv -v "$file" "${file/VCF/~{cluster_name}_VCF}"
+  done
+  # because we cannot predict the filename, use these strings to capture the output filenames
+  ls ksnp3/~{cluster_name}_VCF.*.vcf > VCF_REF_GENOME_FILE
+  ls ksnp3/~{cluster_name}_VCF.SNPsNotinRef.* > VCF_SNPS_NOT_IN_REF_FILE
+
   mv -v ksnp3/SNPs_all_matrix.fasta ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta
   mv -v ksnp3/tree.parsimony.tre ksnp3/~{cluster_name}_pan_parsimony.nwk
 
@@ -84,9 +92,10 @@ task ksnp3 {
 
   >>>
   output {
-    File ksnp3_core_matrix = "ksnp3/${cluster_name}_core_SNPs_matrix.fasta"
-    File ksnp3_core_tree = "ksnp3/${cluster_name}_core.nwk"
-    File ksnp3_core_vcf = "ksnp3/${cluster_name}_core.vcf"
+    File ksnp3_core_matrix = "ksnp3/~{cluster_name}_core_SNPs_matrix.fasta"
+    File ksnp3_core_tree = "ksnp3/~{cluster_name}_core.nwk"
+    File ksnp3_vcf_ref_genome = read_string("VCF_REF_GENOME_FILE")
+    File ksnp3_vcf_snps_not_in_ref = read_string("VCF_SNPS_NOT_IN_REF_FILE")
     File ksnp3_pan_matrix = "ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta"
     File ksnp3_pan_parsimony_tree = "ksnp3/~{cluster_name}_pan_parsimony.nwk"
     File? ksnp3_ml_tree = "ksnp3/~{cluster_name}_ML.nwk"

--- a/workflows/phylogenetics/wf_ksnp3.wdl
+++ b/workflows/phylogenetics/wf_ksnp3.wdl
@@ -69,6 +69,7 @@ workflow ksnp3_workflow {
     String ksnp3_snp_dists_version = pan_snp_dists.snp_dists_version
     File ksnp3_vcf_ref_genome = ksnp3_task.ksnp3_vcf_ref_genome
     File ksnp3_vcf_snps_not_in_ref = ksnp3_task.ksnp3_vcf_snps_not_in_ref
+    String ksnp3_vcf_ref_samplename = ksnp3_task.ksnp3_vcf_ref_samplename
     String ksnp3_core_snp_matrix_status = ksnp3_task.skip_core_snp_dists
     File ksnp3_snps = ksnp3_task.ksnp3_snps_all
     # ordered matrixes and reordered trees

--- a/workflows/phylogenetics/wf_ksnp3.wdl
+++ b/workflows/phylogenetics/wf_ksnp3.wdl
@@ -67,7 +67,8 @@ workflow ksnp3_workflow {
     String ksnp3_docker = ksnp3_task.ksnp3_docker_image
     # ksnp3_outputs
     String ksnp3_snp_dists_version = pan_snp_dists.snp_dists_version
-    File ksnp3_core_vcf = ksnp3_task.ksnp3_core_vcf
+    File ksnp3_vcf_ref_genome = ksnp3_task.ksnp3_vcf_ref_genome
+    File ksnp3_vcf_snps_not_in_ref = ksnp3_task.ksnp3_vcf_snps_not_in_ref
     String ksnp3_core_snp_matrix_status = ksnp3_task.skip_core_snp_dists
     File ksnp3_snps = ksnp3_task.ksnp3_snps_all
     # ordered matrixes and reordered trees


### PR DESCRIPTION
 ~~also added 1 new File output and change the output names to be more descriptive~~ See below for better description

~~Draft for now while we test in Terra~~



## :hammer_and_wrench: Changes Being Made

#### `tasks/phylogenetic_inference/task_ksnp3.wdl` changes

- added line break to 2 ksnp3 options for readability
- changed `mv` commands to rename the output VCF & TSV (SNPsNotinRef file) appropriately
- re-named output `File ksnp3_core_vcf` -> `File ksnp3_vcf_ref_genome`
- added 2 new outputs:
  - `File ksnp3_vcf_snps_not_in_ref`
  - `String ksnp3_vcf_ref_samplename` which is the samplename of the genome used to call SNPs

#### `workflows/phylogenetics/wf_ksnp3.wdl` changes

- re-named output `File ksnp3_core_vcf` -> `File ksnp3_vcf_ref_genome`
- added 2 new outputs:
  - `File ksnp3_vcf_snps_not_in_ref`
  - `String ksnp3_vcf_ref_samplename`

## :brain: Context and Rationale

A user pointed out that the ksnp3 output File called `ksnp3_core_vcf` is misleading as these are not the core genome SNPs, but rather SNPs that were found between all samples relative to the reference (reference is one of the samples included in the analysis). This PR changes this column name to `ksnp3_vcf_ref_genome`

Additionally, we needed a way to capture the name of the sample used as the reference so we have added 1 new output String column called `ksnp3_vcf_ref_samplename` which informs the user which of their samples was used as the reference for calling SNPs.

And lastly, one file that was captured in a glob task-level output, but not exposed as a workflow output is the SNPsNotinRef file (kindof a VCF file, but not really. It's more TSV-like) is now exposed as a workflow output for users to view

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

N/A

### Outputs

New outputs described above

## :test_tube: Testing

### Locally

Tested successfully locally with miniwdl (not shown)

### Terra

2 independent successful tests in Terra:

- https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/50eeb7a5-0a45-40a7-81ef-0880ec938816
- https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Scribner_Sandbox/job_history/2e1be41e-f966-460e-95e9-a3a2551ca15a

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)