### PR TITLE
update default nextclade dataset tag to "2023-09-21T12:00:00Z" for all TheiaCov wfs

### DIFF
--- a/tasks/taxon_id/task_kmerfinder.wdl
+++ b/tasks/taxon_id/task_kmerfinder.wdl
@@ -1,0 +1,67 @@
+version 1.0
+
+task kmerfinder_bacteria {
+  input {
+    File assembly
+    String samplename
+    File kmerfinder_db = "gs://theiagen-public-files-rp/terra/theiaprok-files/kmerfinder_bacteria_20230911.tar.gz"
+    String docker = "us-docker.pkg.dev/general-theiagen/biocontainers/kmerfinder:3.0.2--hdfd78af_0"
+    Int memory = 32
+    Int cpu = 4
+    Int disk_size = 100
+    String kmerfinder_args = ""
+  }
+  command <<<
+    # Decompress the kmerfinder bacterial database
+    mkdir db
+    tar -C ./db/ -xzvf ~{kmerfinder_db}  
+
+    # Run kmerfinder
+    kmerfinder.py \
+        -db ./db/bacteria/bacteria.ATG \
+        -tax ./db/bacteria/bacteria.tax \
+        -i ~{assembly} \
+        -o ~{samplename} \
+        ~{kmerfinder_args} 
+
+    # parse outputs
+    if [ ! -f ~{samplename}/results.txt ]; then
+      PF="No hit detected in database"
+      QC="No hit detected in database"
+      TC="No hit detected in database"
+    else
+      PF="$(cat ~{samplename}/results.txt | head -n 2 | tail -n 1 | cut -f 19)"
+      QC="$(cat ~{samplename}/results.txt | head -n 2 | tail -n 1 | cut -f 6)"
+      TC="$(cat ~{samplename}/results.txt | head -n 2 | tail -n 1 | cut -f 7)"
+        # String is empty or just contains the header
+        if [ "$PF" == "" ] || [ "$PF" == "Species" ]; then
+          PF="No hit detected in database"
+          QC="No hit detected in database"
+          TC="No hit detected in database"
+        fi
+      mv -v ~{samplename}/results.txt ~{samplename}_kmerfinder.tsv
+    fi
+    echo $PF | tee TOP_HIT
+    echo $QC | tee QC_METRIC
+    echo $TC | tee TEMPLATE_COVERAGE
+
+    # extract database name
+    DB=$(basename ~{kmerfinder_db} | sed 's/\.tar\.gz$//')
+    echo $DB | tee DATABASE
+  >>>
+  output {
+    String kmerfinder_docker = docker
+    File? kmerfinder_results_tsv = "~{samplename}_kmerfinder.tsv"
+    String kmerfinder_top_hit = read_string("TOP_HIT")
+    String kmerfinder_query_coverage = read_string("QC_METRIC")
+    String kmerfinder_template_coverage = read_string("TEMPLATE_COVERAGE")
+    String kmerfinder_database = read_string("DATABASE")
+  }
+  runtime {
+    docker: docker
+    memory: "~{memory} GB"
+    cpu: cpu
+    disks: "local-disk ~{disk_size} SSD"
+    preemptible: 0
+  }
+}

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -92,6 +92,12 @@ task export_taxon_tables {
     File? ani_output_tsv
     String? ani_top_species_match 
     String? ani_mummer_version
+    String? kmerfinder_docker
+    File? kmerfinder_results_tsv
+    String? kmerfinder_top_hit
+    String? kmerfinder_query_coverage
+    String? kmerfinder_template_coverage
+    String? kmerfinder_database
     File? amrfinderplus_all_report
     File? amrfinderplus_amr_report
     File? amrfinderplus_stress_report
@@ -169,7 +175,7 @@ task export_taxon_tables {
     String? lissero_serotype
     File? sistr_results
     File? sistr_allele_json
-    File? sister_allele_fasta
+    File? sistr_allele_fasta
     File? sistr_cgmlst
     String? sistr_version
     String? sistr_predicted_serotype
@@ -495,7 +501,7 @@ task export_taxon_tables {
       "lissero_serotype": "~{lissero_serotype}",
       "sistr_results": "~{sistr_results}",
       "sistr_allele_json": "~{sistr_allele_json}",
-      "sister_allele_fasta": "~{sister_allele_fasta}",
+      "sistr_allele_fasta": "~{sistr_allele_fasta}",
       "sistr_cgmlst": "~{sistr_cgmlst}",
       "sistr_version": "~{sistr_version}",
       "sistr_predicted_serotype": "~{sistr_predicted_serotype}",
@@ -589,6 +595,12 @@ task export_taxon_tables {
       "ani_output_tsv": "~{ani_output_tsv}",
       "ani_top_species_match": "~{ani_top_species_match}",
       "ani_mummer_version": "~{ani_mummer_version}",
+      "kmerfinder_docker": "~{kmerfinder_docker}",
+      "kmerfinder_results_tsv": "~{kmerfinder_results_tsv}",
+      "kmerfinder_top_hit": "~{kmerfinder_top_hit}",
+      "kmerfinder_query_coverage": "~{kmerfinder_query_coverage}",
+      "kmerfinder_template_coverage": "~{kmerfinder_template_coverage}",
+      "kmerfinder_database": "~{kmerfinder_database}",
       "resfinder_pheno_table": "~{resfinder_pheno_table}",
       "resfinder_pheno_table_species": "~{resfinder_pheno_table_species}",
       "resfinder_seqs": "~{resfinder_seqs}",

--- a/tests/inputs/theiaprok/wf_theiaprok_illumina_pe.json
+++ b/tests/inputs/theiaprok/wf_theiaprok_illumina_pe.json
@@ -36,5 +36,6 @@
     "theiaprok_illumina_pe.merlin_magic.cladetyper.ref_clade5_annotated" : "./tests/inputs/empty-for-test.txt",
     "theiaprok_illumina_pe.bakta.bakta_db" : "./tests/inputs/empty-for-test.txt",
     "theiaprok_illumina_pe.gambit.gambit_db_signatures" : "./tests/inputs/completely-empty-for-test.txt",
-    "theiaprok_illumina_pe.gambit.gambit_db_genomes" : "./tests/inputs/completely-empty-for-test.txt"
+    "theiaprok_illumina_pe.gambit.gambit_db_genomes" : "./tests/inputs/completely-empty-for-test.txt",
+    "theiaprok_illumina_pe.kmerfinder.kmerfinder_db" : "./tests/inputs/completely-empty-for-test.txt"
 }

--- a/tests/inputs/theiaprok/wf_theiaprok_illumina_se.json
+++ b/tests/inputs/theiaprok/wf_theiaprok_illumina_se.json
@@ -35,5 +35,6 @@
     "theiaprok_illumina_se.merlin_magic.cladetyper.ref_clade5_annotated" : "./tests/inputs/empty-for-test.txt",
     "theiaprok_illumina_se.bakta.bakta_db" : "./tests/inputs/empty-for-test.txt",
     "theiaprok_illumina_se.gambit.gambit_db_signatures" : "./tests/inputs/completely-empty-for-test.txt",
-    "theiaprok_illumina_se.gambit.gambit_db_genomes" : "./tests/inputs/completely-empty-for-test.txt"
+    "theiaprok_illumina_se.gambit.gambit_db_genomes" : "./tests/inputs/completely-empty-for-test.txt",
+    "theiaprok_illumina_se.kmerfinder.kmerfinder_db" : "./tests/inputs/completely-empty-for-test.txt"
 }

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -243,7 +243,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/primers.csv
       md5sum: 5990c3483bf66ce607aeb90a44e7ef2e
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/qc.json
-      md5sum: 6587a54553ad565d5f8ea7d214a797d4
+      md5sum: b01f4491a54941fea12ec5b04a10fb8c
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/sequences.fasta

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -38,7 +38,7 @@
       md5sum: 6808ca805661622ad65ae014a4b2a094
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-nextclade/command
-      md5sum: b5ecaad831316b3bd8f066f1e71cc0a5
+      md5sum: ed29cde6f430eff4c408d9ea214ebe85
     - path: miniwdl_run/call-nextclade/inputs.json
     - path: miniwdl_run/call-nextclade/outputs.json
     - path: miniwdl_run/call-nextclade/stderr.txt
@@ -69,11 +69,11 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/sequences.fasta
-      md5sum: bb6b4e9e91304a396724bcb6344b8a5d
+      md5sum: ea475ab0a62a0a68fc3b1108fdff8a20
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/tag.json
-      md5sum: 97e1309e683fbaaa839198d88cd4e2d9
+      md5sum: 6a17b1ee5449279af7bdd0922545d7b8
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/tree.json
-      md5sum: 6892e6019bf88ec571b4560d66d3acb0
+      md5sum: 13eb330629b6ef17a070fcb6283bea2f
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/virus_properties.json
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_E.translation.fasta
       md5sum: dc43b1e98245a25c142aec52b29a07df

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -143,7 +143,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/primers.csv
       md5sum: 5990c3483bf66ce607aeb90a44e7ef2e
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/qc.json
-      md5sum: 6587a54553ad565d5f8ea7d214a797d4
+      md5sum: b01f4491a54941fea12ec5b04a10fb8c
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade/work/nextclade_dataset_dir/sequences.fasta

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -632,9 +632,9 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: 024971d1439dff7d59c0a26a824bd2c6
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 7cffaf4d159b65fbcf9091dd8477500a
+      md5sum: 43ef050bde1fb8755f38e697a1794918
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: ca8825e5cc5a6d910e0368fcb6992905
+      md5sum: 6dc6c393281a19e8dcbcc15964b8e08a
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 2614fac622fa2035b80a7b220b1aed86
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -600,9 +600,9 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: 024971d1439dff7d59c0a26a824bd2c6
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 7cffaf4d159b65fbcf9091dd8477500a
+      md5sum: 43ef050bde1fb8755f38e697a1794918
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: 627a157d962453229f619da37e03e43d
+      md5sum: 24bfd35867f4ae864364e24195bf7f6f
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 2614fac622fa2035b80a7b220b1aed86
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -31,7 +31,7 @@ workflow theiacov_clearlabs {
     File? reference_genome
     # nextclade inputs
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-08-17T12:00:00Z"
+    String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
     String? nextclade_dataset_name
     # kraken parameters
     String? target_org

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -21,7 +21,7 @@ workflow theiacov_fasta {
     String input_assembly_method
     # nextclade inputs
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-08-17T12:00:00Z"
+    String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
     String? nextclade_dataset_name
     # qc check parameters
     File? qc_check_table

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -44,7 +44,7 @@ workflow theiacov_illumina_pe {
     # nextclade inputs
     String nextclade_docker_image = "nextstrain/nextclade:2.14.0"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-08-17T12:00:00Z"
+    String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
     String? nextclade_dataset_name
     # nextclade flu inputs
     String nextclade_flu_h1n1_ha_tag = "2023-04-02T12:00:00Z"

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -31,7 +31,7 @@ workflow theiacov_illumina_se {
     Int trim_window_size = 4
     # nextclade inputs
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-08-17T12:00:00Z"
+    String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
     String? nextclade_dataset_name
     # reference values
     File? reference_genome

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -31,7 +31,7 @@ workflow theiacov_ont {
     Int min_length = 400
     # nextclade inputs
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-08-17T12:00:00Z"
+    String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
     String? nextclade_dataset_name
     # reference values
     File? reference_genome

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -5,6 +5,7 @@ import "../../tasks/quality_control/task_quast.wdl" as quast_task
 import "../../tasks/quality_control/task_busco.wdl" as busco_task
 import "../../tasks/taxon_id/task_gambit.wdl" as gambit_task
 import "../../tasks/quality_control/task_mummer_ani.wdl" as ani_task
+import "../../tasks/taxon_id/task_kmerfinder.wdl" as kmerfinder_task
 import "../../tasks/gene_typing/task_amrfinderplus.wdl" as amrfinderplus
 import "../../tasks/gene_typing/task_resfinder.wdl" as resfinder
 import "../../tasks/species_typing/task_ts_mlst.wdl" as ts_mlst_task
@@ -35,6 +36,7 @@ workflow theiaprok_fasta {
     String terra_workspace="NA"
     # module options
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
+    Boolean call_kmerfinder = false
     Boolean call_resfinder = false
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
@@ -61,6 +63,13 @@ workflow theiaprok_fasta {
   }
   if (call_ani) {
     call ani_task.animummer as ani {
+      input:
+        assembly = assembly_fasta,
+        samplename = samplename
+    }
+  }
+  if (call_kmerfinder) {
+    call kmerfinder_task.kmerfinder_bacteria as kmerfinder {
       input:
         assembly = assembly_fasta,
         samplename = samplename
@@ -166,6 +175,12 @@ workflow theiaprok_fasta {
         ani_output_tsv = ani.ani_output_tsv,
         ani_top_species_match = ani.ani_top_species_match,
         ani_mummer_version = ani.ani_mummer_version,
+        kmerfinder_docker = kmerfinder.kmerfinder_docker,
+        kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv,
+        kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit,
+        kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage,
+        kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage,
+        kmerfinder_database = kmerfinder.kmerfinder_database,
         amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report,
         amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report,
         amrfinderplus_stress_report = amrfinderplus_task.amrfinderplus_stress_report,
@@ -243,7 +258,7 @@ workflow theiaprok_fasta {
         lissero_serotype = merlin_magic.lissero_serotype,
         sistr_results = merlin_magic.sistr_results,
         sistr_allele_json = merlin_magic.sistr_allele_json,
-        sister_allele_fasta = merlin_magic.sistr_allele_fasta,
+        sistr_allele_fasta = merlin_magic.sistr_allele_fasta,
         sistr_cgmlst = merlin_magic.sistr_cgmlst,
         sistr_version = merlin_magic.sistr_version,
         sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype,
@@ -412,6 +427,13 @@ workflow theiaprok_fasta {
     File? ani_output_tsv = ani.ani_output_tsv
     String? ani_top_species_match = ani.ani_top_species_match
     String? ani_mummer_version = ani.ani_mummer_version
+    # kmerfinder outputs
+    String? kmerfinder_docker = kmerfinder.kmerfinder_docker
+    File? kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv
+    String? kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit
+    String? kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage
+    String? kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage
+    String? kmerfinder_database = kmerfinder.kmerfinder_database
     # NCBI-AMRFinderPlus Outputs
     File amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report
     File amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report
@@ -499,7 +521,7 @@ workflow theiaprok_fasta {
     # Salmonella Typing
     File? sistr_results = merlin_magic.sistr_results
     File? sistr_allele_json = merlin_magic.sistr_allele_json
-    File? sister_allele_fasta = merlin_magic.sistr_allele_fasta
+    File? sistr_allele_fasta = merlin_magic.sistr_allele_fasta
     File? sistr_cgmlst = merlin_magic.sistr_cgmlst
     String? sistr_version = merlin_magic.sistr_version
     String? sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -9,6 +9,7 @@ import "../../tasks/quality_control/task_screen.wdl" as screen
 import "../../tasks/quality_control/task_busco.wdl" as busco_task
 import "../../tasks/taxon_id/task_gambit.wdl" as gambit_task
 import "../../tasks/quality_control/task_mummer_ani.wdl" as ani_task
+import "../../tasks/taxon_id/task_kmerfinder.wdl" as kmerfinder_task
 import "../../tasks/gene_typing/task_amrfinderplus.wdl" as amrfinderplus
 import "../../tasks/gene_typing/task_resfinder.wdl" as resfinder
 import "../../tasks/species_typing/task_ts_mlst.wdl" as ts_mlst_task
@@ -53,6 +54,7 @@ workflow theiaprok_illumina_pe {
     Int trim_window_size = 10
     # module options
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
+    Boolean call_kmerfinder = false 
     Boolean call_resfinder = false
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon  # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species    # qc check parameters
@@ -137,6 +139,13 @@ workflow theiaprok_illumina_pe {
       }
       if (call_ani) {
         call ani_task.animummer as ani {
+          input:
+            assembly = shovill_pe.assembly_fasta,
+            samplename = samplename
+        }
+      }
+      if (call_kmerfinder) {
+        call kmerfinder_task.kmerfinder_bacteria as kmerfinder {
           input:
             assembly = shovill_pe.assembly_fasta,
             samplename = samplename
@@ -291,6 +300,12 @@ workflow theiaprok_illumina_pe {
             ani_output_tsv = ani.ani_output_tsv,
             ani_top_species_match = ani.ani_top_species_match,
             ani_mummer_version = ani.ani_mummer_version,
+            kmerfinder_docker = kmerfinder.kmerfinder_docker,
+            kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv,
+            kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit,
+            kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage,
+            kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage,
+            kmerfinder_database = kmerfinder.kmerfinder_database,
             amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report,
             amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report,
             amrfinderplus_stress_report = amrfinderplus_task.amrfinderplus_stress_report,
@@ -368,7 +383,7 @@ workflow theiaprok_illumina_pe {
             lissero_serotype = merlin_magic.lissero_serotype,
             sistr_results = merlin_magic.sistr_results,
             sistr_allele_json = merlin_magic.sistr_allele_json,
-            sister_allele_fasta = merlin_magic.sistr_allele_fasta,
+            sistr_allele_fasta = merlin_magic.sistr_allele_fasta,
             sistr_cgmlst = merlin_magic.sistr_cgmlst,
             sistr_version = merlin_magic.sistr_version,
             sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype,
@@ -606,6 +621,13 @@ workflow theiaprok_illumina_pe {
     File? ani_output_tsv = ani.ani_output_tsv
     String? ani_top_species_match = ani.ani_top_species_match
     String? ani_mummer_version = ani.ani_mummer_version
+    # kmerfinder outputs
+    String? kmerfinder_docker = kmerfinder.kmerfinder_docker
+    File? kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv
+    String? kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit
+    String? kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage
+    String? kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage
+    String? kmerfinder_database = kmerfinder.kmerfinder_database
     # NCBI-AMRFinderPlus Outputs
     File? amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report
     File? amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report
@@ -721,7 +743,7 @@ workflow theiaprok_illumina_pe {
     # Salmonella Typing
     File? sistr_results = merlin_magic.sistr_results
     File? sistr_allele_json = merlin_magic.sistr_allele_json
-    File? sister_allele_fasta = merlin_magic.sistr_allele_fasta
+    File? sistr_allele_fasta = merlin_magic.sistr_allele_fasta
     File? sistr_cgmlst = merlin_magic.sistr_cgmlst
     String? sistr_version = merlin_magic.sistr_version
     String? sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -9,6 +9,7 @@ import "../../tasks/quality_control/task_screen.wdl" as screen
 import "../../tasks/quality_control/task_busco.wdl" as busco_task
 import "../../tasks/taxon_id/task_gambit.wdl" as gambit_task
 import "../../tasks/quality_control/task_mummer_ani.wdl" as ani_task
+import "../../tasks/taxon_id/task_kmerfinder.wdl" as kmerfinder_task
 import "../../tasks/gene_typing/task_amrfinderplus.wdl" as amrfinderplus
 import "../../tasks/gene_typing/task_resfinder.wdl" as resfinder
 import "../../tasks/species_typing/task_ts_mlst.wdl" as ts_mlst_task
@@ -52,6 +53,7 @@ workflow theiaprok_illumina_se {
     Int trim_window_size = 4
     # module options
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
+    Boolean call_kmerfinder = false 
     Boolean call_resfinder = false
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
@@ -130,6 +132,13 @@ workflow theiaprok_illumina_se {
       }
       if (call_ani) {
         call ani_task.animummer as ani {
+          input:
+            assembly = shovill_se.assembly_fasta,
+            samplename = samplename
+        }
+      }
+      if (call_kmerfinder) {
+        call kmerfinder_task.kmerfinder_bacteria as kmerfinder {
           input:
             assembly = shovill_se.assembly_fasta,
             samplename = samplename
@@ -264,6 +273,12 @@ workflow theiaprok_illumina_se {
             ani_output_tsv = ani.ani_output_tsv,
             ani_top_species_match = ani.ani_top_species_match,
             ani_mummer_version = ani.ani_mummer_version,
+            kmerfinder_docker = kmerfinder.kmerfinder_docker,
+            kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv,
+            kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit,
+            kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage,
+            kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage,
+            kmerfinder_database = kmerfinder.kmerfinder_database,
             amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report,
             amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report,
             amrfinderplus_stress_report = amrfinderplus_task.amrfinderplus_stress_report,
@@ -341,7 +356,7 @@ workflow theiaprok_illumina_se {
             lissero_serotype = merlin_magic.lissero_serotype,
             sistr_results = merlin_magic.sistr_results,
             sistr_allele_json = merlin_magic.sistr_allele_json,
-            sister_allele_fasta = merlin_magic.sistr_allele_fasta,
+            sistr_allele_fasta = merlin_magic.sistr_allele_fasta,
             sistr_cgmlst = merlin_magic.sistr_cgmlst,
             sistr_version = merlin_magic.sistr_version,
             sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype,
@@ -558,6 +573,13 @@ workflow theiaprok_illumina_se {
     File? ani_output_tsv = ani.ani_output_tsv
     String? ani_top_species_match = ani.ani_top_species_match
     String? ani_mummer_version = ani.ani_mummer_version
+    # kmerfinder outputs
+    String? kmerfinder_docker = kmerfinder.kmerfinder_docker
+    File? kmerfinder_results_tsv = kmerfinder.kmerfinder_results_tsv
+    String? kmerfinder_top_hit = kmerfinder.kmerfinder_top_hit
+    String? kmerfinder_query_coverage = kmerfinder.kmerfinder_query_coverage
+    String? kmerfinder_template_coverage = kmerfinder.kmerfinder_template_coverage
+    String? kmerfinder_database = kmerfinder.kmerfinder_database
     # NCBI-AMRFinderPlus Outputs
     File? amrfinderplus_all_report = amrfinderplus_task.amrfinderplus_all_report
     File? amrfinderplus_amr_report = amrfinderplus_task.amrfinderplus_amr_report
@@ -673,7 +695,7 @@ workflow theiaprok_illumina_se {
     # Salmonella Typing
     File? sistr_results = merlin_magic.sistr_results
     File? sistr_allele_json = merlin_magic.sistr_allele_json
-    File? sister_allele_fasta = merlin_magic.sistr_allele_fasta
+    File? sistr_allele_fasta = merlin_magic.sistr_allele_fasta
     File? sistr_cgmlst = merlin_magic.sistr_cgmlst
     String? sistr_version = merlin_magic.sistr_version
     String? sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype


### PR DESCRIPTION
applied on wfs: theiacov clearlabs, fasta, ilmn pe, ilmn se, ont


## :hammer_and_wrench: Changes Being Made

Updates default `nextclade_dataset_tag` for sars-cov-2 to be up to date (as of 2023-10-10) across 5 TheiaCov workflows

## :brain: Context and Rationale

Staying up-to-date. Specific to sars-cov-2 (as is many of the default inputs for TheiaCov workflows)

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

N/A

### Outputs

N/A

## :test_tube: Testing

### Locally

Did not test locally, will test all workflows in Terra

### Terra



## :microscope: Quality checks


Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)