### PR TITLE
Nextclade Output Added

### DIFF
--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -144,7 +144,7 @@ task nextclade_output_parser {
             nc_lineage = tsv_dict['lineage']
             if nc_lineage is None:
               nc_lineage = ""
-          elif 'lineage' in tsv_dict:
+          elif 'Nextclade_pango' in tsv_dict:
             nc_lineage = tsv_dict['Nextclade_pango']
             if nc_lineage is None:
               nc_lineage = ""

--- a/tasks/taxon_id/task_nextclade.wdl
+++ b/tasks/taxon_id/task_nextclade.wdl
@@ -144,9 +144,19 @@ task nextclade_output_parser {
             nc_lineage = tsv_dict['lineage']
             if nc_lineage is None:
               nc_lineage = ""
+          elif 'lineage' in tsv_dict:
+            nc_lineage = tsv_dict['Nextclade_pango']
+            if nc_lineage is None:
+              nc_lineage = ""
           else:
             nc_lineage = ""
           Nextclade_Lineage.write(nc_lineage)
+        
+        with codecs.open("NEXTCLADE_QC", 'wt') as Nextclade_QC:
+          nc_qc = tsv_dict['qc.overallStatus']
+          if nc_qc == '':
+            nc_qc = 'NA'
+          Nextclade_QC.write(nc_qc)
       CODE
     >>>
     runtime {
@@ -164,6 +174,7 @@ task nextclade_output_parser {
       String nextclade_tamiflu_aa_subs = read_string("TAMIFLU_AASUBS")
       String nextclade_aa_dels = read_string("NEXTCLADE_AADELS")
       String nextclade_lineage = read_string("NEXTCLADE_LINEAGE")
+      String nextclade_qc = read_string("NEXTCLADE_QC")
     }
 }
 

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -276,7 +276,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_S.translation.fasta
       md5sum: 0ce44a0a8e2784ca4b3e8d8f03211813
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: a01b0a826425399bc59854b7c74acb1e
+      md5sum: 81a13f84fdc07c4dd038114f688bd042
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json
@@ -293,7 +293,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_CLADE
       md5sum: 96d3cf337be2f7948d6f6df5c1ab69a4
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_LINEAGE
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+      md5sum: 717da6cd0df2d2f1d00461f3498aaca9
     - path: miniwdl_run/call-nextclade_output_parser/work/TAMIFLU_AASUBS
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.nextclade.tsv

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -100,7 +100,7 @@
     - path: miniwdl_run/call-nextclade/work/nextclade_gene_S.translation.fasta
       md5sum: e630a638abbb2c8ab4a8b74455e9668f
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 8bab8bc62cb16fff613907f34c54ec51
+      md5sum: b682d6fdfc827cf46564c61ab80cd2a5
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json
     - path: miniwdl_run/call-nextclade_output_parser/stderr.txt
@@ -114,7 +114,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_CLADE
       md5sum: 96d3cf337be2f7948d6f6df5c1ab69a4
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_LINEAGE
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+      md5sum: 717da6cd0df2d2f1d00461f3498aaca9
     - path: miniwdl_run/call-nextclade_output_parser/work/TAMIFLU_AASUBS
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.fasta.gz.nextclade.tsv

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -178,7 +178,7 @@
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade/work/ont.medaka.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 5354c0f11f6f2301ce6f0a07dc3b3aca
+      md5sum: 6e30109d985d8d896cf8b0b82092fada
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json
@@ -195,7 +195,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_CLADE
       md5sum: 111fd243cc71936455964c3956dd2e28
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_LINEAGE
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+      md5sum: dc20c75a91e9d9de3d98af59d035f17c
     - path: miniwdl_run/call-nextclade_output_parser/work/TAMIFLU_AASUBS
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/ont.medaka.consensus.nextclade.tsv

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -223,6 +223,8 @@ workflow theiacov_clearlabs {
     String? nextclade_aa_subs = nextclade_output_parser.nextclade_aa_subs
     String? nextclade_aa_dels = nextclade_output_parser.nextclade_aa_dels
     String? nextclade_clade = nextclade_output_parser.nextclade_clade
+    String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
+    String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -115,6 +115,7 @@ workflow theiacov_fasta {
     String? nextclade_aa_subs = nextclade_output_parser.nextclade_aa_subs
     String? nextclade_aa_dels = nextclade_output_parser.nextclade_aa_dels
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
+    String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -352,6 +352,7 @@ workflow theiacov_illumina_pe {
     String nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels, nextclade_output_parser.nextclade_aa_dels, ""])
     String nextclade_clade = select_first([nextclade_output_parser.nextclade_clade, ""])
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
+    String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # Nextclade Flu outputs - NA specific columns - tamiflu mutation
     String? nextclade_tamiflu_resistance_aa_subs = nextclade_output_parser_flu_na.nextclade_tamiflu_aa_subs
     # VADR Annotation QC

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -264,6 +264,7 @@ workflow theiacov_illumina_se {
     String? nextclade_aa_dels = nextclade_output_parser.nextclade_aa_dels
     String? nextclade_clade = nextclade_output_parser.nextclade_clade
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
+    String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -301,6 +301,7 @@ workflow theiacov_ont {
     String? nextclade_aa_dels = nextclade_output_parser.nextclade_aa_dels
     String? nextclade_clade = nextclade_output_parser.nextclade_clade
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
+    String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts


### PR DESCRIPTION


## :hammer_and_wrench: Changes Being Made

1. Previously Nextclade_Lineage looked for a column header "lineage" to populate this variable, however this not what the lineage column is called for SARS-CoV-2 - it's called "Nextclade_pango". This led to the nextclade_lineage variable being NULL for SARS-CoV-2. Monkeypox uses "lineage" as the column name for its lineage data so the task now looks for "Nextclade_pango" in the column names if "lineage" is not found.  

You can find these edits in tasks\taxon_id\task_nextclade.wdl lines 142-153
```
with codecs.open("NEXTCLADE_LINEAGE", 'wt') as Nextclade_Lineage:
          if 'lineage' in tsv_dict:
            nc_lineage = tsv_dict['lineage']
            if nc_lineage is None:
              nc_lineage = ""
          elif 'Nextclade_pango' in tsv_dict: # added elif statement
            nc_lineage = tsv_dict['Nextclade_pango']
            if nc_lineage is None:
              nc_lineage = ""
          else:
            nc_lineage = ""
          Nextclade_Lineage.write(nc_lineage)
```
   2. We have had some requests from our Epi's for the Nextclade QC summary to  be extracted from the Nextclade output tsv so the following was added at tasks\taxon_id\task_nextclade.wdl lines 154-159:
```
        with codecs.open("NEXTCLADE_QC", 'wt') as Nextclade_QC:
          nc_qc = tsv_dict['qc.overallStatus']
          if nc_qc == '':
            nc_qc = 'NA'
          Nextclade_QC.write(nc_qc)
```
And added to workflows\theiacov\wf_theiacov_illumina_pe.wdl line 355,
workflows\theiacov\wf_theiacov_clearlabs.wdl line 227,
workflows\theiacov\wf_theiacov_fasta.wdl line 118
workflows\theiacov\wf_theiacov_illumina_se.wdl line 267
workflows\theiacov\wf_theiacov_ont.wdl line 304 :
`String? nextclade_qc = nextclade_output_parser.nextclade_qc`

And added to workflows\theiacov\wf_theiacov_clearlabs.wdl line 226:
`String? nextclade_lineage = nextclade_output_parser.nextclade_lineage`

### Impacted Workflows/Tasks

These changes directly impact the output of:
wf_theiacov_illumina_pe.wdl
wf_theiacov_clearlabs.wdl
wf_theiacov_fasta.wdl
wf_theiacov_illumina_se.wdl
wf_theiacov_ont.wdl

## :brain: Context and Rationale

Fixing a variable population issue for lineages. Nextclade QC has been requested by our Epi's as another QC standard to look at to decide which sequences get uploaded to repositories.

## :clipboard: Workflow/Task Steps

nextclade_output_parser task *edit only*:
Task read in nextclade output, scans for certain column names and populates variables with values from found columns. When a column isn't found for a given variable, the variable is assigned a NULL value.


### Inputs

```
      File nextclade_tsv
      String docker = "python:slim"
      Int disk_size = 50
      String? organism
      Boolean? NA_segment
      String tamiflu_aa_substitutions = "NA:H275Y,NA:R292K"
```

### Outputs

```
      String nextclade_clade = read_string("NEXTCLADE_CLADE")
      String nextclade_aa_subs = read_string("NEXTCLADE_AASUBS")
      String nextclade_tamiflu_aa_subs = read_string("TAMIFLU_AASUBS")
      String nextclade_aa_dels = read_string("NEXTCLADE_AADELS")
      String nextclade_lineage = read_string("NEXTCLADE_LINEAGE")
      String nextclade_qc = read_string("NEXTCLADE_QC")
```

### Impacted Outputs

The following has been added as workflow-level output:
`String? nextclade_qc = nextclade_output_parser.nextclade_qc`

This should now populate correctly for SARS-CoV-2:
`String? nextclade_lineage = nextclade_output_parser.nextclade_lineage`

## :test_tube: Testing

### Locally

skipped

### Terra

![image](https://github.com/theiagen/public_health_bioinformatics/assets/88352855/38a2e9d7-704d-416f-89fb-ecd07ae35df8)

Columns in Terra table affected:
![image](https://github.com/theiagen/public_health_bioinformatics/assets/88352855/d4bf78d1-3ab1-4f22-b93e-a0af4249025c)


### Scenarios for Reviewer to Test

I tested this in the wf_theiacov_illumina_pe.wdl pipeline as that is fitting for the data I have access to. I was not able to test this task as it works in:
wf_theiacov_clearlabs.wdl
wf_theiacov_fasta.wdl
wf_theiacov_illumina_se.wdl
wf_theiacov_ont.wdl

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x ] Include a description of what is in this pull request in this message.
- [ x] The workflow/task has been tested on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)