### PR TITLE
Remove the genes and colors input files

### DIFF
--- a/tasks/utilities/task_augur_utilities.wdl
+++ b/tasks/utilities/task_augur_utilities.wdl
@@ -332,8 +332,6 @@ task set_mpxv_defaults { # establish mpxv default values for augur
     File mpxv_reference_fasta = "gs://theiagen-public-files-rp/terra/augur-mpox-references/reconstructed_ancestral_mpox.fasta"
     File mpxv_reference_genbank = "gs://theiagen-public-files-rp/terra/augur-mpox-references/NC_063383.1_reference.gb"
     File mpxv_auspice_config = "gs://theiagen-public-files-rp/terra/augur-mpox-references/mpox_auspice_config_mpxv.json"
-    File mpxv_gene_annotations_gff = "gs://theiagen-public-files-rp/terra/augur-mpox-references/genemap.gff"
-    File mpxv_colors = "gs://theiagen-public-files-rp/terra/augur-mpox-references/colors_mpxv.tsv"
 
     Int disk_size = 50
   }
@@ -349,8 +347,6 @@ task set_mpxv_defaults { # establish mpxv default values for augur
     File reference_fasta = mpxv_reference_fasta
     File reference_genbank = mpxv_reference_genbank
     File auspice_config = mpxv_auspice_config
-    File genes = mpxv_gene_annotations_gff
-    File colors = mpxv_colors
     # inherited from flu defaults
     Float min_date = 2020.0
     Int pivot_interval = 1

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -37,8 +37,6 @@ workflow augur {
     # these are very minimal files that hopefully will prevent workflow failure but will not provide any useful information
     File lat_longs_tsv = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-lat-longs.tsv"
     File auspice_config = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-auspice-config.json"
-    File genes = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-genes.tsv"
-    File colors = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-colors.tsv"
 
     Boolean distance_tree_only = false # by default, do not skip making a time tree
   }
@@ -112,7 +110,6 @@ workflow augur {
         refined_tree = augur_refine.refined_tree,
         ancestral_nt_muts_json = augur_ancestral.ancestral_nt_muts_json,
         reference_genbank = select_first([reference_genbank, sc2_defaults.reference_genbank, flu_defaults.reference_genbank, mpxv_defaults.reference_genbank]),
-        genes = select_first([mpxv_defaults.genes, genes]),
         build_name = build_name
     }
     if (flu_segment == "HA") { # we only have clade information for HA segments (but SC2 defaults will be selected first)
@@ -150,7 +147,6 @@ workflow augur {
                             augur_clades.clade_assignments_json,
                             augur_traits.traits_assignments_json]),
         build_name = build_name,
-        colors_tsv = select_first([mpxv_defaults.colors, colors]),
         lat_longs_tsv = select_first([sc2_defaults.lat_longs_tsv, flu_defaults.lat_longs_tsv, mpxv_defaults.lat_longs_tsv, lat_longs_tsv]),
         auspice_config = select_first([sc2_defaults.auspice_config, flu_defaults.auspice_config, mpxv_defaults.auspice_config, auspice_config])
     }

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -24,8 +24,6 @@ workflow augur {
     String build_name
     File? reference_fasta
     File? reference_genbank
-    File? genes
-    File? colors
     Int? min_num_unambig
     String organism = "sars-cov-2" # options: sars-cov-2 or flu or mpxv
     String flu_segment = "HA" # options: HA or NA
@@ -39,6 +37,8 @@ workflow augur {
     # these are very minimal files that hopefully will prevent workflow failure but will not provide any useful information
     File lat_longs_tsv = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-lat-longs.tsv"
     File auspice_config = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-auspice-config.json"
+    File genes = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-genes.tsv"
+    File colors = "gs://theiagen-public-files-rp/terra/augur-defaults/minimal-colors.tsv"
 
     Boolean distance_tree_only = false # by default, do not skip making a time tree
   }
@@ -112,7 +112,7 @@ workflow augur {
         refined_tree = augur_refine.refined_tree,
         ancestral_nt_muts_json = augur_ancestral.ancestral_nt_muts_json,
         reference_genbank = select_first([reference_genbank, sc2_defaults.reference_genbank, flu_defaults.reference_genbank, mpxv_defaults.reference_genbank]),
-        genes = select_first([genes, mpxv_defaults.genes]),
+        genes = select_first([mpxv_defaults.genes, genes]),
         build_name = build_name
     }
     if (flu_segment == "HA") { # we only have clade information for HA segments (but SC2 defaults will be selected first)
@@ -126,7 +126,7 @@ workflow augur {
         }
       }
       if (! run_traits) {
-        if (defined(clades_tsv) || defined(sc2_defaults.clades_tsv) || defined(flu_defaults.clades_tsv) || defined(mpxv_defaults.clades_tsv) ) { # one of these must be present
+        if (defined(clades_tsv) || defined(sc2_defaults.clades_tsv) || defined(flu_defaults.clades_tsv) || defined(mpxv_defaults.clades_tsv)) { # one of these must be present
           call clades_task.augur_clades { # assign clades to nodes based on amino-acid or nucleotide signatures
             input:
               refined_tree = augur_refine.refined_tree,
@@ -150,7 +150,7 @@ workflow augur {
                             augur_clades.clade_assignments_json,
                             augur_traits.traits_assignments_json]),
         build_name = build_name,
-        colors_tsv = select_first([colors, mpxv_defaults.colors]),
+        colors_tsv = select_first([mpxv_defaults.colors, colors]),
         lat_longs_tsv = select_first([sc2_defaults.lat_longs_tsv, flu_defaults.lat_longs_tsv, mpxv_defaults.lat_longs_tsv, lat_longs_tsv]),
         auspice_config = select_first([sc2_defaults.auspice_config, flu_defaults.auspice_config, mpxv_defaults.auspice_config, auspice_config])
     }


### PR DESCRIPTION
Closes #211 

## :hammer_and_wrench: Changes Being Made

Due to failures, the `genes` and `colors` optional input files have been removed.

## :brain: Context and Rationale

These changes will prevent workflow failure. 

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

### Outputs

<!--What are the outputs of your workflow/task?-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [ ] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)