### PR TITLE
Add krona task to TheiaMeta_Illumina_PE

### DIFF
--- a/tasks/taxon_id/task_krona.wdl
+++ b/tasks/taxon_id/task_krona.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+task krona {
+  input {
+    File kraken2_report
+    String samplename
+    String docker = "us-docker.pkg.dev/general-theiagen/biocontainers/krona:2.7.1--pl526_5"
+    Int memory = 8
+    Int cpu = 4
+  }
+  command <<<
+    # Get VERSION
+    ktImportTaxonomy 2>&1 | sed -n '/KronaTools /p' | sed 's/^.*KronaTools //; s/ - ktImportTaxonomy.*//' | tee VERSION
+
+    # Get taxonomy file 
+    ktUpdateTaxonomy.sh taxonomy
+
+    # Run krona with taxonomy on krakren report
+    ktImportTaxonomy -o ~{samplename}_krona.html ~{kraken2_report} -tax taxonomy
+  >>>
+  output {
+    String krona_version = read_string("VERSION")
+    String krona_docker = docker
+    File krona_html = "~{samplename}_krona.html"
+  }
+  runtime {
+      docker: "~{docker}"
+      memory: "~{memory} GB"
+      cpu: cpu
+      disks: "local-disk 100 SSD"
+      preemptible: 0
+  }
+}

--- a/workflows/metagenomics/wf_theiameta_illumina_pe.wdl
+++ b/workflows/metagenomics/wf_theiameta_illumina_pe.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "../utilities/wf_read_QC_trim_pe.wdl" as read_qc_wf
 import "../utilities/wf_metaspades_assembly.wdl" as metaspades_assembly_wf
 import "../../tasks/taxon_id/task_kraken2.wdl" as kraken_task
+import "../../tasks/taxon_id/task_krona.wdl" as krona_task
 import "../../tasks/alignment/task_minimap2.wdl" as minimap2_task
 import "../../tasks/utilities/task_parse_mapping.wdl" as parse_mapping_task
 import "../../tasks/quality_control/task_quast.wdl" as quast_task
@@ -30,6 +31,11 @@ workflow theiameta_illumina_pe {
       classified_out = "classified#.fastq",
       unclassified_out = "unclassified#.fastq"
   }
+  call krona_task.krona as krona_raw {
+    input:
+      kraken2_report = kraken2_raw.kraken2_report,
+      samplename = samplename
+  }
   call read_qc_wf.read_QC_trim_pe as read_QC_trim {
       input:
         samplename = samplename,
@@ -46,6 +52,11 @@ workflow theiameta_illumina_pe {
       kraken2_args = "",
       classified_out = "classified#.fastq",
       unclassified_out = "unclassified#.fastq"
+  }
+  call krona_task.krona as krona_clean {
+    input:
+      kraken2_report = kraken2_raw.kraken2_report,
+      samplename = samplename
   }
   call metaspades_assembly_wf.metaspades_assembly_pe as metaspades {
     input:
@@ -134,6 +145,11 @@ workflow theiameta_illumina_pe {
     Float kraken2_percent_human_raw = kraken2_raw.kraken2_percent_human
     File kraken2_report_clean = kraken2_clean.kraken2_report
     Float kraken2_percent_human_clean = kraken2_clean.kraken2_percent_human
+    # Krona outputs
+    String krona_version = krona_raw.krona_version
+    String krona_docker = krona_raw.krona_docker
+    File krona_html_raw = krona_raw.krona_html
+    File krona_html_clean = krona_clean.krona_html
     # Read QC - dehosting outputs
     File? read1_dehosted = read_QC_trim.read1_dehosted
     File? read2_dehosted = read_QC_trim.read2_dehosted

--- a/workflows/metagenomics/wf_theiameta_illumina_pe.wdl
+++ b/workflows/metagenomics/wf_theiameta_illumina_pe.wdl
@@ -55,7 +55,7 @@ workflow theiameta_illumina_pe {
   }
   call krona_task.krona as krona_clean {
     input:
-      kraken2_report = kraken2_raw.kraken2_report,
+      kraken2_report = kraken2_clean.kraken2_report,
       samplename = samplename
   }
   call metaspades_assembly_wf.metaspades_assembly_pe as metaspades {


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes <Issue number>

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->

This PR adds new functionality to TheiaMeta: **[Krona Charts](https://github.com/marbl/Krona/wiki)**

Krona allows hierarchical data to be explored with zooming, multi-layered pie charts. 
![KronaChart](https://marbl.github.io/Krona/img/screen_phymmbl.png)

On Terra, **an HTML file** is populated on the datatable that can be downloaded and explored on the browser interactively for both raw and read screen taxonomic assessment.  

## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->

Krona allows for the interactive visualization of the entire community at a high level. It also allows for to drill down for taxa of interest, keeping the taxonomic relationships. 

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

![Viral Metagenomic workflow - TheiaMeta_Illumina_PE](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/5eafbcd2-1431-4654-9edc-4bb9bebcee3d)

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

N/A

### Outputs

<!--What are the outputs of your workflow/task?-->

4 new outputs have been added to TheiaMeta:
```
    String krona_version = krona_raw.krona_version
    String krona_docker = krona_raw.krona_docker
    File krona_html_raw = krona_raw.krona_html
    File krona_html_clean = krona_clean.krona_html
```

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

Tested locally with `miniwdl`, both at the task level and the entire TheiaMeta workflow

```
2023-10-11 09:04:27.829 wdl.w:theiameta_illumina_pe done
{
  "dir": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe",
  "outputs": {
    "theiameta_illumina_pe.assembly_fasta": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/assembly_fasta/HAV0024.fasta",
    "theiameta_illumina_pe.assembly_length": 7499,
    "theiameta_illumina_pe.assembly_mean_coverage": 2436.59,
    "theiameta_illumina_pe.average_read_length": 157.0,
    "theiameta_illumina_pe.bbduk_docker": "us-docker.pkg.dev/general-theiagen/staphb/bbtools:38.76",
    "theiameta_illumina_pe.bedtools_docker": "us-docker.pkg.dev/general-theiagen/staphb/bedtools:2.31.0",
    "theiameta_illumina_pe.bedtools_version": "v2.31.0",
    "theiameta_illumina_pe.contig_number": 1,
    "theiameta_illumina_pe.fastq_scan_docker": "quay.io/biocontainers/fastq-scan:0.4.4--h7d875b9_1",
    "theiameta_illumina_pe.fastq_scan_version": "fastq-scan 0.4.4",
    "theiameta_illumina_pe.kraken2_docker": "us-docker.pkg.dev/general-theiagen/staphb/kraken2:2.1.2-no-db",
    "theiameta_illumina_pe.kraken2_percent_human_clean": 24.04,
    "theiameta_illumina_pe.kraken2_percent_human_raw": 68.11,
    "theiameta_illumina_pe.kraken2_report_clean": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/kraken2_report_clean/HAV0024.report.txt",
    "theiameta_illumina_pe.kraken2_report_raw": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/kraken2_report_raw/HAV0024.report.txt",
    "theiameta_illumina_pe.kraken2_version": "2.1.2",
    "theiameta_illumina_pe.krona_docker": "us-docker.pkg.dev/general-theiagen/biocontainers/krona:2.7.1--pl526_5", <---
    "theiameta_illumina_pe.krona_html_clean": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/krona_html_clean/HAV0024_krona.html",  <--- 
    "theiameta_illumina_pe.krona_html_raw": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/krona_html_raw/HAV0024_krona.html",  <---
    "theiameta_illumina_pe.krona_version": "2.7.1", <---
    "theiameta_illumina_pe.largest_contig": 7499, 
    "theiameta_illumina_pe.metaspades_docker": "us-docker.pkg.dev/general-theiagen/biocontainers/spades:3.12.0--h9ee0642_3",
    "theiameta_illumina_pe.metaspades_version": "v3.12.0",
    "theiameta_illumina_pe.minimap2_docker": "us-docker.pkg.dev/general-theiagen/staphb/minimap2:2.22",
    "theiameta_illumina_pe.minimap2_version": "2.22-r1101",
    "theiameta_illumina_pe.ncbi_scrub_docker": "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:1.0.2021-05-05",
    "theiameta_illumina_pe.num_reads_clean1": 246155,
    "theiameta_illumina_pe.num_reads_clean2": 246155,
    "theiameta_illumina_pe.num_reads_clean_pairs": "246155",
    "theiameta_illumina_pe.num_reads_raw1": 1607300,
    "theiameta_illumina_pe.num_reads_raw2": 1607300,
    "theiameta_illumina_pe.num_reads_raw_pairs": "1607300",
    "theiameta_illumina_pe.percent_coverage": 99.08,
    "theiameta_illumina_pe.percentage_mapped_reads": 21.0312,
    "theiameta_illumina_pe.pilon_docker": "us-docker.pkg.dev/general-theiagen/biocontainers/pilon:1.24--hdfd78af_0",
    "theiameta_illumina_pe.pilon_version": "1.24",
    "theiameta_illumina_pe.quast_docker": "us-docker.pkg.dev/general-theiagen/staphb/quast:5.0.2",
    "theiameta_illumina_pe.quast_version": "QUAST v5.0.2",
    "theiameta_illumina_pe.read1_clean": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read1_clean/HAV0024_1.clean.fastq.gz",
    "theiameta_illumina_pe.read1_dehosted": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read1_dehosted/HAV0024_R1_dehosted.fastq.gz",
    "theiameta_illumina_pe.read1_mapped": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read1_mapped/assembled_HAV0024_1.fq.gz",
    "theiameta_illumina_pe.read1_unmapped": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read1_unmapped/unassembled_HAV0024_1.fq.gz",
    "theiameta_illumina_pe.read2_clean": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read2_clean/HAV0024_2.clean.fastq.gz",
    "theiameta_illumina_pe.read2_dehosted": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read2_dehosted/HAV0024_R2_dehosted.fastq.gz",
    "theiameta_illumina_pe.read2_mapped": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read2_mapped/assembled_HAV0024_2.fq.gz",
    "theiameta_illumina_pe.read2_unmapped": "/home/ines_mendes/WDL/20231011_083247_theiameta_illumina_pe/out/read2_unmapped/unassembled_HAV0024_2.fq.gz",
    "theiameta_illumina_pe.samtools_docker": "us-docker.pkg.dev/general-theiagen/staphb/samtools:1.17",
    "theiameta_illumina_pe.samtools_version": "1.17",
    "theiameta_illumina_pe.theiameta_illumina_pe_analysis_date": "2023-10-11",
    "theiameta_illumina_pe.theiameta_illumina_pe_version": "PHB v1.2.0",
    "theiameta_illumina_pe.trimmomatic_docker": "us-docker.pkg.dev/general-theiagen/staphb/trimmomatic:0.39",
    "theiameta_illumina_pe.trimmomatic_version": "Trimmomatic 0.39"
  }
}
```

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

~~Underway~~
21 blood samples containing DENV: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/e59ebd75-006d-4c29-82be-bda2d4ed0b15

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)