### PR TITLE
Fix bug on Kraken2_PE standalone workflow

### DIFF
--- a/workflows/standalone_modules/wf_kraken2_pe.wdl
+++ b/workflows/standalone_modules/wf_kraken2_pe.wdl
@@ -33,8 +33,8 @@ workflow kraken2_pe_wf {
     File kraken2_report = kraken2_pe.kraken2_report
     File kraken2_classified_report = kraken2_pe.kraken2_classified_report
     File kraken2_unclassified_read1 = kraken2_pe.kraken2_unclassified_read1
-    File kraken2_unclassified_read2 = kraken2_pe.kraken2_unclassified_read2
+    File? kraken2_unclassified_read2 = kraken2_pe.kraken2_unclassified_read2
     File kraken2_classified_read1 = kraken2_pe.kraken2_classified_read1
-    File kraken2_classified_read2 = kraken2_pe.kraken2_classified_read2
+    File? kraken2_classified_read2 = kraken2_pe.kraken2_classified_read2
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes #218 

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->

This PR fixes a bug introduced in #178 where Kraken2_PE standalone was expecting outputs that are now optional on the Kraken2 task. 

### Impacted Workflows/Tasks

<!--List the workflows and/or tasks that will be affected by this change-->

- Kraken2_PE
- Kraken2_SE

The following workflow uses Kraken2_standalone task but SHOULD NOT be affected as it does not require the affected outputs:
- TheiaMeta_Illumina_PE

The following workflows have their own Kraken2 task and SHOULD NOT be affected:
- TheiaCoV_Illumina_PE
- TheiaCoV_Illumina_SE

## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->

Read2 outputs were marked as optional to avoid WDL conflicts. 

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

N/A

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

N/A

### Outputs

<!--What are the outputs of your workflow/task?-->

N/A

### Impacted Outputs

<!--List any existing outputs that will be affected by this change-->

N/A

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

`miniwdl run /home/ines_mendes/Git/public_health_bioinformatics/workflows/standalone_modules/wf_kraken2_pe.wdl read1= ~/Validation/metagenomics_in_silico/bacterial_1.fq.gz read2= ~/Validation/metagenomics_in_silico/bacterial_2.fq.gz kraken2_db="gs://theiagen-public-files-rp/terra/theiaprok-files/k2_standard_08gb_20230605.tar.gz" samplename=Test`

<img width="689" alt="image" src="https://github.com/theiagen/public_health_bioinformatics/assets/15690332/1c5aa985-98c6-4d3a-8646-749062857251">

`miniwdl run /home/ines_mendes/Git/public_health_bioinformatics/workflows/standalone_modules/wf_kraken2_se.wdl read1= ~/Validation/metagenomics_in_silico/bacterial_1.fq.gz kraken2_db="gs://theiagen-public
-files-rp/terra/theiaprok-files/k2_standard_08gb_20230605.tar.gz" samplename=Test`



### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

Kraken2_PE: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/608f6c7c-e7d1-4830-92bc-57fb2255279e

Kraken2_SE: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/fe71e8f0-860e-42b7-9c3c-3b51eb2d49c9

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)