### PR TITLE
[Augur_PHB] Update ncov repo commit and remove reference input to augur clades task

### DIFF
--- a/tasks/phylogenetic_inference/augur/task_augur_clades.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_clades.wdl
@@ -5,7 +5,7 @@ task augur_clades {
     File refined_tree
     File ancestral_nt_muts_json
     File translated_aa_muts_json
-    File reference_fasta
+   # File reference_fasta
     String build_name
 
     File clades_tsv # tsv file containing clade definitions by amino acid
@@ -18,7 +18,7 @@ task augur_clades {
       --clades "~{clades_tsv}" \
       --output-node-data "~{build_name}_clades.json"
 
-    #--reference "~{reference_fasta}" \
+    #--reference "{reference_fasta}" \
   >>>
   output {
     File clade_assignments_json = "~{build_name}_clades.json"

--- a/tasks/phylogenetic_inference/augur/task_augur_clades.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_clades.wdl
@@ -15,9 +15,10 @@ task augur_clades {
     AUGUR_RECURSION_LIMIT=10000 augur clades \
       --tree "~{refined_tree}" \
       --mutations "~{ancestral_nt_muts_json}" "~{translated_aa_muts_json}" \
-      --reference "~{reference_fasta}" \
       --clades "~{clades_tsv}" \
       --output-node-data "~{build_name}_clades.json"
+
+    #--reference "~{reference_fasta}" \
   >>>
   output {
     File clade_assignments_json = "~{build_name}_clades.json"

--- a/tasks/utilities/task_augur_utilities.wdl
+++ b/tasks/utilities/task_augur_utilities.wdl
@@ -203,7 +203,7 @@ task filter_sequences_by_length {
 
 task set_sc2_defaults { # establish sars-cov-2 default values for augur
   input {
-    String nextstrain_ncov_repo_commit = "23d1243127e8838a61b7e5c1a72bc419bf8c5a0d" # last updated on 2023-03-07
+    String nextstrain_ncov_repo_commit = "cec4fa0ecd8612e4363d40662060a5a9c712d67e" # last updated on 2024-02-01    
     Int disk_size = 50
   }
   command <<<

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -129,7 +129,6 @@ workflow augur {
               refined_tree = augur_refine.refined_tree,
               ancestral_nt_muts_json = augur_ancestral.ancestral_nt_muts_json,
               translated_aa_muts_json = augur_translate.translated_aa_muts_json,
-              reference_fasta = select_first([reference_fasta, sc2_defaults.reference_fasta, flu_defaults.reference_fasta, mpxv_defaults.reference_fasta]),
               build_name = build_name,
               clades_tsv = select_first([clades_tsv, sc2_defaults.clades_tsv, flu_defaults.clades_tsv, mpxv_defaults.clades_tsv])
           }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #234!

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: Yes

- The ncov repo commit change will cause all future *SARS-CoV-2* Augur trees to be built with updated lineages and clades as of 2024-02-01.

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: 

Databases or database versions changed:

in the `set_sc2_defaults` task, the `nextstrain_ncov_repo_commit` was updated from "23d1243127e8838a61b7e5c1a72bc419bf8c5a0d" to "cec4fa0ecd8612e4363d40662060a5a9c712d67e" which differ in about 11 months of age. 

Data processing/commands changed:

In `task_augur_clades.wdl`, the `augur_clades` task had previously used the `--references "{reference_fasta}"` input, but this was not implemented in the `augur clades` command, leading to a warning. 

File processing changed:

Compute resources changed:

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

The optional input `nextstrain_ncov_repo_commit` was updated to "cec4fa0ecd8612e4363d40662060a5a9c712d67e" and will affect all users if the input is left blank.

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

The `clades_tsv` file will now contain clades (intermediate file, not sent to Terra table), and the `auspice_input_json` file will now be able to be colored by clade.

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

We tested on 7 SARS-CoV-2 Omicron samples from different Omicron clades.

#### Command-line Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

Command-line testing did not occur.

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

[This job](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/8f7d0f43-be9b-4d71-b575-8e130bcb2bb6) demonstrates the correct output behavior from `augur clades`.

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

More SC2 samples. Additionally, flu and mpox should be tested as well.

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. 
-Are there any output files that should be checked after running the version release testing?
-->

In the release, this PR will require:
- validation testing (visual check)
- no new samples
- The `auspice_input_json` should be checked and compared with previous versions.


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
