### PR TITLE
[New Utility] Workflow to rename FASTQ files (non-destructive)

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -248,3 +248,8 @@ workflows:
    primaryDescriptorPath: /workflows/utilities/wf_czgenepi_prep.wdl
    testParameterFiles:
     - empty.json
+ - name: Rename_FASTQ_PHB
+   subclass: WDL
+   primaryDescriptorPath: /workflows/utilities/file_handling/wf_rename_fastq_files.wdl
+   testParameterFiles:
+    - empty.json

--- a/tasks/utilities/task_rename_files.wdl
+++ b/tasks/utilities/task_rename_files.wdl
@@ -17,25 +17,25 @@ task rename_PE_files {
     # rename forward read
     # check if compressed, if not rename and compress
     if [[ "~{read1}" == *.gz ]]; then
-      cp ~{read1} ~{new_filename}_1.fastq.gz
+      cp ~{read1} ~{new_filename}_R1.fastq.gz
     else
-      cp ~{read1} ~{new_filename}_1.fastq
-      gzip ~{new_filename}_1.fastq
+      cp ~{read1} ~{new_filename}_R1.fastq
+      gzip ~{new_filename}_R1.fastq
     fi
 
     # check if reverse read exists
     if [ ! -z ~{read2} ]; then
       if [[ "~{read2}" == *.gz ]]; then
-        cp ~{read2} ~{new_filename}_2.fastq.gz
+        cp ~{read2} ~{new_filename}_R2.fastq.gz
       else
-        cp ~{read2} ~{new_filename}_2.fastq
-        gzip ~{new_filename}_2.fastq
+        cp ~{read2} ~{new_filename}_R2.fastq
+        gzip ~{new_filename}_R2.fastq
       fi
     fi
   >>>
   output {
-    File read1_renamed = "~{new_filename}_1.fastq.gz"
-    File? read2_renamed = "~{new_filename}_2.fastq.gz"
+    File read1_renamed = "~{new_filename}_R1.fastq.gz"
+    File? read2_renamed = "~{new_filename}_R2.fastq.gz"
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/utilities/task_rename_files.wdl
+++ b/tasks/utilities/task_rename_files.wdl
@@ -6,7 +6,7 @@ task rename_PE_files {
   }
   input {
     File read1
-    File read2
+    File? read2
     String new_filename
     String docker = "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
     Int disk_size = 100
@@ -14,12 +14,28 @@ task rename_PE_files {
     Int mem = 2
   }
   command <<<
-    mv ~{read1} ~{new_filename}_R1.fastq.gz
-    mv ~{read2} ~{new_filename}_R2.fastq.gz
+    # rename forward read
+    # check if compressed, if not rename and compress
+    if [[ "~{read1}" == *.gz ]]; then
+      cp ~{read1} ~{new_filename}_1.fastq.gz
+    else
+      cp ~{read1} ~{new_filename}_1.fastq
+      gzip ~{new_filename}_1.fastq
+    fi
+
+    # check if reverse read exists
+    if [ ! -z ~{read2} ]; then
+      if [[ "~{read2}" == *.gz ]]; then
+        cp ~{read2} ~{new_filename}_2.fastq.gz
+      else
+        cp ~{read2} ~{new_filename}_2.fastq
+        gzip ~{new_filename}_2.fastq
+      fi
+    fi
   >>>
   output {
-    File read1_renamed = "~{new_filename}_R1.fastq.gz"
-    File read2_renamed = "~{new_filename}_R2.fastq.gz"
+    File read1_renamed = "~{new_filename}_1.fastq.gz"
+    File? read2_renamed = "~{new_filename}_2.fastq.gz"
   }
   runtime {
     docker: "~{docker}"
@@ -27,7 +43,7 @@ task rename_PE_files {
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 3
+    maxRetries: 0
     preemptible: 0
   }
 }

--- a/tasks/utilities/task_rename_files.wdl
+++ b/tasks/utilities/task_rename_files.wdl
@@ -1,0 +1,34 @@
+version 1.0
+
+task rename_PE_files {
+  meta {
+    description: "Rename a set of Paired-End FASTQ files"
+  }
+  input {
+    File read1
+    File read2
+    String new_filename
+    String docker = "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
+    Int disk_size = 100
+    Int cpu = 2
+    Int mem = 2
+  }
+  command <<<
+    mv ~{read1} ~{new_filename}_R1.fastq.gz
+    mv ~{read2} ~{new_filename}_R2.fastq.gz
+  >>>
+  output {
+    File read1_renamed = "~{new_filename}_R1.fastq.gz"
+    File read2_renamed = "~{new_filename}_R2.fastq.gz"
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: mem + " GB"
+    cpu: cpu
+    disks: "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    maxRetries: 3
+    preemptible: 0
+  }
+}
+

--- a/tasks/utilities/task_rename_files.wdl
+++ b/tasks/utilities/task_rename_files.wdl
@@ -6,7 +6,7 @@ task rename_PE_files {
   }
   input {
     File read1
-    File? read2
+    File read2
     String new_filename
     String docker = "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
     Int disk_size = 100
@@ -24,18 +24,16 @@ task rename_PE_files {
     fi
 
     # check if reverse read exists
-    if [ ! -z ~{read2} ]; then
-      if [[ "~{read2}" == *.gz ]]; then
-        cp ~{read2} ~{new_filename}_R2.fastq.gz
-      else
-        cp ~{read2} ~{new_filename}_R2.fastq
-        gzip ~{new_filename}_R2.fastq
-      fi
+    if [[ "~{read2}" == *.gz ]]; then
+      cp ~{read2} ~{new_filename}_R2.fastq.gz
+    else
+      cp ~{read2} ~{new_filename}_R2.fastq
+      gzip ~{new_filename}_R2.fastq
     fi
   >>>
   output {
     File read1_renamed = "~{new_filename}_R1.fastq.gz"
-    File? read2_renamed = "~{new_filename}_R2.fastq.gz"
+    File read2_renamed = "~{new_filename}_R2.fastq.gz"
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/utilities/task_rename_files.wdl
+++ b/tasks/utilities/task_rename_files.wdl
@@ -48,3 +48,39 @@ task rename_PE_files {
   }
 }
 
+task rename_SE_files {
+  meta {
+    description: "Rename a set of Single-End FASTQ files"
+  }
+  input {
+    File read1
+    String new_filename
+    String docker = "us-docker.pkg.dev/general-theiagen/ubuntu/ubuntu:jammy-20230816"
+    Int disk_size = 100
+    Int cpu = 2
+    Int mem = 2
+  }
+  command <<<
+    # rename forward read
+    # check if compressed, if not rename and compress
+    if [[ "~{read1}" == *.gz ]]; then
+      cp ~{read1} ~{new_filename}.fastq.gz
+    else
+      cp ~{read1} ~{new_filename}.fastq
+      gzip ~{new_filename}.fastq
+    fi
+  >>>
+  output {
+    File read1_renamed = "~{new_filename}.fastq.gz"
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: mem + " GB"
+    cpu: cpu
+    disks: "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    maxRetries: 0
+    preemptible: 0
+  }
+}
+

--- a/workflows/utilities/file_handling/wf_rename_PE_files.wdl
+++ b/workflows/utilities/file_handling/wf_rename_PE_files.wdl
@@ -1,0 +1,27 @@
+version 1.0
+
+import "../../../tasks/utilities/task_rename_files.wdl" as rename_files_task
+import "../../../tasks/task_versioning.wdl" as versioning
+
+workflow rename_files {
+  input {
+    File read1
+    File read2
+    String new_filename
+  }
+  call rename_files_task.rename_PE_files {
+    input:
+      read1 = read1,
+      read2 = read2,
+      new_filename = new_filename
+  }
+  call versioning.version_capture {
+    input:
+  }
+  output {
+    String rename_PE_files_version = version_capture.phb_version
+    String rename_PE_files_analysis_date = version_capture.date
+    File read1_renamed = rename_PE_files.read1_renamed
+    File read2_renamed = rename_PE_files.read2_renamed
+  }
+}

--- a/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
+++ b/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
@@ -29,8 +29,8 @@ workflow rename_fastq_files {
     input:
   }
   output {
-    String rename_PE_files_version = version_capture.phb_version
-    String rename_PE_files_analysis_date = version_capture.date
+    String rename_fastq_files_version = version_capture.phb_version
+    String rename_fastq_files_analysis_date = version_capture.date
     File read1_renamed = select_first([rename_PE_files.read1_renamed, rename_SE_files.read1_renamed])
     File? read2_renamed = rename_PE_files.read2_renamed
   }

--- a/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
+++ b/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
@@ -3,10 +3,10 @@ version 1.0
 import "../../../tasks/utilities/task_rename_files.wdl" as rename_files_task
 import "../../../tasks/task_versioning.wdl" as versioning
 
-workflow rename_files {
+workflow rename_fastq_files {
   input {
     File read1
-    File read2
+    File? read2
     String new_filename
   }
   call rename_files_task.rename_PE_files {
@@ -22,6 +22,6 @@ workflow rename_files {
     String rename_PE_files_version = version_capture.phb_version
     String rename_PE_files_analysis_date = version_capture.date
     File read1_renamed = rename_PE_files.read1_renamed
-    File read2_renamed = rename_PE_files.read2_renamed
+    File? read2_renamed = rename_PE_files.read2_renamed
   }
 }

--- a/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
+++ b/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
@@ -13,7 +13,7 @@ workflow rename_fastq_files {
     call rename_files_task.rename_PE_files {
       input:
         read1 = read1,
-        read2 = read2,
+        read2 = select_first([read2]),
         new_filename = new_filename
     }
   } 

--- a/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
+++ b/workflows/utilities/file_handling/wf_rename_fastq_files.wdl
@@ -9,19 +9,29 @@ workflow rename_fastq_files {
     File? read2
     String new_filename
   }
-  call rename_files_task.rename_PE_files {
-    input:
-      read1 = read1,
-      read2 = read2,
-      new_filename = new_filename
+  if (defined(read2)) {
+    call rename_files_task.rename_PE_files {
+      input:
+        read1 = read1,
+        read2 = read2,
+        new_filename = new_filename
+    }
+  } 
+  if (!defined(read2)) {
+    call rename_files_task.rename_SE_files {
+      input:
+        read1 = read1,
+        new_filename = new_filename
+    }
   }
+
   call versioning.version_capture {
     input:
   }
   output {
     String rename_PE_files_version = version_capture.phb_version
     String rename_PE_files_analysis_date = version_capture.date
-    File read1_renamed = rename_PE_files.read1_renamed
+    File read1_renamed = select_first([rename_PE_files.read1_renamed, rename_SE_files.read1_renamed])
     File? read2_renamed = rename_PE_files.read2_renamed
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes #266

## :hammer_and_wrench: Changes Being Made

<!--Here give examples of the changes you've made to this pull request. Include an itemized list if you can. It'll help the reviewer-->

This PR implements a new utility workflow as requested in #266. This workflow received a read file or a pair of read files (FASTQ), compressed or uncompressed, and returned a new, renamed and compressed FASTQ file for submission in GISAID. 

### Impacted Workflows/Tasks

<!--List the workflows and/or tasks that will be affected by this change-->

None, this is a new implementation

## :brain: Context and Rationale

<!--What's the context of the changes? Were there any trade-offs you had to consider?-->

Requested by SFPHL

## :clipboard: Workflow/Task Steps

<!--What are the main steps of your workflow/task? Make it explicit enough so that someone who doesn't have deep knowledge of the workflow/task can understand how the rationale was implemented.-->

This is a sample-level workflow. If a reverse read (`read2`) is provided, the files get renamed to the provided `new_filename` input with the notation `<new_filename>_R1.fastq.gz` and `<new_filename>_R2.fastq.gz`. If only `read1` is provided, the file gets renamed to `<new_filename>.fastq.gz`. If a not-compressed file is provided, this gets compressed automatically by the workflow. ´


### Inputs

<!--What are the mandatory and optional inputs of your workflow/task?-->

```
  input {
    File read1  
    File? read2
    String new_filename
  }
```

`read1`: Mandatory input; Forward-facing or single-end reads, compressed or uncompressed
`read2`: Optional input; Reverse-facing reads, compressed or uncompressed
`new_filename`: Mandatory input; String with new name for read files

### Outputs

<!--What are the outputs of your workflow/task?-->

```
output {
    String rename_fastq_files_version = version_capture.phb_version
    String rename_fastq_files_analysis_date = version_capture.date
    File read1_renamed = select_first([rename_PE_files.read1_renamed, rename_SE_files.read1_renamed])
    File? read2_renamed = rename_PE_files.read2_renamed
  }
```

`rename_fastq_files_version`: version of PHB used to run this workflow
`rename_fastq_files_analysis_date`: date of renaming
`read1_renamed`: Forward-facing or single-end reads. Always present
`read2_renamed`: Reverse-facing reads. Only present if `read2` is provided

### Impacted Outputs

<!--List any existing outputs that will be affected by this change-->

None, new workflow

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

Paired-end reads (compressed):
<img width="686" alt="image" src="https://github.com/theiagen/public_health_bioinformatics/assets/15690332/937e5941-ce56-444a-892f-961344f66cbe">

Single-end reads (compressed):
<img width="685" alt="image" src="https://github.com/theiagen/public_health_bioinformatics/assets/15690332/303dd562-4e44-469c-ba91-1b631d6df190">

Single-end reads (uncompressed):
<img width="690" alt="image" src="https://github.com/theiagen/public_health_bioinformatics/assets/15690332/97519590-ef74-442b-9ff8-9ba87efd1a35">


### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

~~Underway~~

22 Samples PE, Compressed: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/ff1cda0d-1c92-4fc0-8b5e-7001d520cfe6

### Scenarios for Reviewer to Test

<!--Please list any potential scenarios that the reviewer should test, such as edge-cases or data types-->

- Weird filenames
- Should we keep the `_R1.fastq.gz` output name or change it to something else?

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)