### PR TITLE
Update Gambit database files to version 1.3.0

### DIFF
--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -5,8 +5,8 @@ task gambit {
     File assembly
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/gambit:1.0.0"
-    File gambit_db_genomes = "gs://theiagen-public-files/terra/gambit_files/1.1.0/gambit-metadata-1.1-230417.gdb"
-    File gambit_db_signatures = "gs://theiagen-public-files/terra/gambit_files/1.1.0/gambit-signatures-1.1-230417.gs"
+    File gambit_db_genomes = "gs://theiagen-public-files/terra/gambit_files/1.3.0/gambit-metadata-1.3-231016.gdb"
+    File gambit_db_signatures = "gs://theiagen-public-files/terra/gambit_files/1.3.0/gambit-signatures-1.3-231016.gs"
     Int disk_size = 100
     Int memory = 16 # set default
     Int cpu = 8 # set default

--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -5,8 +5,8 @@ task gambit {
     File assembly
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/gambit:1.0.0"
-    File gambit_db_genomes = "gs://theiagen-public-files/terra/gambit_files/1.3.0/gambit-metadata-1.3-231016.gdb"
-    File gambit_db_signatures = "gs://theiagen-public-files/terra/gambit_files/1.3.0/gambit-signatures-1.3-231016.gs"
+    File gambit_db_genomes = "gs://gambit-databases-rp/1.3.0/gambit-metadata-1.3-231016.gdb"
+    File gambit_db_signatures = "gs://gambit-databases-rp/1.3.0/gambit-signatures-1.3-231016.gs"
     Int disk_size = 100
     Int memory = 16 # set default
     Int cpu = 8 # set default

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -626,7 +626,7 @@
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
-      md5sum: 08987d952c67c6ff6debf6898af15f9a
+      md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -592,7 +592,7 @@
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: 3469cf6787f279ffa81fa50f6257fcd7
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl
-      md5sum: 08987d952c67c6ff6debf6898af15f9a
+      md5sum: 4e1d4f6b8085a209f9721748a0c0fef0
     - path: miniwdl_run/wdl/tasks/taxon_id/task_kraken2.wdl
       md5sum: a1f287e6e6feaf2d7d3c74a70e3b5a28
     - path: miniwdl_run/wdl/tasks/taxon_id/task_midas.wdl


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!
Please fill in the appropriate checklist below and delete whatever is not relevant.

Documentation on how to contribute can be found at https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows

Please replace all '[ ]' with '[X]' to demonstrate completion.

Please delete all text within '<>'. 
-->
Closes #277 

## :hammer_and_wrench: Changes Being Made

Updating default gambit reference files (signatures and metadata) to v1.3.0 using a Theiagen hosted, requester-pay bucket. 

### Impacted Workflows/Tasks

- workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
- workflows/theiaprok/wf_theiaprok_fasta.wdl
- workflows/theiaprok/wf_theiaprok_illumina_se.wdl
- workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
- workflows/standalone_modules/wf_gambit_query.wdl
- workflows/theiaprok/wf_theiaprok_ont.wdl

## :brain: Context and Rationale

Sourcing from a requester-pay, us-central1 bucket will help to reduce egress fees currently incurred from the gs://theiagen-public-files/terra/gambit_files/1.1.0/* files. Also, utilizing the updated database files will help refine taxon mis-calls noted in previous GAMBIT database versions.

## :clipboard: Workflow/Task Steps

For the gambit task to function, it requires two references files as input: `gambit_db_genomes` and `gambit_db_signatures`. This PR modifies the default inputs to utilize v1.3.0 gambit files that are hosted in a requester-pay, us-central1 GCP bucket rather than the current v1.1.0 files hosted in an open, multi-region GCP bucket. 

### Inputs

The mandatory inputs to the task are `gambit_db_genomes` and `gambit_db_signatures` which have been set to `"gs://theiagen-public-files/terra/gambit_files/1.1.0/gambit-metadata-1.1-230417.gdb"` and `"gs://theiagen-public-files/terra/gambit_files/1.1.0/gambit-signatures-1.1-230417.gs"`, respectively.

### Outputs

The outputs for this task will remain the same: 
```
  output {
    File gambit_report_file = report_path
    File gambit_closest_genomes_file = closest_genomes_path
    String gambit_predicted_taxon = read_string("PREDICTED_TAXON")
    String gambit_predicted_taxon_rank = read_string("PREDICTED_TAXON_RANK") 
    String gambit_next_taxon = read_string("NEXT_TAXON")
    String gambit_next_taxon_rank = read_string("NEXT_TAXON_RANK")
    String gambit_version = read_string("GAMBIT_VERSION")
    String gambit_db_version = read_string("GAMBIT_DB_VERSION")
    String merlin_tag = read_string("MERLIN_TAG")
    String gambit_docker = docker
  }
```

### Impacted Outputs

By default, the `gambit_db_version` will be impacted. In some instances, the GAMBIT taxon predictions may also differ slightly due to the updates made from GAMBIT db v1.1.0 to v1.3.0

## :test_tube: Testing

### Terra

<!--Please show, with screenshots when possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra.bio-->

### Scenarios for Reviewer to Test

<!--Please list any potential scenarios that the reviewer should test, such as edge-cases or data types-->

## :microscope: Quality checks

<!--Please ensure that your changes respect the following quality checks.-->

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The workflow/task has been tested locally and on Terra
- [x] The CI/CD has been adjusted and tests are passing
- [x] Everything follows the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)