### PR TITLE
TheiaCoV_ONT: prevent failure by coercing files into strings

### DIFF
--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -312,7 +312,7 @@ workflow theiacov_ont {
     String? kraken_target_org_dehosted = read_qc_trim.kraken_target_org_dehosted
     File? kraken_report_dehosted = read_qc_trim.kraken_report_dehosted
     # Read Alignment - Artic consensus outputs
-    File? assembly_fasta = select_first([consensus.consensus_seq, irma.irma_assembly_fasta, ""])
+    String assembly_fasta = select_first([consensus.consensus_seq, irma.irma_assembly_fasta, ""])
     File? aligned_bam = consensus.trim_sorted_bam
     File? aligned_bai = consensus.trim_sorted_bai
     File? medaka_vcf = consensus.medaka_pass_vcf
@@ -323,7 +323,7 @@ workflow theiacov_ont {
     String? artic_docker = consensus.artic_pipeline_docker
     String? medaka_reference = consensus.medaka_reference
     String? primer_bed_name = consensus.primer_bed_name
-    String? assembly_method = "TheiaCoV (~{version_capture.phb_version}): " + select_first([consensus.artic_pipeline_version, irma.irma_version, ""])
+    String assembly_method = "TheiaCoV (~{version_capture.phb_version}): " + select_first([consensus.artic_pipeline_version, irma.irma_version, ""])
     # Assembly QC - consensus assembly qc outputs
     File? consensus_stats = stats_n_coverage.stats
     File? consensus_flagstat = stats_n_coverage.flagstat
@@ -354,15 +354,15 @@ workflow theiacov_ont {
     String? pangolin_docker = pangolin4.pangolin_docker
     String? pangolin_versions = pangolin4.pangolin_versions
     # Nextclade outputs
-    String? nextclade_json = select_first([nextclade.nextclade_json, ""])
-    String? auspice_json = select_first([ nextclade.auspice_json, ""])
-    String? nextclade_tsv = select_first([nextclade.nextclade_tsv, ""])
-    String? nextclade_version = select_first([nextclade.nextclade_version, ""])
-    String? nextclade_docker = select_first([nextclade.nextclade_docker, ""])
-    String? nextclade_ds_tag = select_first([ha_na_nextclade_ds_tag, abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag, ""])
-    String? nextclade_aa_subs = select_first([ha_na_nextclade_aa_subs, nextclade_output_parser.nextclade_aa_subs, ""])
-    String? nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels, nextclade_output_parser.nextclade_aa_dels, ""])
-    String? nextclade_clade = select_first([nextclade_output_parser.nextclade_clade, ""])
+    String nextclade_json = select_first([nextclade.nextclade_json, ""])
+    String auspice_json = select_first([ nextclade.auspice_json, ""])
+    String nextclade_tsv = select_first([nextclade.nextclade_tsv, ""])
+    String nextclade_version = select_first([nextclade.nextclade_version, ""])
+    String nextclade_docker = select_first([nextclade.nextclade_docker, ""])
+    String nextclade_ds_tag = select_first([ha_na_nextclade_ds_tag, abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag, ""])
+    String nextclade_aa_subs = select_first([ha_na_nextclade_aa_subs, nextclade_output_parser.nextclade_aa_subs, ""])
+    String nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels, nextclade_output_parser.nextclade_aa_dels, ""])
+    String nextclade_clade = select_first([nextclade_output_parser.nextclade_clade, ""])
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
     String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # Nextclade Flu outputs - NA specific columns - tamiflu mutation


### PR DESCRIPTION
Closes #270 

## :hammer_and_wrench: Changes Being Made

To prevent workflow failure when read screening fails, this PR coerces the File `assembly_fasta` output into a String. Outputs behave the same on Terra, but workflow failure no longer will occur.

Also, some redundant `?` were removed

### Impacted Workflows/Tasks

- TheiaCoV_ONT

## :brain: Context and Rationale

`""` cannot be evaluated as a File, but a File _can_ be evaluated as a String.

## :clipboard: Workflow/Task Steps

No change

### Inputs

No change

### Outputs

No new outputs

### Impacted Outputs

`String assembly_fasta`

## :test_tube: Testing

### Locally

<!--Please show, with screenshots when possible, that your changes pass the local execution of the workflow-->

### Terra

No original failures (before change) in read screen: https://app.terra.bio/#workspaces/cdc-terra-resources/Theiagen_Wright_SC2_Sandbox/job_history/17bbd163-1949-431f-a745-b4d5c9d15193

Original failures (before change) in read screen: https://app.terra.bio/#workspaces/cdc-terra-resources/Theiagen_Wright_SC2_Sandbox/job_history/4443d283-9729-42f8-ae4b-596a13c1800d

### Scenarios for Reviewer to Test

- Samples that fail the read screen
- Samples that pass the read screen

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)