### PR TITLE
restore vadr_num_alerts string output to theiacov_fasta workflow

### DIFF
--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -157,6 +157,7 @@ workflow theiacov_fasta {
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
+    String? vadr_num_alerts = vadr.num_alerts
     # QC_Check Results
     String? qc_check = qc_check_phb.qc_check
     File? qc_standard = qc_check_phb.qc_standard


### PR DESCRIPTION
Adding back the `vadr_num_alerts` string output to theiacov_fasta workflow. It appears that this output was accidentally removed in PR #194 and went unnoticed until we ran the TheiaValidate workflow for the 1.3.0 release.

This PR closes #306 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: No

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
Nothing has changed, we are just re-adding an output column to the workflow

Docker/software or software versions changed: N/A

Databases or database versions changed: N/A

Data processing/commands changed: N/A

File processing changed: N/A

Compute resources changed: N/A

#### ➡️ Inputs 

N/A

#### ⬅️ Outputs 

- `String? vadr_num_alerts = vadr.num_alerts` added to theiacov_fasta WDL wf file

## :test_tube: Testing 
#### Test Dataset
 
re-tested in Terra using TheiaCov_FASTA validation dataset (includes SC2, Mpox, Flu)

#### Commandline Testing with MiniWDL or Cromwell (optional)

Testing just done in Terra, no local testing necessary

#### Terra Testing

will add link to Terra workflow later

#### Suggested Scenarios for Reviewer to Test

run anything through theiacov_fasta

#### Theiagen Version Release Testing (optional)

-Will changes require functional or validation testing (checking outputs etc) during the release? Yes, validation testing
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. No
-Are there any output files that should be checked after running the version release testing? No


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [ ] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
