### PR TITLE
HOSTILE: For TheiaCoV_Illumina_PE_PHB and TheiaCoV_ONT_PHB

### DIFF
--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -5,7 +5,7 @@ task hostile {
     File read1
     File? read2
     String samplename
-    String docker = "quay.io/biocontainers/hostile:0.2.0--pyhdfd78af_0"
+    String docker = "quay.io/biocontainers/hostile:0.3.0--pyhdfd78af_0"
     String seq_method
 
     Int disk_size = 100
@@ -36,8 +36,8 @@ task hostile {
       mv ./*.clean_2.fastq.gz "~{samplename}_R2_dehosted.fastq.gz"
     fi
     # extract the number of removed human reads
-    grep '"reads_removed":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tee HUMANREADS
-    grep '"reads_removed_proportion":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tee HUMANREADS_PROP
+    grep '"reads_removed":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' > HUMANREADS
+    grep '"reads_removed_proportion":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' > HUMANREADS_PROP
   >>>
   output {
     String hostile_version = read_string("VERSION")

--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -10,7 +10,7 @@ task hostile {
 
     Int disk_size = 100
     Int cpu = 4
-    Int mem = 8
+    Int mem = 16
   }
   command <<<
     # date and version control

--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -43,8 +43,8 @@ task hostile {
     String hostile_version = read_string("VERSION")
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File? read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
-    Int human_reads_removed = read_int("HUMANREADS")
-    Float human_reads_removed_proportion = read_float("HUMANREADS_PROP")
+    Int? human_reads_removed = read_int("HUMANREADS")
+    Float? human_reads_removed_proportion = read_float("HUMANREADS_PROP")
     String hostile_docker = docker
   }
   runtime {

--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -5,7 +5,7 @@ task hostile {
     File read1
     File? read2
     String samplename
-    String docker = "quay.io/biocontainers/hostile:0.3.0--pyhdfd78af_0"
+    String docker = "quay.io/biocontainers/hostile:0.2.0--pyhdfd78af_0"
     String seq_method
 
     Int disk_size = 100
@@ -37,12 +37,14 @@ task hostile {
     fi
     # extract the number of removed human reads
     grep '"reads_removed":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tee HUMANREADS
+    grep '"reads_removed_proportion":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tee HUMANREADS_PROP
   >>>
   output {
     String hostile_version = read_string("VERSION")
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File? read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
     Int human_reads_removed = read_int("HUMANREADS")
+    Float human_reads_removed_proportion = read_float("HUMANREADS_PROP")
     String hostile_docker = docker
   }
   runtime {

--- a/tasks/quality_control/task_hostile.wdl
+++ b/tasks/quality_control/task_hostile.wdl
@@ -1,0 +1,57 @@
+version 1.0
+
+task hostile {
+  input {
+    File read1
+    File? read2
+    String samplename
+    String docker = "quay.io/biocontainers/hostile:0.3.0--pyhdfd78af_0"
+    String seq_method
+
+    Int disk_size = 100
+    Int cpu = 4
+    Int mem = 8
+  }
+  command <<<
+    # date and version control
+    date | tee DATE
+    hostile --version | tee VERSION
+
+    # dehost reads based on sequencing method
+    if [[ "~{seq_method}" == "OXFORD_NANOPORE" ]]; then
+      hostile clean \
+        --fastq1 ~{read1} \
+        --aligner "minimap2" \
+        --threads ~{cpu} > decontamination-log.json
+      
+      mv ./*.clean.fastq.gz "~{samplename}_R1_dehosted.fastq.gz"
+    else
+      hostile clean \
+        --fastq1 ~{read1} \
+        --fastq2 ~{read2} \
+        --aligner "bowtie2" \
+        --threads ~{cpu} > decontamination-log.json
+      
+      mv ./*.clean_1.fastq.gz "~{samplename}_R1_dehosted.fastq.gz"
+      mv ./*.clean_2.fastq.gz "~{samplename}_R2_dehosted.fastq.gz"
+    fi
+    # extract the number of removed human reads
+    grep '"reads_removed":' ./decontamination-log.json | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tee HUMANREADS
+  >>>
+  output {
+    String hostile_version = read_string("VERSION")
+    File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
+    File? read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
+    Int human_reads_removed = read_int("HUMANREADS")
+    String hostile_docker = docker
+  }
+  runtime {
+      docker: docker
+      memory: "~{mem} GB"
+      cpu: cpu
+      disks:  "local-disk " + disk_size + " SSD"
+      disk: disk_size + " GB" # TES
+      preemptible: 0
+      maxRetries: 3
+  }
+}

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -28,6 +28,8 @@ workflow theiacov_illumina_pe {
     File? primer_bed
     File? adapters
     File? phix
+    # Human reads removal (dehosting) tool
+    String dehosting_tool = "ncbi_scrub" # options: "ncbi_scrub", "hostile"
     # reference values
     File? reference_gff
     File? reference_genome
@@ -91,7 +93,9 @@ workflow theiacov_illumina_pe {
         workflow_series = "theiacov",
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        dehosting_tool = dehosting_tool,
+        seq_method = seq_method
     }
     call screen.check_reads as clean_check_reads {
       input:

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -76,7 +76,8 @@ workflow theiacov_ont {
         max_length = max_length,
         run_prefix = run_prefix,
         target_org = target_org,
-        workflow_series = "theiacov"
+        workflow_series = "theiacov",
+        seq_method = seq_method
     }
     call screen.check_reads_se as clean_check_reads {
       input:

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "../../tasks/quality_control/task_fastq_scan.wdl" as fastq_scan
 import "../../tasks/quality_control/task_trimmomatic.wdl" as trimmomatic
 import "../../tasks/quality_control/task_ncbi_scrub.wdl" as ncbi_scrub
+import "../../tasks/quality_control/task_hostile.wdl" as hostile_task
 import "../../tasks/quality_control/task_bbduk.wdl" as bbduk_task
 import "../../tasks/quality_control/task_readlength.wdl" as readlength_task
 import "../../tasks/quality_control/task_fastp.wdl" as fastp_task
@@ -30,13 +31,24 @@ workflow read_QC_trim_pe {
     String read_processing = "trimmomatic"
     String? trimmomatic_args
     String fastp_args = "--detect_adapter_for_pe -g -5 20 -3 20"
+    String dehosting_tool
+    String seq_method
   }
-  if (("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) {
+  if ((("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) && (dehosting_tool == "ncbi_scrub")) {
     call ncbi_scrub.ncbi_scrub_pe {
       input:
         samplename = samplename,
         read1 = read1_raw,
         read2 = read2_raw
+    }
+  }
+  if ((("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) && (dehosting_tool == "hostile")) {
+    call hostile_task.hostile {
+      input:
+        samplename = samplename,
+        read1 = read1_raw,
+        read2 = read2_raw,
+        seq_method = seq_method
     }
   }
   if ("~{workflow_series}" == "theiacov") {
@@ -50,8 +62,8 @@ workflow read_QC_trim_pe {
     call kraken.kraken2_theiacov as kraken2_theiacov_dehosted {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted]),
-        read2 = ncbi_scrub_pe.read2_dehosted,
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted]),
         target_org = target_org
     }
   }
@@ -59,8 +71,8 @@ workflow read_QC_trim_pe {
     call trimmomatic.trimmomatic_pe {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted, read1_raw]),
-        read2 = select_first([ncbi_scrub_pe.read2_dehosted, read2_raw]),
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted, read1_raw]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted, read2_raw]),
         trimmomatic_window_size = trim_window_size,
         trimmomatic_quality_trim_score = trim_quality_trim_score,
         trimmomatic_minlen = trim_minlen,
@@ -71,8 +83,8 @@ workflow read_QC_trim_pe {
     call fastp_task.fastp_pe as fastp {
       input:
         samplename = samplename,
-        read1 = select_first([ncbi_scrub_pe.read1_dehosted, read1_raw]),
-        read2 = select_first([ncbi_scrub_pe.read2_dehosted, read2_raw]),
+        read1 = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted, read1_raw]),
+        read2 = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted, read2_raw]),
         fastp_window_size = trim_window_size,
         fastp_quality_trim_score = trim_quality_trim_score,
         fastp_minlen = trim_minlen,
@@ -115,11 +127,13 @@ workflow read_QC_trim_pe {
     }
   }
   output {
-    # NCBI scrubber
-    File? read1_dehosted = ncbi_scrub_pe.read1_dehosted
-    File? read2_dehosted = ncbi_scrub_pe.read2_dehosted
+    # NCBI scrubber and HOSTILE
+    File? read1_dehosted = select_first([ncbi_scrub_pe.read1_dehosted, hostile.read1_dehosted])
+    File? read2_dehosted = select_first([ncbi_scrub_pe.read2_dehosted, hostile.read2_dehosted])
     Int? ncbi_scrub_human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String? ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
+    Int? hostile_human_reads_removed = hostile.human_reads_removed
+    String? hostile_docker = hostile.hostile_docker
 
     # bbduk
     File read1_clean = bbduk.read1_clean


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
NOTE: Merge https://github.com/theiagen/public_health_bioinformatics/pull/202 before merging this branch!!

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->
Adding a new `hostile` task as the human reads removal (dehosting) tool for `TheiaCoV_ONT_PHB`, and an optional dehosting tool for `TheiaCoV_Illumina_PE_PHB`.

### Impacted Workflows/Tasks

<!--List the workflows and/or tasks that will be affected by this change-->
`task_hostile`
`wf_read_QC_trim_pe`
`TheiaCoV_Illumina_PE_PHB`
`wf_read_QC_trim_ont`
`TheiaCoV_ONT_PHB`

## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->
The current dehosting tool `ncbi-scrub` only works with illumina paired end reads, whereas `hostile` works with both illumina and oxford nanopore (ONT) reads. Therefore, we are implementing `hostile` for dehosting of reads in the `TheiaCoV_ONT_PHB` workflow.

For `TheiaCoV_Illumina_PE_PHB`, we are giving users the option to use hostile if so preferred.

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->
The `hostile` task takes as input the variable `seq_method` to determine if working with or ONT reads. By default, these are set in the `TheiaCoV_Illumina_PE_PHB` and `TheiaCoV_ONT_PHB` workflows as `ILLUMINA` and `OXFORD_NANOPORE`, respectively.

### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->
`TheiaCoV_ONT_PHB`: Inputs remain the same
`TheiaCoV_Illumina_PE_PHB`: Added an optional input `dehosting_tool` which takes in the options `ncbi_scrub` (default) or `hostile`

### Outputs

<!--What are the outputs of your workflow/task?-->
Remain the same

### Impacted Outputs

<!--List any existing outputs that will be affected by this change-->

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->
Works as expected locally for the `TheiaCoV_ONT_PHB` and `TheiaCoV_Illumina_PE_PHB` workflows

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->
Works as expected for 
`TheiaCoV_ONT_PHB`: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/Global_tree_testing/job_history/f84b2815-6ef5-4ba2-9da6-ba27e49b0a9f SARS-CoV-2
 and 
`TheiaCoV_Illumina_PE_PHB`: 
  With `dehosting_tool` set to `hostile`: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/Global_tree_testing/job_history/d731282a-07c6-4aca-8015-f15c5c7dd2c8 Influenza
  With `dehosting_tool` blank or the default `ncbi_scrub`: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/Global_tree_testing/job_history/8c8e1e82-cf14-4ad2-a872-011d03248bc2 influenza


### Scenarios for Reviewer to Test

<!--Please list any potential scenarios that the reviewer should test, such as edge-cases or data types-->
Test for pathogens other than SARS-CoV-2 and Influenza, and with samples rich in human reads.

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [X] Include a description of what is in this pull request in this message.
- [X] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [X] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)