### PR TITLE
theiacov_fasta_batch_PHB wf improvements

### DIFF
--- a/tasks/utilities/task_theiacov_fasta_batch.wdl
+++ b/tasks/utilities/task_theiacov_fasta_batch.wdl
@@ -19,8 +19,6 @@ task sm_theiacov_fasta_wrangling { # the sm stands for supermassive
     File? pango_lineage_report
     String? pangolin_docker
 
-    String seq_platform
-    String assembly_method
     String theiacov_fasta_analysis_date
     String theiacov_fasta_version
     
@@ -68,8 +66,6 @@ task sm_theiacov_fasta_wrangling { # the sm stands for supermassive
     upload_table = pd.DataFrame(samplenames_array, columns=["entity:~{table_name}_id"]).set_index("entity:~{table_name}_id")
 
     # fill in the standard output parameters
-    upload_table["seq_platform"] = "~{seq_platform}"
-    upload_table["assembly_method"] = "~{assembly_method}"
     upload_table["theiacov_fasta_analysis_date"] = "~{theiacov_fasta_analysis_date}"
     upload_table["theiacov_fasta_version"] = "~{theiacov_fasta_version}"
 

--- a/workflows/theiacov/wf_theiacov_fasta_batch.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta_batch.wdl
@@ -14,9 +14,6 @@ workflow theiacov_fasta_batch {
     Array[String] samplenames
     Array[File] assembly_fastas
     String organism = "sars-cov-2"
-    # sequencing values
-    String seq_method
-    String input_assembly_method
     # nextclade inputs
     String nextclade_dataset_reference = "MN908947"
     String nextclade_dataset_tag = "2023-09-21T12:00:00Z"
@@ -69,8 +66,6 @@ workflow theiacov_fasta_batch {
       nextclade_json = nextclade.nextclade_json,
       pango_lineage_report = pangolin4.pango_lineage_report,
       pangolin_docker = pangolin4.pangolin_docker,
-      seq_platform = seq_method,
-      assembly_method = input_assembly_method,
       theiacov_fasta_analysis_date = version_capture.date,
       theiacov_fasta_version = version_capture.phb_version
   }


### PR DESCRIPTION
removed required string inputs `seq_method` and `input_assembly_method` since they are not used in the workflow. They are not required.

This PR closes #320 

🗑️ This dev branch should **NOT** be deleted after merging to main (one potential PHL user)

## :brain: Aim, Context and Functionality

described in issue #320 

These changes are to ease the usage of this workflow.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes, `seq_method` and `input_assembly_method` will no longer be updated/overwritten after running this workflow**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing: **No, results should not change if identical versions of pangolin or nextclade (and their respective databases) are used between workflow runs** 

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

`seq_method` and `input_assembly_method` are no longer an input, they are removed entirely. This also means they are no longer output (i.e. those output columns are no longer updated/overwritten)

Docker/software or software versions changed: **No**

Databases or database versions changed: **No**

Data processing/commands changed: **No**

File processing changed: **Yes**

Compute resources changed: **No**

#### ➡️ Inputs 

`seq_method` and `input_assembly_method` are no longer an input, they are removed entirely.

#### ⬅️ Outputs 

`seq_method` and `input_assembly_method` are no longer output (i.e. those output columns are no longer updated/overwritten)

## :test_tube: Testing 
#### Test Dataset

I tested with a batch of ~33 SC2 genomes (Omicron and decendant lineages) downloaded from GISAID. 

#### Commandline Testing with MiniWDL or Cromwell (optional)

only tested via Terra, since it's difficult or impossible to test locally since the workflow involves updating Terra data tables

#### Terra Testing

successful workflow here: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/610e9035-24d5-40a7-b22b-70668ff4a4eb

data table is called `omicron_pango_validation`

#### Suggested Scenarios for Reviewer to Test

Would be good for the reviewer to test a large batch of genomes (300+). Should run OK. I'm just curious about how many we could run at once (1000? 10000? more??)

#### Theiagen Version Release Testing (optional)

-Will changes require functional or validation testing (checking outputs etc) during the release? **functional**
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
-Are there any output files that should be checked after running the version release testing? **Check the final output TSV used to update the Terra data table**

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
