### PR TITLE
theiacov_fasta wf logic change for flu

### DIFF
--- a/tests/inputs/theiacov/wf_theiacov_fasta.json
+++ b/tests/inputs/theiacov/wf_theiacov_fasta.json
@@ -4,5 +4,5 @@
     "theiacov_fasta.seq_method": "clearlabs",
     "theiacov_fasta.input_assembly_method": "clearlabs",
     "theiacov_fasta.reference_genome": "tests/inputs/completely-empty-for-test.txt",
-    "theiacov_fasta.pangolin4.skip_scorpio": "true"
+    "theiacov_fasta.pangolin4.skip_scorpio": true
 }

--- a/tests/inputs/theiacov/wf_theiacov_fasta.json
+++ b/tests/inputs/theiacov/wf_theiacov_fasta.json
@@ -3,5 +3,6 @@
     "theiacov_fasta.assembly_fasta": "tests/data/theiacov/fasta/clearlabs.fasta.gz",
     "theiacov_fasta.seq_method": "clearlabs",
     "theiacov_fasta.input_assembly_method": "clearlabs",
-    "theiacov_fasta.reference_genome": "tests/inputs/completely-empty-for-test.txt"
+    "theiacov_fasta.reference_genome": "tests/inputs/completely-empty-for-test.txt",
+    "theiacov_fasta.pangolin4.skip_scorpio": "true"
 }

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -122,7 +122,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
       md5sum: 9b459df2831ab1974c9c8cef5bc5340e
     - path: miniwdl_run/call-pangolin4/command
-      md5sum: 85d3001929bde4169a11947fb38fb693
+      md5sum: 558f8f3b23b7562e7dca67dc0a647522
     - path: miniwdl_run/call-pangolin4/inputs.json
     - path: miniwdl_run/call-pangolin4/outputs.json
     - path: miniwdl_run/call-pangolin4/stderr.txt
@@ -144,7 +144,7 @@
       md5sum: 9f9c4c00a1ceb5526bed7dc4cdb3dcfd
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-pangolin4/work/fasta.pangolin_report.csv
-      md5sum: 81679363ffed582650f8512794035806
+      md5sum: c8ddc2706b30b5bfcaf32636ed5a63ec
     - path: miniwdl_run/call-vadr/command
       md5sum: f4ad614b7ad39f28a8145cec280a93c0
     - path: miniwdl_run/call-vadr/inputs.json

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -37,7 +37,8 @@ workflow theiacov_fasta {
     Int? maxlen
     String? vadr_opts
   }
-  if (!defined(flu_subtype)) {
+  # only run abricate if user sets organism = "flu" AND if flu_subtype is unknown/not set by user
+  if (!defined(flu_subtype) && organism == "flu") {
     call abricate.abricate_flu {
       input:
         assembly = assembly_fasta,

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -50,7 +50,7 @@ workflow theiacov_fasta {
     input:
       organism = organism,
       flu_segment = flu_segment,
-      flu_subtype = select_first([flu_subtype, abricate_subtype]),
+      flu_subtype = select_first([flu_subtype, abricate_subtype, ""]),
       reference_genome = reference_genome,
       genome_length = genome_length,
       nextclade_ds_reference = nextclade_dataset_reference,

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -50,7 +50,7 @@ workflow theiacov_fasta {
     input:
       organism = organism,
       flu_segment = flu_segment,
-      flu_subtype = select_first([flu_subtype, abricate_subtype, ""]),
+      flu_subtype = select_first([flu_subtype, abricate_subtype, "N/A"]),
       reference_genome = reference_genome,
       genome_length = genome_length,
       nextclade_ds_reference = nextclade_dataset_reference,


### PR DESCRIPTION
This PR closes #304 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Came across this bug during 1.3.0 release validation testing. This impacts the TheiaCoV_FASTA_PHB workflow only.

Mpox samples were accidentally run through the `abricate` task which is an Influenza-specific task. Workflow succeeded, but running this task is inappropriate for non-Flu samples.

The workflow code change is so that abricate is only run if user sets `organism` to `flu` AND `flu_subtype` is not set by user or unknown

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No **

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: N/A

Databases or database versions changed: N/A

Data processing/commands changed: N/A

File processing changed: N/A

Compute resources changed: N/A

#### ➡️ Inputs 
N/A

#### ⬅️ Outputs 
abricate task outputs will NOT be outputted for non-Flu samples (as desired)

## :test_tube: Testing 
#### Test Dataset
Using the PHB validation dataset for testing. Includes sars-cov-2, Flu, Mpox, 

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

#### Suggested Scenarios for Reviewer to Test

Test TheiaCov_FASTA on Flu and non-Flu samples (sars-cov-2, Mpox, etc.)

#### Theiagen Version Release Testing (optional)

-Will changes require functional or validation testing (checking outputs etc) during the release?
functional
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
  - No.
-Are there any output files that should be checked after running the version release testing?
  - yes, ensure abricate outputs are not filled out for non-Flu samples and that they are filled out for Flu samples where we do not know the subtype a priori


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [ ] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [ ] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [ ] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
