### PR TITLE
Expose midas secondary genus absolute coverage

### DIFF
--- a/tasks/quality_control/task_qc_check_phb.wdl
+++ b/tasks/quality_control/task_qc_check_phb.wdl
@@ -32,7 +32,8 @@ task qc_check_phb {
     Float? quast_gc_percent
     String? busco_results
     # theiaprok only inputs
-    String? midas_secondary_genus_abundance 
+    Float? midas_secondary_genus_abundance 
+    Float? midas_secondary_genus_coverage
     Float? ani_highest_percent 
     Float? ani_highest_percent_bases_aligned
     # theiacov inputs
@@ -238,6 +239,11 @@ task qc_check_phb {
           if ("~{midas_secondary_genus_abundance}"): # if midas_secondary_genus_abundance variable exists,
             qc_note, qc_status = compare(qc_note, "midas_secondary_genus_abundance", float(~{midas_secondary_genus_abundance}), "<", float(taxon_df["midas_secondary_genus_abundance"][0]))
             qc_check_metrics.remove("midas_secondary_genus_abundance")  
+
+        if ("midas_secondary_genus_coverage" in qc_check_metrics): # if this var is in the qc_check_metrics,
+          if ("~{midas_secondary_genus_coverage}"): # if midas_secondary_genus_coverage variable exists,
+            qc_note, qc_status = compare(qc_note, "midas_secondary_genus_coverage", float(~{midas_secondary_genus_coverage}), "<", float(taxon_df["midas_secondary_genus_coverage"][0]))
+            qc_check_metrics.remove("midas_secondary_genus_coverage")  
 
         if ("assembly_length_min" in qc_check_metrics):
           if ("~{assembly_length}"):

--- a/tasks/taxon_id/task_midas.wdl
+++ b/tasks/taxon_id/task_midas.wdl
@@ -46,11 +46,13 @@ task midas {
     filtered_sorted_df = filtered_df.sort_values(by=['relative_abundance'], ascending=False)
     # capture secondary genus
     secondary_genus = filtered_sorted_df.genus.iloc[0]
-    # capture abundance of secondary genus
+    # capture relative abundance of secondary genus
     secondary_genus_abundance = filtered_sorted_df.relative_abundance.iloc[0]
     # if secondary genus abundance is less than one, replace genus with text indicating no secondary genus detected
     if secondary_genus_abundance < 0.01:
       secondary_genus="No secondary genus detected (>1% relative abundance)"
+    # capture absolute coverage of secondary genus
+    secondary_genus_coverage = filtered_sorted_df.coverage.iloc[0]
 
     # write text files
     with open("PRIMARY_GENUS", 'wt') as pg:
@@ -59,6 +61,8 @@ task midas {
       sg.write(str(secondary_genus))
     with open("SECONDARY_GENUS_ABUNDANCE", 'wt') as sga:
       sga.write(str(secondary_genus_abundance))
+    with open("SECONDARY_GENUS_COVERAGE", 'wt') as sgc:
+      sgc.write(str(secondary_genus_coverage))
 
     CODE
   >>>
@@ -70,6 +74,7 @@ task midas {
     String midas_primary_genus = read_string("PRIMARY_GENUS")
     String midas_secondary_genus = read_string("SECONDARY_GENUS")
     Float midas_secondary_genus_abundance = read_string("SECONDARY_GENUS_ABUNDANCE")
+    Float midas_secondary_genus_coverage = read_string("SECONDARY_GENUS_COVERAGE")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -289,6 +289,7 @@ task export_taxon_tables {
     String? midas_primary_genus
     String? midas_secondary_genus
     Float? midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage
     File? bakta_gbff
     File? bakta_gff3
     File? bakta_tsv
@@ -646,6 +647,7 @@ task export_taxon_tables {
       "midas_primary_genus": "~{midas_primary_genus}",
       "midas_secondary_genus": "~{midas_secondary_genus}",
       "midas_secondary_genus_abundance": "~{midas_secondary_genus_abundance}",
+      "midas_secondary_genus_coverage": "~{midas_secondary_genus_coverage}",
       "bakta_gbff": "~{bakta_gbff}",
       "bakta_gff3": "~{bakta_gff3}",
       "bakta_tsv": "~{bakta_tsv}",

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -634,7 +634,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: dd53769da387ff48ae41c26c6ab0de9a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 4fcaef0a35953b0472518b34466f8502
+      md5sum: 276243ad207e034c445076af873c77b2
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -631,9 +631,9 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: dd53769da387ff48ae41c26c6ab0de9a
+      md5sum: 49d8350161dd66ef382938128e2d327c
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 276243ad207e034c445076af873c77b2
+      md5sum: 6979e7ae9700d4272b29472aff4f0974
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 90eb6ac7463058a81da77120aa45138b
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -630,11 +630,11 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
-      md5sum: faacd87946ee3fbdf70f3a15b79ce547
+      md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 43ef050bde1fb8755f38e697a1794918
+      md5sum: bd8d8c6a24114649b094bc199237ef36
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 0c87a7279c4870a821c3dc1db9a6a94b
+      md5sum: 0b9cb986cd8ae28dc96d23a03c6897da
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -632,9 +632,9 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: bd8d8c6a24114649b094bc199237ef36
+      md5sum: dd53769da387ff48ae41c26c6ab0de9a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 0b9cb986cd8ae28dc96d23a03c6897da
+      md5sum: 4fcaef0a35953b0472518b34466f8502
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -596,14 +596,14 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
-      md5sum: faacd87946ee3fbdf70f3a15b79ce547
+      md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: 43ef050bde1fb8755f38e697a1794918
+      md5sum: bd8d8c6a24114649b094bc199237ef36
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: e1d9e75dae5176ceeb95b88a5d3bbba7
+      md5sum: e6fe66c28e9f70bf6b8e1b337618d35c
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: 53d322d895837c0bcb049786572e944d
+      md5sum: f9f50499336d88b3665760173a21cf95
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,12 +598,12 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: bd8d8c6a24114649b094bc199237ef36
+      md5sum: dd53769da387ff48ae41c26c6ab0de9a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: e6fe66c28e9f70bf6b8e1b337618d35c
+      md5sum: 74bdaeba04fe0afdcbe2200045dd0e69
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: f9f50499336d88b3665760173a21cf95
+      md5sum: dd851d804922a26633ee93e1b20e4df6
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -596,12 +596,12 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl
       md5sum: c6f3b8b3e3894208f7b247709944c9bc
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
-      md5sum: dd53769da387ff48ae41c26c6ab0de9a
+      md5sum: 49d8350161dd66ef382938128e2d327c
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: 7a086085fbf80ad1bbdba2bca0fe98e5
+      md5sum: d8e6c9b24f4f7c69007e74b43e706559
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 90eb6ac7463058a81da77120aa45138b
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: 41d4eea28006fce852660abe334d0342
+      md5sum: b2e5df989c03c0a56a2f158edbc62f26
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -600,10 +600,10 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: dd53769da387ff48ae41c26c6ab0de9a
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: 74bdaeba04fe0afdcbe2200045dd0e69
+      md5sum: 7a086085fbf80ad1bbdba2bca0fe98e5
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 00bd2489b2a7aa5b88340a940961a857
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: dd851d804922a26633ee93e1b20e4df6
+      md5sum: 41d4eea28006fce852660abe334d0342
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -84,7 +84,8 @@ workflow theiaprok_illumina_pe {
         read2_raw = read2_raw,
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        workflow_series = "theiaprok"
 
     }
     call screen.check_reads as clean_check_reads {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -214,6 +214,7 @@ workflow theiaprok_illumina_pe {
             est_coverage_raw = cg_pipeline_raw.est_coverage,
             est_coverage_clean = cg_pipeline_clean.est_coverage,
             midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance,
+            midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage,
             assembly_length = quast.genome_length,
             number_contigs = quast.number_contigs,
             n50_value = quast.n50_value,
@@ -521,6 +522,7 @@ workflow theiaprok_illumina_pe {
             midas_primary_genus = read_QC_trim.midas_primary_genus,
             midas_secondary_genus = read_QC_trim.midas_secondary_genus,
             midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance,
+            midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage,
             pasty_serogroup = merlin_magic.pasty_serogroup,
             pasty_serogroup_coverage = merlin_magic.pasty_serogroup_coverage,
             pasty_serogroup_fragments = merlin_magic.pasty_serogroup_fragments,
@@ -583,6 +585,7 @@ workflow theiaprok_illumina_pe {
     String? midas_primary_genus = read_QC_trim.midas_primary_genus
     String? midas_secondary_genus = read_QC_trim.midas_secondary_genus
     Float? midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage
     # Assembly - shovill outputs 
     File? assembly_fasta = shovill_pe.assembly_fasta
     File? contigs_gfa = shovill_pe.contigs_gfa

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -197,6 +197,7 @@ workflow theiaprok_illumina_se {
             est_coverage_raw = cg_pipeline_raw.est_coverage,
             est_coverage_clean = cg_pipeline_clean.est_coverage,
             midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance,
+            midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage,
             assembly_length = quast.genome_length,
             number_contigs = quast.number_contigs,
             n50_value = quast.n50_value,
@@ -479,6 +480,7 @@ workflow theiaprok_illumina_se {
             midas_primary_genus = read_QC_trim.midas_primary_genus,
             midas_secondary_genus = read_QC_trim.midas_secondary_genus,
             midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance,
+            midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage,
             pasty_serogroup = merlin_magic.pasty_serogroup,
             pasty_serogroup_coverage = merlin_magic.pasty_serogroup_coverage,
             pasty_serogroup_fragments = merlin_magic.pasty_serogroup_fragments,
@@ -537,6 +539,7 @@ workflow theiaprok_illumina_se {
     String? midas_primary_genus = read_QC_trim.midas_primary_genus
     String? midas_secondary_genus = read_QC_trim.midas_secondary_genus
     Float? midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage
     #Assembly - shovill outputs
     File? assembly_fasta = shovill_se.assembly_fasta
     File? contigs_gfa = shovill_se.contigs_gfa

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -82,7 +82,8 @@ workflow theiaprok_illumina_se {
         read1_raw = read1_raw,
         trim_minlen = trim_minlen,
         trim_quality_trim_score = trim_quality_trim_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        workflow_series = "theiaprok"
     }
     call screen.check_reads_se as clean_check_reads {
       input:

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -21,7 +21,7 @@ workflow read_QC_trim_pe {
     Int trim_quality_trim_score = 30
     Int trim_window_size = 4
     Int bbduk_mem = 8
-    Boolean call_midas = false
+    Boolean call_midas = true
     File? midas_db
     String? target_org
     File? adapters

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -98,13 +98,15 @@ workflow read_QC_trim_pe {
       read1 = bbduk.read1_clean,
       read2 = bbduk.read2_clean
   }
-  if (call_midas) {
-    call midas_task.midas {
-      input:
-        samplename = samplename,
-        read1 = read1_raw,
-        read2 = read2_raw,
-        midas_db = midas_db
+  if ("~{workflow_series}" == "theiaprok") {
+    if (call_midas) {
+      call midas_task.midas {
+        input:
+          samplename = samplename,
+          read1 = read1_raw,
+          read2 = read2_raw,
+          midas_db = midas_db
+      }
     }
   }
   if ("~{workflow_series}" == "theiameta") {

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -160,6 +160,7 @@ workflow read_QC_trim_pe {
     String? midas_primary_genus = midas.midas_primary_genus
     String? midas_secondary_genus = midas.midas_secondary_genus
     Float? midas_secondary_genus_abundance = midas.midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage = midas.midas_secondary_genus_coverage
 
     # readlength
     Float? average_read_length = readlength.average_read_length

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -74,12 +74,14 @@ workflow read_QC_trim_se {
         target_org = target_org
     }
   }
-  if (call_midas) {
-    call midas_task.midas {
-      input:
-        samplename = samplename,
-        read1 = read1_raw,
-        midas_db = midas_db
+  if ("~{workflow_series}" == "theiaprok"){
+    if (call_midas) {
+      call midas_task.midas {
+        input:
+          samplename = samplename,
+          read1 = read1_raw,
+          midas_db = midas_db
+      }
     }
   }
   output {

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -110,5 +110,6 @@ workflow read_QC_trim_se {
     String? midas_primary_genus = midas.midas_primary_genus
     String? midas_secondary_genus = midas.midas_secondary_genus
     Float? midas_secondary_genus_abundance = midas.midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage = midas.midas_secondary_genus_coverage
   }
 }

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -23,7 +23,7 @@ workflow read_QC_trim_se {
     File? phix
     String? workflow_series
     String? trimmomatic_args
-    Boolean call_midas = false
+    Boolean call_midas = true
     File? midas_db
     String read_processing = "trimmomatic"
     String fastp_args = "-g -5 20 -3 20"


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes https://github.com/theiagen/public_health_bioinformatics/issues/247
## :hammer_and_wrench: Changes Being Made

### Impacted Workflows/Tasks

./tasks/taxon_id/task_midas.wdl
./tasks/quality_control/task_qc_check.wdl
./tasks/utilities/task_broad_terra_tools.wdl
./workflows/theiaprok/wf_theiaprok_illumina_se.wdl
./workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
./workflows/utilities/wf_read_QC_trim_se.wdl
./workflows/utilities/wf_read_QC_trim_pe.wdl

## :brain: Context and Rationale

This PR exposes the absolute coverage of the second-most prevalent genus detected by MIDAS in a sample. It also makes MIDAS a default module so that contamination is more easily identifiable. 




## :clipboard: Workflow/Task Steps

The MIDAS task performs the following steps: 
1. orders the MIDAS report by the relative abundance column
2. identifies the most prevalent genus by relative abundance
3. identifies the second-most prevalent genus by relative abundance
4. flags if the relative abundance of the second-most prevalent genus is above 0.01 (1%)

In addition to these steps, the task will now also:

5. report the absolute coverage of the second-most prevalent genus as shown in the "coverage" column below.


species_id | count_reads | coverage | relative_abundance
-- | -- | -- | --
Salmonella_enterica_58156 | 3309 | 89.88006645 | 0.855888033
Salmonella_enterica_58266 | 501 | 11.60606061 | 0.110519371
Salmonella_enterica_53987 | 99 | 2.232896237 | 0.021262881
Citrobacter_youngae_61659 | 46 | **0.995216227** | 0.009477003
Escherichia_coli_58110 | 5 | 0.123668877 | 0.001177644


**This PR also makes the MIDAS module default in TheiaProk_Illumina_PE_PHB and TheiaProk_Illumina_SE_PHB.** However, the workflow can be turned off by setting `call_midas` to `false` to conserve compute resources and time.

Finally, this PR adds the string input `workflow_series` to the TheiaProk PE and SE workflows with the default value of "theiaprok" for consistency with the TheiaProk ONT workflow. This input is passed to read_qc_trim_pe and read_qc_trim_se, respectively, to ensure that the MIDAS task is **only** run for the TheiaProk workflows.

### Inputs

No workflow inputs 

### Outputs

midas_secondary_genus_coverage

### Impacted Outputs

<!--List any existing outputs that will be affected by this change-->

## :test_tube: Testing

### Locally

No local testing was performed

### Terra

TheiaProk_Illumina_PE_PHB testing on 55 enteric samples: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Scribner_Sandbox/job_history/27465535-a7d4-42a4-a979-c880ea737019

### Scenarios for Reviewer to Test

TheiaProk_Illumina_SE_PHB still needs testing

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [ ] The workflow/task has been tested locally and on Terra
- [ ] The CI/CD has been adjusted and tests are passing
- [ ] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)