### PR TITLE
Mercury_Prep_N_Batch: print the excluded_samples.tsv and update Docker to avoid Google SDK warning

### DIFF
--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -541,6 +541,11 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     bash gisaid-fasta-manipulation.sh
     cat *_gisaid.fasta > ~{output_name}_gisaid.fasta
 
+
+    # print the excluded samples file
+    echo "DEBUG: printing excluded samples file"
+    cat ~{output_name}_excluded_samples.tsv
+    
     unset CLOUDSDK_PYTHON   # reset env var
 
   >>>

--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -229,12 +229,12 @@ task sm_metadata_wrangling { # the sm stands for supermassive
 
         # prettify the filenames and rename them to be sra compatible; write out copy commands to a file to rename and move later
         sra_metadata["filename"] = sra_metadata["sample_name"] + "_R1.fastq.gz"
-        sra_metadata["copy_command_r1"] = "gsutil -m cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
+        sra_metadata["copy_command_r1"] = "gcloud storage cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
         sra_metadata["copy_command_r1"].to_csv("sra-file-transfer.sh", index=False, header=False)
         sra_metadata.drop(["copy_command_r1", read1_column_name], axis=1, inplace=True)
         if read2_column_name in table.columns: # enable optional single end submission
           sra_metadata["filename2"] = sra_metadata["sample_name"] + "_R2.fastq.gz"
-          sra_metadata["copy_command_r2"] = "gsutil -m cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
+          sra_metadata["copy_command_r2"] = "gcloud storage cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
           sra_metadata["copy_command_r2"].to_csv("sra-file-transfer.sh", mode='a', index=False, header=False)
           sra_metadata.drop(["copy_command_r2", read2_column_name], axis=1, inplace=True)
 
@@ -252,7 +252,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
         genbank_metadata.rename(columns={"submission_id" : "Sequence_ID", "host_sci_name" : "host", "collection_date" : "collection-date", "isolation_source" : "isolation-source", "biosample_accession" : "BioSample", "bioproject_accession" : "BioProject"}, inplace=True)
 
         # prep for file manipulation and manuevering 
-        genbank_metadata["cp"] = "gsutil cp"
+        genbank_metadata["cp"] = "gcloud storage cp"
         genbank_metadata["fn"] = genbank_metadata["Sequence_ID"] + "_genbank_untrimmed.fasta"
         genbank_metadata.to_csv("genbank-file-transfer.sh", sep=' ', header=False, index=False, columns = ["cp", assembly_fasta_column_name, "fn"], quoting=csv.QUOTE_NONE, escapechar=" ")
         genbank_metadata.drop(["cp", assembly_fasta_column_name], axis=1, inplace=True)
@@ -316,7 +316,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
       gisaid_metadata.drop("submission_id", axis=1, inplace=True)
 
       # write out the command to rename the assembly files to a file for bash to move about
-      gisaid_metadata["cp"] = "gsutil cp"
+      gisaid_metadata["cp"] = "gcloud storage cp"
       gisaid_metadata.to_csv("gisaid-file-transfer.sh", sep=' ', header=False, index=False, columns = ["cp", assembly_fasta_column_name, "fn"], quoting=csv.QUOTE_NONE, escapechar=" ")
       gisaid_metadata.drop(["cp", assembly_fasta_column_name], axis=1, inplace=True)
 
@@ -416,12 +416,12 @@ task sm_metadata_wrangling { # the sm stands for supermassive
         
         # prettify the filenames and rename them to be sra compatible
         sra_metadata["filename"] = sra_metadata["sample_name"] + "_R1.fastq.gz"
-        sra_metadata["copy_command_r1"] = "gsutil -m cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
+        sra_metadata["copy_command_r1"] = "gcloud storage cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
         sra_metadata["copy_command_r1"].to_csv("sra-file-transfer.sh", index=False, header=False)
         sra_metadata.drop(["copy_command_r1", read1_column_name], axis=1, inplace=True)
         if read2_column_name in table.columns: # enable optional single end submission
           sra_metadata["filename2"] = sra_metadata["sample_name"] + "_R2.fastq.gz"
-          sra_metadata["copy_command_r2"] = "gsutil -m cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
+          sra_metadata["copy_command_r2"] = "gcloud storage cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
           sra_metadata["copy_command_r2"].to_csv("sra-file-transfer.sh", mode='a', index=False, header=False)
           sra_metadata.drop(["copy_command_r2", read2_column_name], axis=1, inplace=True)
 
@@ -437,7 +437,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
             bankit_metadata[column] = ""
         bankit_metadata.rename(columns={"submission_id" : "Sequence_ID", "isolate" : "Isolate", "collection_date" : "Collection_date", "country" : "Country", "host" : "Host", "isolation_source" : "Isolation_source"}, inplace=True)
 
-        bankit_metadata["cp"] = "gsutil cp"
+        bankit_metadata["cp"] = "gcloud storage cp"
         bankit_metadata["fn"] = bankit_metadata["Sequence_ID"] + "_bankit.fasta"
         bankit_metadata.to_csv("bankit-file-transfer.sh", sep=' ', header=False, index=False, columns = ["cp", assembly_fasta_column_name, "fn"], quoting=csv.QUOTE_NONE, escapechar=" ")
         bankit_metadata.drop(["cp", assembly_fasta_column_name], axis=1, inplace=True)
@@ -479,7 +479,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
       gisaid_metadata.drop("submission_id", axis=1, inplace=True)
 
       # write out the command to rename the assembly files to a file for bash to move about
-      gisaid_metadata["cp"] = "gsutil cp"
+      gisaid_metadata["cp"] = "gcloud storage cp"
       gisaid_metadata.to_csv("gisaid-file-transfer.sh", sep=' ', header=False, index=False, columns = ["cp", "assembly_fasta", "fn"], quoting=csv.QUOTE_NONE, escapechar=" ")
       gisaid_metadata.drop(["cp", "assembly_fasta"], axis=1, inplace=True)
 

--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -513,9 +513,6 @@ task sm_metadata_wrangling { # the sm stands for supermassive
 
     echo "DEBUG: performing file transfers and manipulations"
      
-    # this version of gsutil only works on python2.7
-    export CLOUDSDK_PYTHON=python2.7
-
     if ~{skip_ncbi}; then
       echo "Skipping NCBI file manipulations..."
     else
@@ -545,8 +542,6 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     # print the excluded samples file
     echo "DEBUG: printing excluded samples file"
     cat ~{output_name}_excluded_samples.tsv
-    
-    unset CLOUDSDK_PYTHON   # reset env var
 
   >>>
   output {
@@ -561,7 +556,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     File gisaid_fasta = "~{output_name}_gisaid.fasta"
   }
   runtime {
-    docker: "us-docker.pkg.dev/general-theiagen/theiagen/terra-tools:2023-03-16"
+    docker: "us-docker.pkg.dev/general-theiagen/theiagen/terra-tools:2023-08-28-v4"
     memory: "8 GB"
     cpu: 4
     disks:  "local-disk " + disk_size + " SSD"

--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -24,7 +24,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     python3 /scripts/export_large_tsv/export_large_tsv.py --project "~{project_name}" --workspace "~{workspace_name}" --entity_type ~{table_name} --tsv_filename ~{table_name}-data.tsv
     
     # when running locally, use the input_table in place of downloading from Terra
-    #cp ~{input_table} ~{table_name}-data.tsv
+    #cp -v ~{input_table} ~{table_name}-data.tsv
 
     # transform boolean skip_county into string for python comparison
     if ~{skip_county}; then
@@ -141,16 +141,16 @@ task sm_metadata_wrangling { # the sm stands for supermassive
       for index, row in table.iterrows():
         if ("VADR skipped due to poor assembly") in str(row["vadr_num_alerts"]):
           notification = "VADR skipped due to poor assembly"
-          quality_exclusion = quality_exclusion.append({"sample_name": row["~{table_name}_id".lower()], "message": notification}, ignore_index=True)
+          quality_exclusion = pd.concat([quality_exclusion, pd.Series({"sample_name": row["~{table_name}_id".lower()], "message": notification}).to_frame().T], ignore_index=True)
         elif int(row["vadr_num_alerts"]) > ~{vadr_alert_limit}:
           notification = "VADR number alerts too high: " + str(row["vadr_num_alerts"]) + " greater than limit of " + str(~{vadr_alert_limit})
-          quality_exclusion = quality_exclusion.append({"sample_name": row["~{table_name}_id".lower()], "message": notification}, ignore_index=True)
+          quality_exclusion = pd.concat([quality_exclusion, pd.Series({"sample_name": row["~{table_name}_id".lower()], "message": notification}).to_frame().T], ignore_index=True)
         elif int(row["number_n"]) > ~{number_N_threshold}:
           notification="Number of Ns was too high: " + str(row["number_n"]) + " greater than limit of " + str(~{number_N_threshold})
-          quality_exclusion = quality_exclusion.append({"sample_name": row["~{table_name}_id".lower()], "message": notification}, ignore_index=True)
+          quality_exclusion = pd.concat([quality_exclusion, pd.Series({"sample_name": row["~{table_name}_id".lower()], "message": notification}).to_frame().T], ignore_index=True)
         if pd.isna(row["year"]):
           notification="The collection date format was incorrect"
-          quality_exclusion = quality_exclusion.append({"sample_name": row["~{table_name}_id".lower()], "message": notification}, ignore_index=True)
+          quality_exclusion = pd.concat([quality_exclusion, pd.Series({"sample_name": row["~{table_name}_id".lower()], "message": notification}).to_frame().T], ignore_index=True)
 
       with open("~{output_name}_excluded_samples.tsv", "w") as exclusions:
         exclusions.write("Samples excluded for quality thresholds:\n")
@@ -345,7 +345,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
       for index, row in table.iterrows():
         if pd.isna(row["year"]):
           notification="The collection date format was incorrect."
-          quality_exclusion = quality_exclusion.append({"sample_name": row["~{table_name}_id".lower()], "message": notification}, ignore_index=True)
+          quality_exclusion = pd.concat([quality_exclusion, pd.Series({"sample_name": row["~{table_name}_id".lower()], "message": notification}).to_frame().T], ignore_index=True)
 
       with open("~{output_name}_excluded_samples.tsv", "w") as exclusions:
         exclusions.write("Samples excluded for bad collection_date format:\n")

--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -232,7 +232,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
         sra_metadata["copy_command_r1"] = "gcloud storage cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
         sra_metadata["copy_command_r1"].to_csv("sra-file-transfer.sh", index=False, header=False)
         sra_metadata.drop(["copy_command_r1", read1_column_name], axis=1, inplace=True)
-        if read2_column_name in table.columns: # enable optional single end submission
+        if read2_column_name in table.columns and using_clearlabs_data == false and using_reads_dehosted == false: # enable optional single end submission
           sra_metadata["filename2"] = sra_metadata["sample_name"] + "_R2.fastq.gz"
           sra_metadata["copy_command_r2"] = "gcloud storage cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
           sra_metadata["copy_command_r2"].to_csv("sra-file-transfer.sh", mode='a', index=False, header=False)

--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -232,7 +232,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
         sra_metadata["copy_command_r1"] = "gcloud storage cp " + sra_metadata[read1_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename"]
         sra_metadata["copy_command_r1"].to_csv("sra-file-transfer.sh", index=False, header=False)
         sra_metadata.drop(["copy_command_r1", read1_column_name], axis=1, inplace=True)
-        if read2_column_name in table.columns and using_clearlabs_data == false and using_reads_dehosted == false: # enable optional single end submission
+        if read2_column_name in table.columns and os.environ["using_clearlabs_data"] == "false" and os.environ["using_reads_dehosted"] == "false": # enable optional single end submission
           sra_metadata["filename2"] = sra_metadata["sample_name"] + "_R2.fastq.gz"
           sra_metadata["copy_command_r2"] = "gcloud storage cp " + sra_metadata[read2_column_name] + " " + "~{gcp_bucket_uri}" + "/" + sra_metadata["filename2"]
           sra_metadata["copy_command_r2"].to_csv("sra-file-transfer.sh", mode='a', index=False, header=False)


### PR DESCRIPTION
Closes #186 

## :hammer_and_wrench: Changes Being Made

This PR:
- prints the excluded_samples.tsv to the log file because when the workflow fails, Terra likes to delete the file so the helpful information included is never seen and is no longer helpful

In addition, since the log file was becoming unwiedly, this PR also:
- updates the Docker image to the latest version so whenever a `gsutil` command is used, a warning isn't printed which inflates the log file unreasonably
- updates all `gsutil cp` commands to `gcloud storage cp` in order to keep in line with the latest Google recommendations

### Impacted Workflows/Tasks

- Mercury_Prep_N_Batch
  - `sm_metadata_wrangling`

## :brain: Context and Rationale

Troubleshooting this workflow was becoming difficult when the issue resulted from missing metadata. By printing out this file to the log, this will ease troubleshooting significantly.

## :clipboard: Workflow/Task Steps

No new workflow/task changes 

### Inputs

No changes

### Outputs

No changes

### Impacted Outputs

None

## :test_tube: Testing

### Locally

Not tested locally

### Terra

Tested here: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/74f4093a-2632-4d91-8570-007e8c3d7d60

This test demonstrates the reduced log file size and prints out the excluded_samples.tsv file.

### Reviewer Tests: 
The reviewer will want to test the following situations:
- where all samples are missing a required column
- where only a few samples are missing a required column
- where no samples are missing a required column. 

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)