### PR TITLE
disable call caching for various workflows

### DIFF
--- a/tasks/utilities/submission/task_mercury_file_wrangling.wdl
+++ b/tasks/utilities/submission/task_mercury_file_wrangling.wdl
@@ -19,6 +19,10 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     Boolean usa_territory = false # only for SC2; uses territory name (in state column) for country in GISAID submissions 
     Int disk_size = 100
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     # when running on terra, comment out all input_table mentions
     python3 /scripts/export_large_tsv/export_large_tsv.py --project "~{project_name}" --workspace "~{workspace_name}" --entity_type ~{table_name} --tsv_filename ~{table_name}-data.tsv

--- a/tasks/utilities/submission/task_submission.wdl
+++ b/tasks/utilities/submission/task_submission.wdl
@@ -14,6 +14,10 @@ task prune_table {
     String read1_column_name = "read1"
     String read2_column_name = "read2"
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     # when running on terra, comment out all input_table mentions
     python3 /scripts/export_large_tsv/export_large_tsv.py --project "~{project_name}" --workspace "~{workspace_name}" --entity_type ~{table_name} --tsv_filename ~{table_name}-data.tsv

--- a/tasks/utilities/task_basespace_cli.wdl
+++ b/tasks/utilities/task_basespace_cli.wdl
@@ -16,6 +16,10 @@ task fetch_bs {
 
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/basespace_cli:1.2.1"
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     # set basespace name and id variables
     if [[ ! -z "~{basespace_sample_id}" ]]; then

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -332,6 +332,10 @@ task export_taxon_tables {
     String? srst2_vibrio_serogroup
     String? srst2_vibrio_biotype
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
   
     # capture taxon and corresponding table names from input taxon_tables

--- a/tasks/utilities/task_czgenepi_wrangling.wdl
+++ b/tasks/utilities/task_czgenepi_wrangling.wdl
@@ -25,6 +25,10 @@ task czgenepi_wrangling {
 
     # runtime
     Int disk_size = 100
+  }  
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
   }
   command <<<
     # parse terra table for data

--- a/tasks/utilities/task_download_terra_table.wdl
+++ b/tasks/utilities/task_download_terra_table.wdl
@@ -2,7 +2,10 @@ version 1.0
 
 task download_terra_table {
   meta {
-    description: "This task downloads a Terra table and reduces it to only include the samples of interest."
+    description: "This task downloads a Terra table and reduces it to only include the samples of interest."   
+    
+    # added so that call caching is always turned off
+    volatile: true
   }
   input {
     String terra_table_name

--- a/tasks/utilities/task_file_handling.wdl
+++ b/tasks/utilities/task_file_handling.wdl
@@ -83,13 +83,17 @@ task transfer_files {
     Int mem_size_gb = 8
     String docker_image = "us-docker.pkg.dev/general-theiagen/theiagen/utility:1.1"
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     file_path_array="~{sep=' ' files_to_transfer}"
 
     gsutil -m cp -n ${file_path_array[@]} ~{target_bucket}
     
     echo "transferred_files" > transferred_files.tsv
-    gsutil ls ~{target_bucket} >> transferred_files.tsv        
+    gsutil -m ls ~{target_bucket} >> transferred_files.tsv        
    >>>
   output {
     File transferred_files = "transferred_files.tsv"

--- a/tasks/utilities/task_ncbi_datasets.wdl
+++ b/tasks/utilities/task_ncbi_datasets.wdl
@@ -10,6 +10,10 @@ task ncbi_datasets_download_genome_accession {
     Boolean include_gbff = false
     Boolean include_gff3 = false
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     date | tee DATE
     datasets --version | sed 's|datasets version: ||' | tee DATASETS_VERSION

--- a/tasks/utilities/task_summarize_data.wdl
+++ b/tasks/utilities/task_summarize_data.wdl
@@ -15,6 +15,10 @@ task summarize_data {
     #File? input_table
     Boolean phandango_coloring = true
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<   
     # when running on terra, comment out all input_table mentions
     python3 /scripts/export_large_tsv/export_large_tsv.py --project "~{terra_project}" --workspace "~{terra_workspace}" --entity_type ~{terra_table} --tsv_filename ~{terra_table}-data.tsv 

--- a/tasks/utilities/task_theiacov_fasta_batch.wdl
+++ b/tasks/utilities/task_theiacov_fasta_batch.wdl
@@ -26,6 +26,10 @@ task sm_theiacov_fasta_wrangling { # the sm stands for supermassive
     
     Int disk_size = 100
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     # convert the map into a JSON file for use in the python block
     # example map: {ERR4439752.test: /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/ERR4439752.ivar.consensus.fasta}

--- a/tasks/utilities/task_theiacov_fasta_batch.wdl
+++ b/tasks/utilities/task_theiacov_fasta_batch.wdl
@@ -26,10 +26,6 @@ task sm_theiacov_fasta_wrangling { # the sm stands for supermassive
     
     Int disk_size = 100
   }
-  meta {
-    # added so that call caching is always turned off
-    volatile: true
-  }
   command <<<
     # convert the map into a JSON file for use in the python block
     # example map: {ERR4439752.test: /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/ERR4439752.ivar.consensus.fasta}

--- a/tasks/utilities/task_validate.wdl
+++ b/tasks/utilities/task_validate.wdl
@@ -66,6 +66,10 @@ task compare_two_tsvs {
 
     Int disk_size = 10
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     # too lazy to create a new docker image, this is not good practice
     pip install pretty_html_table

--- a/tasks/utilities/task_validate.wdl
+++ b/tasks/utilities/task_validate.wdl
@@ -10,6 +10,10 @@ task export_two_tsvs {
     String datatable2
     Int disk_size = 10
   }
+  meta {
+    # added so that call caching is always turned off
+    volatile: true
+  }
   command <<<
     python3 /scripts/export_large_tsv/export_large_tsv.py --project ~{terra_project1} --workspace ~{terra_workspace1} --entity_type ~{datatable1} --tsv_filename "~{datatable1}.tsv"
 

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -632,7 +632,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 43ef050bde1fb8755f38e697a1794918
+      md5sum: 83b48f6ff9651d8897e30c581b5cfe32
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: 0c87a7279c4870a821c3dc1db9a6a94b
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -634,7 +634,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: 83b48f6ff9651d8897e30c581b5cfe32
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 3acf4dcddbb44d547b69f597761cc048
+      md5sum: 4106837e51f6445e02776e0a74606ed5
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -632,9 +632,9 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 83b48f6ff9651d8897e30c581b5cfe32
-    - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: 4106837e51f6445e02776e0a74606ed5
+    - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+      md5sum: 3acf4dcddbb44d547b69f597761cc048
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 83b48f6ff9651d8897e30c581b5cfe32
+      md5sum: 4106837e51f6445e02776e0a74606ed5
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 3e19938fc8a624c7948b57867865561a
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: faacd87946ee3fbdf70f3a15b79ce547
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 43ef050bde1fb8755f38e697a1794918
+      md5sum: 83b48f6ff9651d8897e30c581b5cfe32
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: e1d9e75dae5176ceeb95b88a5d3bbba7
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl


### PR DESCRIPTION
~~Need to test in Terra, but wanted to at least get the draft PR in place.~~

Testing is done in Terra, ready for review and further testing. I would recommend that the reviewer re-launches workflows on the dev branch `cjk-disable-call-cache` for workflows that have been run previously. If you don't have previous workflows, launch the workflow twice. Ensure the call cache box IS CHECKED (default behavior) and inspect job manager to ensure cache was not used for the updated WDL tasks

Closes #250 #235 

## :hammer_and_wrench: Changes Being Made

Added this code to a few different task files:

```WDL
  meta {
    # added so that call caching is always turned off
    volatile: true
  }
```

So that call caching is disabled when running these workflows in Terra. In my opinion these are workflows where the expected behavior is to always run from the beginning, regardless of previous attempts.

The benefit of knowing the output files are fresh & not having to troubleshoot after a user accidentally forgets to disable the call caching feature in Terra (which is on by default) far outweigh the benefit of saving on compute time.

### Impacted Workflows/Tasks

- **basespace_fetch** task and workflow
- **transfer_column_content** task and workflow
- and ncbi_datasets task which impacts **assembly_fetch** workflow and **Snippy_streamline** workflow
  - enabled multi-threading for transfer_column_content task: added this flag `gsutil -m`
- **theiavalidate workflow** tasks, `export_two_tsvs` and `compare_two_tsvs`,

## :brain: Context and Rationale

See above for rationale

## :clipboard: Workflow/Task Steps

N/A

### Inputs

N/A

### Outputs

N/A

### Impacted Outputs



## :test_tube: Testing

### Locally

Did not test locally, change is most relevant to Terra environment. Although these files pass `miniwdl check` syntax check.

### Terra

Will add test workflows later

### Scenarios for Reviewer to Test

Would be good to re-launch workflows that have been run in the past. Then inspect the Job Manager in Terra and ensure call caching is off for the specified task.

## :microscope: Quality checks

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)