### PR TITLE
reduce unnecessary logging in MIDAS task

### DIFF
--- a/tasks/taxon_id/task_midas.wdl
+++ b/tasks/taxon_id/task_midas.wdl
@@ -16,14 +16,15 @@ task midas {
 
     # Decompress the Midas database
     mkdir db
-    tar -C ./db/ -xzvf ~{midas_db}  
+    echo "Decompressing Midas database. Please be patient, this may take a few minutes."
+    tar -C ./db/ -xzf ~{midas_db}  
 
     # Run Midas
     run_midas.py species ~{samplename} -1 ~{read1} ~{'-2 ' + read2} -d db/midas_db_v1.2/ -t ~{cpu} 
 
     # rename output files
-    mv ~{samplename}/species/species_profile.txt ~{samplename}/species/~{samplename}_species_profile.tsv
-    mv ~{samplename}/species/log.txt ~{samplename}/species/~{samplename}_log.txt
+    mv -v ~{samplename}/species/species_profile.txt ~{samplename}/species/~{samplename}_species_profile.tsv
+    mv -v ~{samplename}/species/log.txt ~{samplename}/species/~{samplename}_log.txt
 
     # Run a python block to parse output file for terra data tables
     # pandas is available in default docker image for python2 but not python3

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -630,7 +630,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
-      md5sum: 024971d1439dff7d59c0a26a824bd2c6
+      md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: 7cffaf4d159b65fbcf9091dd8477500a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
-      md5sum: 024971d1439dff7d59c0a26a824bd2c6
+      md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: 7cffaf4d159b65fbcf9091dd8477500a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

made the un-tar/decompression of midas database (.tar.gz file) quiet since it produces 41k lines of output. 

When using the `tar -v` flag with this database, it results in a log file that is 2.7MB in size 😱 

also made the 2 `mv` commands verbose (but it's only 2 lines!)

## :brain: Context and Rationale

lower storage cost, and task should run faster since it doesn't have to produce the 41k lines in the STDOUT

## :clipboard: Workflow/Task Steps

N/A

### Inputs

N/A

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

planning to only test in Terra since it's a simple code change

### Terra

Test here ~~(still running as of 2023-10-06 afternoon) but I expect it to succeed~~ which ran successfully: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/41fe3b0b-f92f-4f25-bcc0-d894090e2efe

## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)