### PR TITLE
output unaligned FASTQ files TheiaCov_Illumina PE and SE

### DIFF
--- a/tasks/alignment/task_bwa.wdl
+++ b/tasks/alignment/task_bwa.wdl
@@ -27,13 +27,18 @@ task bwa {
       ref_genome="/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta"  
     fi
 
+    echo "input R1 has $(zcat ~{read1} | grep -c '^@') reads as input"
+    echo "input R2 has $(zcat ~{read2} | grep -c '^@') reads as input"
+
     # Map with BWA MEM; pipe to samtools sort to write sorted SAM file
     bwa mem \
       -t ~{cpu} \
       "${ref_genome}" \
       ~{read1} \
       ~{read2} | \
-    samtools sort -@ ~{cpu} > ~{samplename}.sorted.sam
+    samtools sort \
+      -@ ~{cpu} - \
+      > ~{samplename}.sorted.sam
     
     # convert SAM to BAM that only includes aligned reads
     samtools view \
@@ -51,15 +56,21 @@ task bwa {
       -o ~{samplename}.sorted.unaligned-reads.bam \
       ~{samplename}.sorted.sam
 
+    # see here for "samtools fastq" options: https://www.htslib.org/doc/samtools-fasta.html
+    # TL;DR is that "samtools fastq -1 R1.fastq -2 R2.fastq" works with paired-end inputs and will output R1 and R2 reads to separate files due to tags in the SAM & BAM file
+
+    # AFAIK for single end alignments w/ bwa mem, the output SAM/BAM files do not have tags to differentiate between R1 and R2 reads, so the "samtools fastq -0 R1.fastq" command is used to output all reads to a single file
+
     # if read2 was provided by user, extract both read1 and read2 from aligned and unaligned BAMs
     if [[ ! -z "~{read2}" ]]; then
-      echo "Generating FASTQs for aligned and unaligned paired reads"
+      echo "Generating FASTQs for aligned reads"
       samtools fastq \
         -@ ~{cpu} \
         -F 4 \
         -1 ~{samplename}_R1.fastq.gz \
         -2 ~{samplename}_R2.fastq.gz \
         ~{samplename}.sorted.bam
+      echo "Generating FASTQs for unaligned reads"
       # note the lowercase 'f' here is imporant
       samtools fastq \
         -@ ~{cpu} \
@@ -68,23 +79,39 @@ task bwa {
         -2 ~{samplename}_unaligned_R2.fastq.gz \
         ~{samplename}.sorted.unaligned-reads.bam
     else
-      echo "Generating FASTQs for aligned and unaligned single-end reads"
+      echo "Generating FASTQs for aligned single-end reads"
       samtools fastq \
         -@ ~{cpu} \
         -F 4 \
-        -1 ~{samplename}_R1.fastq.gz \
-        ~{samplename}.sorted.bam 
+        -0 ~{samplename}_R1.fastq.gz \
+        ~{samplename}.sorted.bam
+      echo "Generating FASTQs for unaligned single-end reads" 
       # again, lowercase 'f' is important for getting all unaligned reads
       samtools fastq \
         -@ ~{cpu} \
         -f 4 \
-        -1 ~{samplename}_unaligned_R1.fastq.gz \
+        -0 ~{samplename}_unaligned_R1.fastq.gz \
         ~{samplename}.sorted.unaligned-reads.bam
     fi
 
     # index BAMs
     samtools index ~{samplename}.sorted.bam 
     samtools index ~{samplename}.sorted.unaligned-reads.bam
+
+    # count output reads to ensure we are outputting all reads, regardless if the aligned or not
+    # if read2 does exist as input, count both R1 and R2
+    if [[ ! -z "~{read2}" ]]; then
+      echo "output R1_aligned has $(zcat ~{samplename}_R1.fastq.gz | grep -c '^@') reads as input"
+      echo "output R2_aligned has $(zcat ~{samplename}_R2.fastq.gz | grep -c '^@') reads as input"
+      echo
+      echo "output R1_unaligned has $(zcat ~{samplename}_unaligned_R1.fastq.gz | grep -c '^@') reads as input"
+      echo "output R2_unaligned has $(zcat ~{samplename}_unaligned_R2.fastq.gz | grep -c '^@') reads as input"
+    # else = if read2 does not exist as input, only count R1
+    else
+      echo "output R1_aligned has $(zcat ~{samplename}_R1.fastq.gz | grep -c '^@') reads as input"
+      echo
+      echo "output R1_unaligned has $(zcat ~{samplename}_unaligned_R1.fastq.gz | grep -c '^@') reads as input"
+    fi
   >>>
   output {
     String bwa_version = read_string("BWA_VERSION")

--- a/tasks/alignment/task_bwa.wdl
+++ b/tasks/alignment/task_bwa.wdl
@@ -7,7 +7,9 @@ task bwa {
     String samplename
     File? reference_genome
     Int cpu = 6
+    Int memory = 16
     Int disk_size = 100
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan"
   }
   command <<<
     # date and version control
@@ -25,25 +27,62 @@ task bwa {
       ref_genome="/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta"  
     fi
 
-    # Map with BWA MEM
-    echo "Running bwa mem -t ~{cpu} ${ref_genome} ~{read1} ~{read2} | samtools sort | samtools view -F 4 -o ~{samplename}.sorted.bam "
+    # Map with BWA MEM; pipe to samtools sort to write sorted SAM file
     bwa mem \
-    -t ~{cpu} \
-    "${ref_genome}" \
-    ~{read1} ~{read2} |\
-    samtools sort | samtools view -F 4 -o ~{samplename}.sorted.bam
+      -t ~{cpu} \
+      "${ref_genome}" \
+      ~{read1} \
+      ~{read2} | \
+    samtools sort -@ ~{cpu} > ~{samplename}.sorted.sam
+    
+    # convert SAM to BAM that only includes aligned reads
+    samtools view \
+      -@ ~{cpu} \
+      -F 4 \
+      -b \
+      -o ~{samplename}.sorted.bam \
+      ~{samplename}.sorted.sam
 
+    # convert SAM to BAM that only includes unaligned reads
+    samtools view \
+      -@ ~{cpu} \
+      -f 4 \
+      -b \
+      -o ~{samplename}.sorted.unaligned-reads.bam \
+      ~{samplename}.sorted.sam
+
+    # if read2 was provided by user, extract both read1 and read2 from aligned and unaligned BAMs
     if [[ ! -z "~{read2}" ]]; then
-      echo "processing paired reads"
-      samtools fastq -F4 -1 ~{samplename}_R1.fastq.gz -2 ~{samplename}_R2.fastq.gz ~{samplename}.sorted.bam
+      echo "Generating FASTQs for aligned and unaligned paired reads"
+      samtools fastq \
+        -F 4 \
+        -1 ~{samplename}_R1.fastq.gz \
+        -2 ~{samplename}_R2.fastq.gz \
+        ~{samplename}.sorted.bam
+      # note the lowercase 'f' here is imporant
+      samtools fastq \
+        -f 4 \
+        -1 ~{samplename}_unaligned_R1.fastq.gz \
+        -2 ~{samplename}_unaligned_R2.fastq.gz \
+        ~{samplename}.sorted.unaligned-reads.bam
     else
-      echo "processing single-end reads"
-      samtools fastq -F4 ~{samplename}.sorted.bam | gzip > ~{samplename}_R1.fastq.gz
+      echo "Generating FASTQs for aligned and unaligned single-end reads"
+      samtools fastq \
+        -@ ~{cpu} \
+        -F 4 \
+        -1 ~{samplename}_R1.fastq.gz \
+        ~{samplename}.sorted.bam 
+      # again, lowercase 'f' is important for getting all unaligned reads
+      samtools fastq \
+        -@ ~{cpu} \
+        -f 4 \
+        -1 ~{samplename}_unaligned_R1.fastq.gz \
+        ~{samplename}.sorted.unaligned-reads.bam
     fi
 
-
     # index BAMs
-    samtools index ~{samplename}.sorted.bam
+    samtools index ~{samplename}.sorted.bam 
+    samtools index ~{samplename}.sorted.unaligned-reads.bam
   >>>
   output {
     String bwa_version = read_string("BWA_VERSION")
@@ -52,10 +91,14 @@ task bwa {
     File sorted_bai = "${samplename}.sorted.bam.bai"
     File read1_aligned = "~{samplename}_R1.fastq.gz"
     File? read2_aligned = "~{samplename}_R2.fastq.gz"
+    File read1_unaligned = "~{samplename}_unaligned_R1.fastq.gz"
+    File? read2_unaligned = "~{samplename}_unaligned_R2.fastq.gz"
+    File sorted_bam_unaligned = "~{samplename}.sorted.unaligned-reads.bam"
+    File sorted_bam_unaligned_bai = "~{samplename}.sorted.unaligned-reads.bam.bai"
   }
   runtime {
-    docker: "us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan"
-    memory: "8 GB"
+    docker: docker
+    memory: memory + " GB"
     cpu: cpu
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB" # TES

--- a/tasks/alignment/task_bwa.wdl
+++ b/tasks/alignment/task_bwa.wdl
@@ -55,12 +55,14 @@ task bwa {
     if [[ ! -z "~{read2}" ]]; then
       echo "Generating FASTQs for aligned and unaligned paired reads"
       samtools fastq \
+        -@ ~{cpu} \
         -F 4 \
         -1 ~{samplename}_R1.fastq.gz \
         -2 ~{samplename}_R2.fastq.gz \
         ~{samplename}.sorted.bam
       # note the lowercase 'f' here is imporant
       samtools fastq \
+        -@ ~{cpu} \
         -f 4 \
         -1 ~{samplename}_unaligned_R1.fastq.gz \
         -2 ~{samplename}_unaligned_R2.fastq.gz \

--- a/tasks/alignment/task_bwa.wdl
+++ b/tasks/alignment/task_bwa.wdl
@@ -132,6 +132,6 @@ task bwa {
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB" # TES
     preemptible: 0
-    #maxRetries: 3
+    maxRetries: 3
   }
 }

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -299,6 +299,10 @@ workflow theiacov_illumina_pe {
     File? read2_aligned = ivar_consensus.read2_aligned
     String aligned_bam = select_first([ivar_consensus.aligned_bam, ""])
     String aligned_bai = select_first([ivar_consensus.aligned_bai, ""])
+    File? read1_unaligned = ivar_consensus.read1_unaligned
+    File? read2_unaligned = ivar_consensus.read2_unaligned
+    File? sorted_bam_unaligned = ivar_consensus.sorted_bam_unaligned
+    File? sorted_bam_unaligned_bai = ivar_consensus.sorted_bam_unaligned_bai
     # Read Alignment - primer trimming outputs
     Float? primer_trimmed_read_percent = ivar_consensus.primer_trimmed_read_percent
     String? ivar_version_primtrim = ivar_consensus.ivar_version_primtrim

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -212,6 +212,9 @@ workflow theiacov_illumina_se {
     String? assembly_method = ivar_consensus.assembly_method_nonflu
     File? aligned_bam = ivar_consensus.aligned_bam
     File? aligned_bai = ivar_consensus.aligned_bai
+    File? read1_unaligned = ivar_consensus.read1_unaligned
+    File? sorted_bam_unaligned = ivar_consensus.sorted_bam_unaligned
+    File? sorted_bam_unaligned_bai = ivar_consensus.sorted_bam_unaligned_bai
     # Read Alignment - primer trimming outputs
     Float? primer_trimmed_read_percent = ivar_consensus.primer_trimmed_read_percent
     String? ivar_version_primtrim = ivar_consensus.ivar_version_primtrim

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -75,6 +75,10 @@ workflow ivar_consensus {
     File? read2_aligned = bwa.read2_aligned
     File aligned_bam =  select_first([primer_trim.trim_sorted_bam, bwa.sorted_bam, ""]) # set default values for select_first() to avoid workflow failures
     File aligned_bai = select_first([primer_trim.trim_sorted_bai, bwa.sorted_bai, ""])
+    File read1_unaligned = bwa.read1_unaligned
+    File? read2_unaligned = bwa.read2_unaligned
+    File sorted_bam_unaligned = bwa.sorted_bam_unaligned
+    File sorted_bam_unaligned_bai = bwa.sorted_bam_unaligned_bai
     
     # primer trimming outputs
     Float? primer_trimmed_read_percent = primer_trim.primer_trimmed_read_percent


### PR DESCRIPTION
Closes #242 

This dev branch should NOT be deleted after merging, we need to notify Alex E. and recommend switching to `main` branch for further usage before deleting it

## :hammer_and_wrench: Changes Being Made

### changes to `tasks/alignment/task_bwa.wdl`

- expose `memory` and `docker` as optional inputs
- added functionality to cope with uncompressed FASTQ files used as input
- added lots of `echo` statements throughout to help with debugging and troubleshooting (we should keep these, they will be useful in the future)
- **IMPORTANT CHANGES** 
  - lines 41-48 Altered the main `bwa` command to produce a sorted SAM file as output. Also pass in `cpus` to speed things up
  - lines 51-56 added `samtools view` command to produce a BAM that ONLY includes **aligned reads**
  - lines 59-64 added `samtools view` command to produce a BAM that ONLY includes **unaligned reads**
  - lines 74-79 Altered `samtools fastq` command to produce paired FASTQ files for **aligned reads** 
  - lines 82-87 Added `samtools fastq` command to produced paired FASTQ files for **unaligned reads**
  - lines 89-94 altered `samtools fastq` command to produce FASTQ file for **aligned reads** (single end)
  - lines 95-101 added `samtools fastq` command to produce FASTQ file for **unaligned reads** (single end)
  - lines 105-106 added commands for indexing aligned BAM and unaligned BAM
- re-enabled memory retry feature (it was commented out, likely by accident)


### Changes to `workflows/theiacov/wf_theiacov_illumina_pe.wdl` and `workflows/theiacov/wf_theiacov_illumina_se.wdl` and `workflows/utilities/wf_ivar_consensus.wdl`

- added 4 (PE) or 3 (SE) new optional outputs to both theiacov_illumina workflows:
```WDL
    File? read1_unaligned = ivar_consensus.read1_unaligned
    File? read2_unaligned = ivar_consensus.read2_unaligned
    File? sorted_bam_unaligned = ivar_consensus.sorted_bam_unaligned
    File? sorted_bam_unaligned_bai = ivar_consensus.sorted_bam_unaligned_bai
```

### Impacted Workflows/Tasks

- TheiaCov_Illumina_PE_PHB (iVar subworkflow, NOT Flu track)
- TheiaCov_Illumina_SE_PHB (iVar subworkflow, NOT Flu track)
- Freyja_FASTQ (`bwa` tasked changed, but no workflow changes) - Would be good to compare the results of the same sample analyzed via v1.3.0 vs this dev branch


## :brain: Context and Rationale

A user requested that unaligned FASTQ files (i.e. the reads that do not align to the target reference genome, example: Mpox) are output from the TheiaCov_Illumina workflows. The goal is to take these reads that did not align to the reference and perform downstream analysis on them (like Kraken for taxonomic assignment, or other purposes like attempting to assemble a genome out of those reads not aligned)

In the process of addressing this request, I also added the `unaligned_bam` and it's index which is a BAM file that only contains reads that did not align to the reference (see lines 59-64 in BWA WDL task to see where this BAM is created). Not sure how this would be used, but it doesn't hurt to output this as well.
## :clipboard: Workflow/Task Steps

### Inputs

added 2 new optional inputs to bwa task: `memory` and `docker`

### Outputs

- added 4 new optional outputs to both theiacov_illumina workflows (served up via the ivar subworkflow):
```WDL
    File? read1_unaligned = ivar_consensus.read1_unaligned
    File? read2_unaligned = ivar_consensus.read2_unaligned
    File? sorted_bam_unaligned = ivar_consensus.sorted_bam_unaligned
    File? sorted_bam_unaligned_bai = ivar_consensus.sorted_bam_unaligned_bai
```

### Impacted Outputs

Pre-existing outputs that may be impacted (this excludes the new ones)

- `sorted_bam` which is used heavily downstream in the workflow
- `read1_aligned` & `read2_aligned`. Both existed previously, but command syntax has changed slightly so good to double check these.


## :test_tube: Testing

### Data
Test data used were as follows
1. Simulated SARS-CoV-2 data. This was expected to map 100% to the reference SARS-CoV-2 genome, i.e. 0 unaligned reads.
2. Human data. This was expected not to align, but some reads aligned to the the reference SARS-CoV-2 genome.
3. A spiked dataset from 1. and 2. above. SARS-CoV-2 and some human reads expected to map.
4. Unaligned reads from 2. This was to test cases when nothing aligns to a reference, in which case unaligned reads file will be created but empty.

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->
Worked as expected
### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/Global_tree_testing/job_history/43118990-5338-4d92-b429-19158452cf78

### Scenarios for Reviewer to Test

<!--Please list any potential scenarios that the reviewer should test, such as edge-cases or data types-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [X] Include a description of what is in this pull request in this message.
- [X] The workflow/task has been tested locally and on Terra
- [X] The CI/CD has been adjusted and tests are passing
- [X] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)