### PR TITLE
update default amrfinderplus docker image to v3.11.20 and db 2023-09-26.1

### DIFF
--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -12,7 +12,7 @@ task amrfinderplus_nuc {
     Float? mincov
     Boolean detailed_drug_class = false
     Int cpu = 4
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.11-2023-04-17.1"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.20-2023-09-26.1"
     Int disk_size = 100
     Int memory = 16
     Boolean hide_point_mutations = false

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -30,9 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 2323ca08d3132d198a68e637becea3db
+      md5sum: 54ebef28014734172bfeeb798d0e7873
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
+      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -552,7 +552,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
       md5sum: 8ea4befaa7a09b0def8d033cb9b806d1
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 6d851255fd3132c8ecda764cb2bc0911
+      md5sum: 249db321d15832002c4945394ae9af76
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -624,7 +624,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 9c02b95d23a602d9842fdeac883037b1
+      md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -30,11 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_se", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 2323ca08d3132d198a68e637becea3db
-      md5sum: 2323ca08d3132d198a68e637becea3db
+      md5sum: 54ebef28014734172bfeeb798d0e7873
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
+      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -522,7 +520,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
       md5sum: 8ea4befaa7a09b0def8d033cb9b806d1
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 6d851255fd3132c8ecda764cb2bc0911
+      md5sum: 249db321d15832002c4945394ae9af76
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -592,7 +590,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 9c02b95d23a602d9842fdeac883037b1
+      md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl


### PR DESCRIPTION
## :hammer_and_wrench: Changes Being Made

updates default docker image for amrfinderplus to `us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.20-2023-09-26.1`

This is not the absolute latest version, but the more recent version 3.11.26 only adds a bug fix for a rare bug that does not affect our usage.

More importantly the database has not been updated since 2023-09-26, so we should be pretty up-to-date for the next few months

### Impacted Workflows/Tasks

All TheiaProk workflows- ILMN PE, ILMN SE, ONT, FASTA

Standalone amrfinderplus workflow

## :brain: Context and Rationale


## :clipboard: Workflow/Task Steps

N/A

### Inputs

N/A 

### Outputs

N/A

### Impacted Outputs

All outputs will be impacted as results may differ slightly due to database differences

## :test_tube: Testing

### Locally

Task ran successfully with `miniwdl`

### Terra

~~Will add links when testing is complete~~

- [x] ILMN PE: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/ee39e342-cdeb-4e53-a3ab-1e573fd47522
- [x] ILMN SE: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/287b1378-4aa3-427d-82c2-e6e612b6d32b
- [x] FASTA https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/4d0549c7-70b0-4ada-b113-3c153a38c73c
- [x] ONT: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/6ddb5050-7b00-4ac9-87a7-51ff94b809ae
- [x] standalone amrfinderplus: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/2a34727f-b95f-4118-ab36-7187bfead970

### Scenarios for Reviewer to Test

Good to test a variety of different species to try to trigger all of the `--organism` flag inputs. I have a dataset for doing this with ILMN PE, ILMN SE, and FASTA

My ONT dataset is not comprehensive, it only has a few klebsiella's

## :microscope: Quality checks


Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)