### PR TITLE
[Kraken2] Add module to recalculate abundances based on fragment length - Kraken2_ont wf and TheiaCoV_ONT wf

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,6 +165,11 @@ workflows:
    primaryDescriptorPath: /workflows/standalone_modules/wf_kraken2_se.wdl
    testParameterFiles:
     - empty.json
+ - name: Kraken2_ONT_PHB
+   subclass: WDL
+   primaryDescriptorPath: /workflows/standalone_modules/wf_kraken2_ont.wdl
+   testParameterFiles:
+    - empty.json
  - name: RASUSA_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_rasusa.wdl

--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -12,7 +12,7 @@ task amrfinderplus_nuc {
     Float? mincov
     Boolean detailed_drug_class = false
     Int cpu = 4
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.11-2023-04-17.1"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.20-2023-09-26.1"
     Int disk_size = 100
     Int memory = 16
     Boolean hide_point_mutations = false

--- a/tasks/taxon_id/task_kraken2.wdl
+++ b/tasks/taxon_id/task_kraken2.wdl
@@ -178,7 +178,7 @@ task kraken2_parse_classified {
     for taxon_id in report_table["Taxon_ID"].unique():
       if taxon_id in classifiedreads_table["Taxon_ID"].unique():
       
-        taxon_name = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Name"].values[0]
+        taxon_name = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Name"].values[0].strip()
         rank = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Rank"].values[0].strip()
         taxon_basepairs = classifiedreads_table.loc[classifiedreads_table["Taxon_ID"] == taxon_id, "Read_Len"].sum()
         taxon_percent = taxon_basepairs / total_basepairs * 100

--- a/tasks/taxon_id/task_kraken2.wdl
+++ b/tasks/taxon_id/task_kraken2.wdl
@@ -177,19 +177,17 @@ task kraken2_parse_classified {
     # calculate total basepairs
     total_basepairs = classifiedreads_table["Read_Len"].sum()
 
-    # for each taxon_id in the classifiedreads table, get the percent, num basepairs, rank, and name
+    # for each taxon_id in the report table, check if exists in the classified reads output and if so get the percent, num basepairs, rank, and name
     # write results to dataframe
-    for taxon_id in classifiedreads_table["Taxon_ID"].unique():
+    for taxon_id in report_table["Taxon_ID"].unique():
+      if taxon_id in classifiedreads_table["Taxon_ID"].unique():
       
-      taxon_name = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Name"].values[0].strip()
-      rank = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Rank"].values[0].strip()
-      taxon_basepairs = classifiedreads_table.loc[classifiedreads_table["Taxon_ID"] == taxon_id, "Read_Len"].sum()
-      taxon_percent = taxon_basepairs / total_basepairs * 100
-      
-      results_table = pd.concat([results_table, pd.DataFrame({"Percent":taxon_percent, "Num_basepairs":taxon_basepairs, "Rank":rank, "Taxon_ID":taxon_id, "Name":taxon_name}, index=[0])], ignore_index=True)
-
-    # sort results by percent
-    results_table = results_table.sort_values(by=["Percent"], ascending=False)
+        taxon_name = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Name"].values[0]
+        rank = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Rank"].values[0].strip()
+        taxon_basepairs = classifiedreads_table.loc[classifiedreads_table["Taxon_ID"] == taxon_id, "Read_Len"].sum()
+        taxon_percent = taxon_basepairs / total_basepairs * 100
+        
+        results_table = pd.concat([results_table, pd.DataFrame({"Percent":taxon_percent, "Num_basepairs":taxon_basepairs, "Rank":rank, "Taxon_ID":taxon_id, "Name":taxon_name}, index=[0])], ignore_index=True)
 
     # write results to file
     results_table.to_csv("~{samplename}.report_parsed.txt", sep="\t", index=False, header=False)

--- a/tasks/taxon_id/task_kraken2.wdl
+++ b/tasks/taxon_id/task_kraken2.wdl
@@ -161,11 +161,6 @@ task kraken2_parse_classified {
 
     python3 <<CODE 
     import pandas as pd 
-    import numpy as np 
-    import json
-    import csv
-    import os 
-    import re
 
     # load files into dataframe for parsing
     classifiedreads_table = pd.read_csv("~{samplename}.classifiedreads.txt", names=["Classified_Unclassified","Read_ID","Taxon_ID","Read_Len","Other"], header=None, delimiter="\t")

--- a/tasks/taxon_id/task_kraken2.wdl
+++ b/tasks/taxon_id/task_kraken2.wdl
@@ -166,26 +166,26 @@ task kraken2_parse_classified {
     import pandas as pd 
 
     # load files into dataframe for parsing
-    classifiedreads_table = pd.read_csv("~{samplename}.classifiedreads.txt", names=["Classified_Unclassified","Read_ID","Taxon_ID","Read_Len","Other"], header=None, delimiter="\t")
-    report_table = pd.read_csv("~{kraken2_report}", names=["Percent","Num_reads","Num_reads_with_taxon","Rank","Taxon_ID","Name"], header=None, delimiter="\t")
+    reads_table = pd.read_csv("~{samplename}.classifiedreads.txt", names=["classified_unclassified","read_id","taxon_id","read_len","other"], header=None, delimiter="\t")
+    report_table = pd.read_csv("~{kraken2_report}", names=["percent","num_reads","num_reads_with_taxon","rank","taxon_id","name"], header=None, delimiter="\t")
 
     # create dataframe to store results
-    results_table = pd.DataFrame(columns=["Percent","Num_basepairs","Rank","Taxon_ID","Name"])
+    results_table = pd.DataFrame(columns=["percent","num_basepairs","rank","taxon_id","name"])
     
     # calculate total basepairs
-    total_basepairs = classifiedreads_table["Read_Len"].sum()
+    total_basepairs = reads_table["read_len"].sum()
 
     # for each taxon_id in the report table, check if exists in the classified reads output and if so get the percent, num basepairs, rank, and name
     # write results to dataframe
-    for taxon_id in report_table["Taxon_ID"].unique():
-      if taxon_id in classifiedreads_table["Taxon_ID"].unique():
+    for taxon_id in report_table["taxon_id"].unique():
+      if taxon_id in reads_table["taxon_id"].unique():
       
-        taxon_name = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Name"].values[0].strip()
-        rank = report_table.loc[report_table["Taxon_ID"] == taxon_id, "Rank"].values[0].strip()
-        taxon_basepairs = classifiedreads_table.loc[classifiedreads_table["Taxon_ID"] == taxon_id, "Read_Len"].sum()
+        taxon_name = report_table.loc[report_table["taxon_id"] == taxon_id, "name"].values[0].strip()
+        rank = report_table.loc[report_table["taxon_id"] == taxon_id, "rank"].values[0].strip()
+        taxon_basepairs = reads_table.loc[reads_table["taxon_id"] == taxon_id, "read_len"].sum()
         taxon_percent = taxon_basepairs / total_basepairs * 100
         
-        results_table = pd.concat([results_table, pd.DataFrame({"Percent":taxon_percent, "Num_basepairs":taxon_basepairs, "Rank":rank, "Taxon_ID":taxon_id, "Name":taxon_name}, index=[0])], ignore_index=True)
+        results_table = pd.concat([results_table, pd.DataFrame({"percent":taxon_percent, "num_basepairs":taxon_basepairs, "rank":rank, "taxon_id":taxon_id, "name":taxon_name}, index=[0])], ignore_index=True)
 
     # write results to file
     results_table.to_csv("~{samplename}.report_parsed.txt", sep="\t", index=False, header=False)

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -150,7 +150,7 @@
     - path: miniwdl_run/call-fastq_scan_raw_reads/work/clearlabs_fastq-scan.json
       md5sum: 869dd2e934c600bba35f30f08e2da7c9
     - path: miniwdl_run/call-kraken2_dehosted/command
-      md5sum: 70955302d0fd9f693606ec964978367b
+      md5sum: 9eab22466a4bb80de52ac457b5a00885
     - path: miniwdl_run/call-kraken2_dehosted/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-kraken2_dehosted/outputs.json
@@ -173,7 +173,7 @@
     - path: miniwdl_run/call-kraken2_dehosted/work/clearlabs_kraken2_report.txt
       md5sum: 35841fa2d77ec202c275b1de548b8d98
     - path: miniwdl_run/call-kraken2_raw/command
-      md5sum: a0ea125003ce38efdfd3905c3c38030b
+      md5sum: f590826e868e7a6a27135582c44d8adc
     - path: miniwdl_run/call-kraken2_raw/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-kraken2_raw/outputs.json

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -628,7 +628,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: 9785d1ee2b8cb128987480f976d28052
+      md5sum: 75edb8b498f35c725ff46706df18120c
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -30,9 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 2323ca08d3132d198a68e637becea3db
+      md5sum: 54ebef28014734172bfeeb798d0e7873
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
+      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -552,7 +552,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
       md5sum: 8ea4befaa7a09b0def8d033cb9b806d1
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 6d851255fd3132c8ecda764cb2bc0911
+      md5sum: 249db321d15832002c4945394ae9af76
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -624,7 +624,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 9c02b95d23a602d9842fdeac883037b1
+      md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -627,7 +627,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: cf9f2eb81ed0d725b7344480a929508b
+      md5sum: 8bd6ffb6d89dca981a0a9272d25a10f2
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -628,7 +628,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
+      md5sum: 9785d1ee2b8cb128987480f976d28052
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -627,7 +627,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: 37a1bccc53b5ff8e1968f07a85bb328f
+      md5sum: cf9f2eb81ed0d725b7344480a929508b
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -594,7 +594,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
+      md5sum: 9785d1ee2b8cb128987480f976d28052
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -592,7 +592,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: 37a1bccc53b5ff8e1968f07a85bb328f
+      md5sum: cf9f2eb81ed0d725b7344480a929508b
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -594,7 +594,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: 9785d1ee2b8cb128987480f976d28052
+      md5sum: 75edb8b498f35c725ff46706df18120c
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -30,11 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_se", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 2323ca08d3132d198a68e637becea3db
-      md5sum: 2323ca08d3132d198a68e637becea3db
+      md5sum: 54ebef28014734172bfeeb798d0e7873
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
-      md5sum: df6b62b3e5679b365be6644e8b4882d3
+      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -522,7 +520,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/task_abricate.wdl
       md5sum: 8ea4befaa7a09b0def8d033cb9b806d1
     - path: miniwdl_run/wdl/tasks/gene_typing/task_amrfinderplus.wdl
-      md5sum: 6d851255fd3132c8ecda764cb2bc0911
+      md5sum: 249db321d15832002c4945394ae9af76
     - path: miniwdl_run/wdl/tasks/gene_typing/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/task_plasmidfinder.wdl
@@ -592,7 +590,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/task_ts_mlst.wdl
       md5sum: d49ae0b02e798af0636eb2721bb434b4
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 9c02b95d23a602d9842fdeac883037b1
+      md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 08987d952c67c6ff6debf6898af15f9a
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -592,7 +592,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
       md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
-      md5sum: cf9f2eb81ed0d725b7344480a929508b
+      md5sum: 8bd6ffb6d89dca981a0a9272d25a10f2
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl

--- a/workflows/standalone_modules/wf_kraken2_ont.wdl
+++ b/workflows/standalone_modules/wf_kraken2_ont.wdl
@@ -1,0 +1,44 @@
+version 1.0
+
+import "../../tasks/taxon_id/task_kraken2.wdl" as kraken2
+import "../../tasks/task_versioning.wdl" as versioning
+
+workflow kraken2_ont_wf {
+  meta {
+    description: "Classify ONT single-end reads using Kraken2 by recalculating abundances based on read length"
+  }
+  input {
+    String samplename
+    File read1
+    File kraken2_db
+  }
+  call kraken2.kraken2_standalone as kraken2_se {
+    input:
+      samplename = samplename,
+      read1 = read1,
+      kraken2_db = kraken2_db
+  }
+  call kraken2.kraken2_parse_classified as kraken2_recalculate_abundances {
+    input:
+      samplename = samplename,
+      kraken2_report = kraken2_se.kraken2_report,
+      kraken2_classified_report = kraken2_se.kraken2_classified_report
+  }
+  call versioning.version_capture{
+    input:
+  }
+  output {
+    # PHB Version Captures
+    String kraken2_se_wf_version = version_capture.phb_version
+    String kraken2_se_wf_analysis_date = version_capture.date
+    # Kraken2
+    String kraken2_version = kraken2_se.kraken2_version
+    String kraken2_docker = kraken2_se.kraken2_docker
+    File kraken2_report = kraken2_se.kraken2_report
+    File kraken2_classified_report = kraken2_se.kraken2_classified_report
+    File kraken2_unclassified_read1 = kraken2_se.kraken2_unclassified_read1
+    File kraken2_classified_read1 = kraken2_se.kraken2_classified_read1
+    # Kraken2 - recalculated abundances
+    File kraken2_recalculated_abundances_report = kraken2_recalculate_abundances.kraken_report
+  }
+}

--- a/workflows/standalone_modules/wf_kraken2_ont.wdl
+++ b/workflows/standalone_modules/wf_kraken2_ont.wdl
@@ -35,7 +35,6 @@ workflow kraken2_ont_wf {
     String kraken2_version = kraken2_se.kraken2_version
     String kraken2_docker = kraken2_se.kraken2_docker
     File kraken2_report = kraken2_recalculate_abundances.kraken_report
-    File kraken2_classified_report = kraken2_se.kraken2_classified_report
     File kraken2_unclassified_read1 = kraken2_se.kraken2_unclassified_read1
     File kraken2_classified_read1 = kraken2_se.kraken2_classified_read1
   }

--- a/workflows/standalone_modules/wf_kraken2_ont.wdl
+++ b/workflows/standalone_modules/wf_kraken2_ont.wdl
@@ -34,6 +34,7 @@ workflow kraken2_ont_wf {
     # Kraken2
     String kraken2_version = kraken2_se.kraken2_version
     String kraken2_docker = kraken2_se.kraken2_docker
+    File kraken2_classified_report = kraken2_se.kraken2_classified_report
     File kraken2_report = kraken2_recalculate_abundances.kraken_report
     File kraken2_unclassified_read1 = kraken2_se.kraken2_unclassified_read1
     File kraken2_classified_read1 = kraken2_se.kraken2_classified_read1

--- a/workflows/standalone_modules/wf_kraken2_ont.wdl
+++ b/workflows/standalone_modules/wf_kraken2_ont.wdl
@@ -34,11 +34,9 @@ workflow kraken2_ont_wf {
     # Kraken2
     String kraken2_version = kraken2_se.kraken2_version
     String kraken2_docker = kraken2_se.kraken2_docker
-    File kraken2_report = kraken2_se.kraken2_report
+    File kraken2_report = kraken2_recalculate_abundances.kraken_report
     File kraken2_classified_report = kraken2_se.kraken2_classified_report
     File kraken2_unclassified_read1 = kraken2_se.kraken2_unclassified_read1
     File kraken2_classified_read1 = kraken2_se.kraken2_classified_read1
-    # Kraken2 - recalculated abundances
-    File kraken2_recalculated_abundances_report = kraken2_recalculate_abundances.kraken_report
   }
 }

--- a/workflows/utilities/wf_read_QC_trim_ont.wdl
+++ b/workflows/utilities/wf_read_QC_trim_ont.wdl
@@ -46,6 +46,12 @@ workflow read_QC_trim_ont {
         samplename = samplename,
         read1 = read1,
         target_org = target_org
+    }
+    call kraken2.kraken2_parse_classified as kraken2_recalculate_abundances_raw {
+    input:
+      samplename = samplename,
+      kraken2_report = kraken2_raw.kraken_report,
+      kraken2_classified_report = kraken2_raw.kraken2_classified_report
     }  
     call kraken2.kraken2_theiacov as kraken2_dehosted {
       input:
@@ -53,6 +59,12 @@ workflow read_QC_trim_ont {
         read1 = ncbi_scrub_se.read1_dehosted,
         target_org = target_org
     }
+    call kraken2.kraken2_parse_classified as kraken2_recalculate_abundances_dehosted {
+    input:
+      samplename = samplename,
+      kraken2_report = kraken2_dehosted.kraken_report,
+      kraken2_classified_report = kraken2_dehosted.kraken2_classified_report
+    } 
   }
   if ("~{workflow_series}" == "theiaprok") {
     # kmc for genome size estimation
@@ -92,16 +104,16 @@ workflow read_QC_trim_ont {
     String? kraken_target_org_name = kraken2_raw.kraken_target_org
     
     # kraken outputs raw
-    Float? kraken_human = kraken2_raw.percent_human
-    Float? kraken_sc2 = kraken2_raw.percent_sc2
-    String? kraken_target_org = kraken2_raw.percent_target_org
-    File? kraken_report = kraken2_raw.kraken_report
+    Float? kraken_human = kraken2_recalculate_abundances_raw.percent_human
+    Float? kraken_sc2 = kraken2_recalculate_abundances_raw.percent_sc2
+    String? kraken_target_org = kraken2_recalculate_abundances_raw.percent_target_org
+    File? kraken_report = kraken2_recalculate_abundances_raw.kraken_report
     
     # kraken outputs dehosted
-    Float? kraken_human_dehosted = kraken2_dehosted.percent_human
-    Float? kraken_sc2_dehosted = kraken2_dehosted.percent_sc2
-    String? kraken_target_org_dehosted = kraken2_dehosted.percent_target_org
-    File? kraken_report_dehosted = kraken2_dehosted.kraken_report
+    Float? kraken_human_dehosted = kraken2_recalculate_abundances_dehosted.percent_human
+    Float? kraken_sc2_dehosted = kraken2_recalculate_abundances_dehosted.percent_sc2
+    String? kraken_target_org_dehosted = kraken2_recalculate_abundances_dehosted.percent_target_org
+    File? kraken_report_dehosted = kraken2_recalculate_abundances_dehosted.kraken_report
    
     # theiaprok outputs
     # kmc outputs

--- a/workflows/utilities/wf_read_QC_trim_ont.wdl
+++ b/workflows/utilities/wf_read_QC_trim_ont.wdl
@@ -51,7 +51,8 @@ workflow read_QC_trim_ont {
     input:
       samplename = samplename,
       kraken2_report = kraken2_raw.kraken_report,
-      kraken2_classified_report = kraken2_raw.kraken2_classified_report
+      kraken2_classified_report = kraken2_raw.kraken2_classified_report,
+      target_org = target_org
     }  
     call kraken2.kraken2_theiacov as kraken2_dehosted {
       input:
@@ -63,7 +64,8 @@ workflow read_QC_trim_ont {
     input:
       samplename = samplename,
       kraken2_report = kraken2_dehosted.kraken_report,
-      kraken2_classified_report = kraken2_dehosted.kraken2_classified_report
+      kraken2_classified_report = kraken2_dehosted.kraken2_classified_report,
+      target_org = target_org
     } 
   }
   if ("~{workflow_series}" == "theiaprok") {


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes #167 

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->

This PR implements a new task `kraken2_parse_classified` that takes as input the classified reads file from Kraken2, alongside the Kraken2 report. This task computes the abundances based on fragment length for each taxon_id in the classified reads file, and parses the report to populate the taxon name. 

The new output report has the following structure: `Percent`, `Num_basepairs`, `Rank`, `Taxon_ID`, `Name`
As with Kraken2 report, the header is not included.

```
98.38943139373141	13934600	U	0	unclassified
0.08279494729112387	11726	D	10239	  Viruses
0.08229363045182063	11655	K	2731360	      Heunggongvirae
0.04975040070043142	7046	C	2731619	          Caudoviricetes
0.33614353195365293	47607	S	2859072	                Vibrio phage BUCT194
0.009560323949529397	1354	S	2886042	                  Shigella virus Moo19
0.31753126169445095	44971	S	2163605	              Pseudomonas phage vB_PaeM_PA5oct
0.04687665487512974	6639	S	12336	              Clostridium phage c-st
0.014517005938133267	2056	S	2969598	              Yangshan Harbor Poseidoniales virus
0.025461246796161748	3606	S	2530023	              Pseudomonas phage Psa21
0.06448629145572525	9133	S1	1450749	                      IAS virus
0.03830484300309969	5425	G	2948731	                Gruunavirus
0.05357029379991103	7587	S1	1391428	                  Escherichia phage 4MG
0.0217966913088606	3087	S	2924887	                    Aeromonas phage ZPAH14
0.08151694239092828	11545	S	2126984	                    Tupanvirus deep ocean
0.01912770869961236	2709	S1	1269028	                    Acanthamoeba polyphaga moumouvirus
0.004716614769782598	668	S1	212035	                    Acanthamoeba polyphaga mimivirus
0.04971509669766358	7041	S	251749	                    Phaeocystis globosa virus
0.06076524956399557	8606	S	2023057	                  Orpheovirus IHUMI-LCC2
0.02257337936975294	3197	S1	256729	                      Lymphocystis disease virus - isolate China
0.024705741136930106	3499	S	336486	                    Turkeypox virus
0.00835292705486948	1183	S	10276	                    Swinepox virus
0.01825216943097008	2585	S	2740746	        Fadolivirus 1
0.07009962789581083	9928	S1	224399	              Adoxophyes honmai nucleopolyhedrovirus
0.10765602604023243	15247	S1	2602116	                      Niukluk phantom virus
```

Additionally, a previously unknown error has been patched on the `kraken2_theiacov` tasks that would fail when a target organism was passed due to a syntax error. 

### Impacted Workflows/Tasks

<!--List the workflows and/or tasks that will be affected by this change-->

A new workflow has been added:
- `Kraken2_ONT_PHB`

The following workflow has been adjusted to include the new abundance recalculation step:
- `TheiaCoV_ONT_PHB`

## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->

An [assessment](https://docs.google.com/document/d/1zDO5ybFsqo_UldzplAfwULR8lRxiZbBvS5-IR5E6NhA/edit?usp=sharing) was performed to evaluate the performance of Kraken2 on long error-prone Oxford Nanopore reads. In this assessment, the recalculation of abundances based on the number of basepairs (instead of Kraken2's default behaviour of calculating abundances based on fragment number) has successfully computed the expected results. 

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

For `Kraken2_ONT_PHB`, the following steps are taken:
- Kraken2 task is run with the provided database on the input ONT reads
- The classified reads file and report file are passed to the new `kraken2_parse_classified` task where abundances are recalculated

For `TheiaCoV_ONT_PHB`, the following steps were added:
- In the `read_QC_trim_ont` subworkflow, the classified reads file and report file are passed to the new `kraken2_parse_classified` task where abundances are recalculated for both raw and dehosted reads
- The Kraken2 outputs were substituted by those obtained from the new task

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

For `Kraken2_ONT_PHB`:
- String samplename (mandatory)
- File read1 (mandatory)
- File kraken2_db (mandatory)

For `TheiaCoV_ONT_PHB`:
- No inputs or outputs have been altered

### Outputs

<!--What are the outputs of your workflow/task?-->

For `Kraken2_ONT_PHB`:
```
    # PHB Version Captures
    String kraken2_se_wf_version = version_capture.phb_version
    String kraken2_se_wf_analysis_date = version_capture.date
    # Kraken2
    String kraken2_version = kraken2_se.kraken2_version
    String kraken2_docker = kraken2_se.kraken2_docker
    File kraken2_report = kraken2_recalculate_abundances.kraken_report
    File kraken2_classified_report = kraken2_se.kraken2_classified_report
    File kraken2_unclassified_read1 = kraken2_se.kraken2_unclassified_read1
    File kraken2_classified_read1 = kraken2_se.kraken2_classified_read1
```

For `TheiaCoV_ONT_PHB`:
- No inputs or outputs have been altered

### Impacted Outputs

<!--List any existing outputs that will be affected by this change-->

For `TheiaCoV_ONT_PHB`:
```
    # Read QC - kraken outputs raw
    Float? kraken_human = read_qc_trim.kraken_human
    Float? kraken_sc2 = read_qc_trim.kraken_sc2
    String? kraken_target_org = read_qc_trim.kraken_target_org
    File? kraken_report = read_qc_trim.kraken_report
    # Read QC - kraken outputs dehosted
    Float? kraken_human_dehosted = read_qc_trim.kraken_human_dehosted
    Float? kraken_sc2_dehosted = read_qc_trim.kraken_sc2_dehosted
    String? kraken_target_org_dehosted = read_qc_trim.kraken_target_org_dehosted
    File? kraken_report_dehosted = read_qc_trim.kraken_report_dehosted
``` 

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

```
miniwdl run --task kraken2_parse_classified /home/ines_mendes/Git/public_health_bioinformatics/tasks/taxon_id/task_kraken2.wdl kraken2_classified_report= 20231107_110946_kraken2_standalone/out/kraken2_classified_report/ERR3772599.classifiedreads.txt.gz samplename=ERR3772599 kraken2_report= 20231107_110946_kraken2_standalone/out/kraken2_report/ERR3772599.report.txt 
```
<img width="689" alt="image" src="https://github.com/theiagen/public_health_bioinformatics/assets/15690332/88419e30-e6fe-4199-8a67-947263ebc1ba">

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

Underway

**Kraken2_ONT_PHB**
9 in silico samples of human sequences mixed with target viral sequences: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/b795db74-97fa-49f4-a851-1cbdad2b21e8

### Scenarios for Reviewer to Test

<!--Please list any potential scenarios that the reviewer should test, such as edge-cases or data types-->

- The fix on kraken2_theiacov target organism calculation correctly functions and outputs the result for the input `target_org`
- Test `Kraken2_ONT_PHB` workflow on known abundance samples
- Test `TheiaCoV_ONT_PHB` on samples with known abundance and assert the new results

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)