### PR TITLE
V. cholerae O1/O139 mlst scheme selection bugfix

### DIFF
--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -635,7 +635,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: eb48db7c1ebc9325fd72f58b9de5a7ee
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 4316296ca9cc4ce5b30b377f94aaca5c
+      md5sum: 38804a4043172f09fb3a6c2e879f69c4
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -516,7 +516,7 @@
     - path: miniwdl_run/call-shovill_pe/work/out/skesa.fasta
     - path: miniwdl_run/call-shovill_pe/work/out/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/command
-      md5sum: df3b08d5ed6403b5ef3ae9b854fd3858
+      md5sum: 8674b9fb48f5b1973cd246bf605c9fb9
     - path: miniwdl_run/call-ts_mlst/inputs.json
       contains: ["assembly", "fasta", "sample", "test"]
     - path: miniwdl_run/call-ts_mlst/outputs.json
@@ -633,9 +633,9 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: e7a4488aebdabf9ea15a16538d6c835c
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 4c681a395a318f224d770e423b4c1d75
+      md5sum: eb48db7c1ebc9325fd72f58b9de5a7ee
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 90eb6ac7463058a81da77120aa45138b
+      md5sum: 4316296ca9cc4ce5b30b377f94aaca5c
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -600,7 +600,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 947b3dc02791acf5ef4d90d34892da49
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 4316296ca9cc4ce5b30b377f94aaca5c
+      md5sum: 38804a4043172f09fb3a6c2e879f69c4
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 891579890a8a46d794d0cc9dee38c29a
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -483,7 +483,7 @@
     - path: miniwdl_run/call-shovill_se/work/out/skesa.fasta
     - path: miniwdl_run/call-shovill_se/work/out/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/command
-      md5sum: df3b08d5ed6403b5ef3ae9b854fd3858
+      md5sum: 8674b9fb48f5b1973cd246bf605c9fb9
     - path: miniwdl_run/call-ts_mlst/inputs.json
       contains: ["assembly", "fasta", "sample", "test"]
     - path: miniwdl_run/call-ts_mlst/outputs.json
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: e7a4488aebdabf9ea15a16538d6c835c
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: 947b3dc02791acf5ef4d90d34892da49
+      md5sum: 985580bfae2307a4179795698b9fa1da
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 38804a4043172f09fb3a6c2e879f69c4
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,9 +598,9 @@
     - path: miniwdl_run/wdl/tasks/utilities/task_broad_terra_tools.wdl
       md5sum: e7a4488aebdabf9ea15a16538d6c835c
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: e7c45852e17b11f6e9ae69cd91d52688
+      md5sum: 947b3dc02791acf5ef4d90d34892da49
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 90eb6ac7463058a81da77120aa45138b
+      md5sum: 4316296ca9cc4ce5b30b377f94aaca5c
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 891579890a8a46d794d0cc9dee38c29a
     - path: miniwdl_run/workflow.log

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -42,6 +42,7 @@ workflow theiaprok_fasta {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
+    String? ts_mlst_scheme
   }
   call versioning.version_capture{
     input:
@@ -92,7 +93,8 @@ workflow theiaprok_fasta {
   call ts_mlst_task.ts_mlst {
     input: 
       assembly = assembly_fasta,
-      samplename = samplename
+      samplename = samplename,
+      scheme = ts_mlst_scheme
   }
   if (genome_annotation == "prokka") {
     call prokka_task.prokka {

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -42,7 +42,7 @@ workflow theiaprok_fasta {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
-    String? ts_mlst_scheme
+    String? mlst_scheme
   }
   call versioning.version_capture{
     input:
@@ -90,12 +90,6 @@ workflow theiaprok_fasta {
         organism = select_first([expected_taxon, gambit.gambit_predicted_taxon])
     }
   }
-  call ts_mlst_task.ts_mlst {
-    input: 
-      assembly = assembly_fasta,
-      samplename = samplename,
-      scheme = ts_mlst_scheme
-  }
   if (genome_annotation == "prokka") {
     call prokka_task.prokka {
       input:
@@ -121,7 +115,14 @@ workflow theiaprok_fasta {
       assembly = assembly_fasta,
       samplename = samplename,
       assembly_only = true,
-      paired_end = false
+      paired_end = false,
+      mlst_scheme = mlst_scheme
+  }
+  call ts_mlst_task.ts_mlst {
+    input: 
+      assembly = assembly_fasta,
+      samplename = samplename,
+      scheme = merlin_magic.ts_mlst_scheme
   }
   if (defined(qc_check_table)) {
     call qc_check.qc_check_phb as qc_check_task {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -229,14 +229,15 @@ workflow theiaprok_illumina_pe {
           read2 = read_QC_trim.read2_clean
       }
       # set custom variable to use as input into mlst Task for Vibrio O1 and O139 serogroups
-      if ( merlin_magic.srst2_vibrio_serogroup == "*O1*" || merlin_magic.srst2_vibrio_serogroup == "*O139*") {
+      # hardcoding to the 4 possible output strings where O1 or O139 genes are at least partially (or fully) present and identified by SRST2 task
+      if ( merlin_magic.srst2_vibrio_serogroup == "O1" || merlin_magic.srst2_vibrio_serogroup == "O139" || merlin_magic.srst2_vibrio_serogroup == "O1 (low depth/uncertain)" || merlin_magic.srst2_vibrio_serogroup == "O139 (low depth/uncertain)" ) {
           String ts_mlst_scheme_vcholerae_O1_or_O139 = "vcholerae_2"
       }
         call ts_mlst_task.ts_mlst {
           input: 
             assembly = shovill_pe.assembly_fasta,
             samplename = samplename,
-            scheme = select_first([ts_mlst_scheme_vcholerae_O1_or_O139, ts_mlst_scheme, ""])
+            scheme = select_first([ts_mlst_scheme_vcholerae_O1_or_O139, ts_mlst_scheme, "''"])
         }
       if (defined(taxon_tables)) {
         call terra_tools.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -236,7 +236,7 @@ workflow theiaprok_illumina_pe {
           input: 
             assembly = shovill_pe.assembly_fasta,
             samplename = samplename,
-            scheme = select_first([ts_mlst_scheme_vcholerae_O1_or_O139, ts_mlst_scheme])
+            scheme = select_first([ts_mlst_scheme_vcholerae_O1_or_O139, ts_mlst_scheme, ""])
         }
       if (defined(taxon_tables)) {
         call terra_tools.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -226,18 +226,14 @@ workflow theiaprok_illumina_pe {
           assembly = shovill_pe.assembly_fasta,
           samplename = samplename,
           read1 = read_QC_trim.read1_clean,
-          read2 = read_QC_trim.read2_clean
-      }
-      # set custom variable to use as input into mlst Task for Vibrio O1 and O139 serogroups
-      # hardcoding to the 4 possible output strings where O1 or O139 genes are at least partially (or fully) present and identified by SRST2 task
-      if ( merlin_magic.srst2_vibrio_serogroup == "O1" || merlin_magic.srst2_vibrio_serogroup == "O139" || merlin_magic.srst2_vibrio_serogroup == "O1 (low depth/uncertain)" || merlin_magic.srst2_vibrio_serogroup == "O139 (low depth/uncertain)" ) {
-          String ts_mlst_scheme_vcholerae_O1_or_O139 = "vcholerae_2"
+          read2 = read_QC_trim.read2_clean,
+          ts_mlst_scheme = ts_mlst_scheme
       }
         call ts_mlst_task.ts_mlst {
           input: 
             assembly = shovill_pe.assembly_fasta,
             samplename = samplename,
-            scheme = select_first([ts_mlst_scheme_vcholerae_O1_or_O139, ts_mlst_scheme, "''"])
+            scheme = merlin_magic.ts_mlst_scheme_out
         }
       if (defined(taxon_tables)) {
         call terra_tools.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -59,7 +59,7 @@ workflow theiaprok_illumina_pe {
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon  # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species    # qc check parameters
     File? qc_check_table
-    String? ts_mlst_scheme 
+    String? mlst_scheme 
   }
   call versioning.version_capture{
     input:
@@ -227,13 +227,13 @@ workflow theiaprok_illumina_pe {
           samplename = samplename,
           read1 = read_QC_trim.read1_clean,
           read2 = read_QC_trim.read2_clean,
-          ts_mlst_scheme = ts_mlst_scheme
+          mlst_scheme = mlst_scheme
       }
         call ts_mlst_task.ts_mlst {
           input: 
             assembly = shovill_pe.assembly_fasta,
             samplename = samplename,
-            scheme = merlin_magic.ts_mlst_scheme_out
+            scheme = merlin_magic.ts_mlst_scheme
         }
       if (defined(taxon_tables)) {
         call terra_tools.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -59,6 +59,7 @@ workflow theiaprok_illumina_se {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
+    String? ts_mlst_scheme
   }
   call versioning.version_capture{
     input:
@@ -162,7 +163,8 @@ workflow theiaprok_illumina_se {
       call ts_mlst_task.ts_mlst {
         input: 
           assembly = shovill_se.assembly_fasta,
-          samplename = samplename
+          samplename = samplename,
+          scheme = ts_mlst_scheme
       }
       if (genome_annotation == "prokka") {
         call prokka_task.prokka {

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -59,7 +59,7 @@ workflow theiaprok_illumina_se {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
-    String? ts_mlst_scheme
+    String? mlst_scheme
   }
   call versioning.version_capture{
     input:
@@ -160,12 +160,6 @@ workflow theiaprok_illumina_se {
             organism = select_first([expected_taxon, gambit.gambit_predicted_taxon])
         }
       }      
-      call ts_mlst_task.ts_mlst {
-        input: 
-          assembly = shovill_se.assembly_fasta,
-          samplename = samplename,
-          scheme = ts_mlst_scheme
-      }
       if (genome_annotation == "prokka") {
         call prokka_task.prokka {
           input:
@@ -215,7 +209,14 @@ workflow theiaprok_illumina_se {
           assembly = shovill_se.assembly_fasta,
           samplename = samplename,
           read1 = read_QC_trim.read1_clean,
-          paired_end = false
+          paired_end = false,
+          mlst_scheme = mlst_scheme
+      }
+      call ts_mlst_task.ts_mlst {
+        input: 
+          assembly = shovill_se.assembly_fasta,
+          samplename = samplename,
+          scheme = merlin_magic.ts_mlst_scheme
       }
       if (defined(taxon_tables)) {
         call terra_tools.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -55,7 +55,7 @@ workflow theiaprok_ont {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
-    String? ts_mlst_scheme
+    String? mlst_scheme
   }
   call versioning_task.version_capture{
     input:
@@ -155,12 +155,6 @@ workflow theiaprok_ont {
             organism = select_first([expected_taxon, gambit.gambit_predicted_taxon])
         }
       }
-      call ts_mlst_task.ts_mlst {
-        input: 
-          assembly = dragonflye.assembly_fasta,
-          samplename = samplename,
-          scheme = ts_mlst_scheme
-      }
       if (genome_annotation == "prokka") {
         call prokka_task.prokka {
           input:
@@ -209,7 +203,14 @@ workflow theiaprok_ont {
           assembly = dragonflye.assembly_fasta,
           samplename = samplename,
           read1 = read_qc_trim.read1_clean,
-          ont_data = true
+          ont_data = true,
+          mlst_scheme = mlst_scheme
+      }
+      call ts_mlst_task.ts_mlst {
+        input: 
+          assembly = dragonflye.assembly_fasta,
+          samplename = samplename,
+          scheme = merlin_magic.ts_mlst_scheme
       }
       if (defined(taxon_tables)) {
         call terra_tools_task.export_taxon_tables {

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -55,6 +55,7 @@ workflow theiaprok_ont {
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
     File? qc_check_table
+    String? ts_mlst_scheme
   }
   call versioning_task.version_capture{
     input:
@@ -157,7 +158,8 @@ workflow theiaprok_ont {
       call ts_mlst_task.ts_mlst {
         input: 
           assembly = dragonflye.assembly_fasta,
-          samplename = samplename
+          samplename = samplename,
+          scheme = ts_mlst_scheme
       }
       if (genome_annotation == "prokka") {
         call prokka_task.prokka {

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -367,9 +367,9 @@ workflow merlin_magic {
           srst2_min_edge_depth = srst2_min_edge_depth,
           srst2_gene_max_mismatch = srst2_gene_max_mismatch
       }
-    # this is nested inside of conditional check for merlin_tag so should only be available for Vibrio samples (meaning srst2 task was run)
-    if ( srst2_vibrio.srst2_vibrio_serogroup == "O1" || srst2_vibrio.srst2_vibrio_serogroup == "O139" || srst2_vibrio.srst2_vibrio_serogroup == "O1 (low depth/uncertain)" || srst2_vibrio.srst2_vibrio_serogroup == "O139 (low depth/uncertain)") {
-      String ts_mlst_scheme_vibrio = "vcholerae_2"
+      # this conditional is nested inside of conditional for merlin_tag AND !assembly_only AND !ont_data so ts_mlst_scheme_vibrio variable will only be set for Vibrio samples that are called O1 or O139 (meaning srst2 task was run)
+      if ( srst2_vibrio.srst2_vibrio_serogroup == "O1" || srst2_vibrio.srst2_vibrio_serogroup == "O139" || srst2_vibrio.srst2_vibrio_serogroup == "O1 (low depth/uncertain)" || srst2_vibrio.srst2_vibrio_serogroup == "O139 (low depth/uncertain)") {
+        String ts_mlst_scheme_vibrio = "vcholerae_2"
     }
     }
   }

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -78,7 +78,7 @@ workflow merlin_magic {
     Int? tbp_parser_coverage_threshold
     Boolean? tbp_parser_debug
     String? tbp_parser_docker_image
-    String? ts_mlst_scheme
+    String? mlst_scheme
     String? snippy_query_gene
     Int srst2_min_cov = 80
     Int srst2_max_divergence = 20
@@ -680,8 +680,8 @@ workflow merlin_magic {
     String? srst2_vibrio_toxR = srst2_vibrio.srst2_vibrio_toxR
     String? srst2_vibrio_serogroup = srst2_vibrio.srst2_vibrio_serogroup
     String? srst2_vibrio_biotype = srst2_vibrio.srst2_vibrio_biotype
-    # this output mainly for vibrio, but also for non-vibrio samples. prioritize vibrio output; but otherwise pass along user-defined input, or use 2 single quotes (trick mlst software into using auto-scheme detection feature)
-    String ts_mlst_scheme_out = select_first([ts_mlst_scheme_vibrio, ts_mlst_scheme, "''"])
+    # this output mainly for vibrio, but also for non-vibrio samples. prioritize user-defined input, then vibrio output; but otherwise use 2 single quotes (trick mlst software into using auto-scheme detection feature)
+    String ts_mlst_scheme = select_first([mlst_scheme, ts_mlst_scheme_vibrio, "''"])
     # theiaeuk
     # c auris 
     String? clade_type = cladetyper.gambit_cladetype

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -78,6 +78,7 @@ workflow merlin_magic {
     Int? tbp_parser_coverage_threshold
     Boolean? tbp_parser_debug
     String? tbp_parser_docker_image
+    String? ts_mlst_scheme
     String? snippy_query_gene
     Int srst2_min_cov = 80
     Int srst2_max_divergence = 20
@@ -366,6 +367,10 @@ workflow merlin_magic {
           srst2_min_edge_depth = srst2_min_edge_depth,
           srst2_gene_max_mismatch = srst2_gene_max_mismatch
       }
+    # this is nested inside of conditional check for merlin_tag so should only be available for Vibrio samples (meaning srst2 task was run)
+    if ( srst2_vibrio.srst2_vibrio_serogroup == "O1" || srst2_vibrio.srst2_vibrio_serogroup == "O139" || srst2_vibrio.srst2_vibrio_serogroup == "O1 (low depth/uncertain)" || srst2_vibrio.srst2_vibrio_serogroup == "O139 (low depth/uncertain)") {
+      String ts_mlst_scheme_vibrio = "vcholerae_2"
+    }
     }
   }
   
@@ -675,6 +680,8 @@ workflow merlin_magic {
     String? srst2_vibrio_toxR = srst2_vibrio.srst2_vibrio_toxR
     String? srst2_vibrio_serogroup = srst2_vibrio.srst2_vibrio_serogroup
     String? srst2_vibrio_biotype = srst2_vibrio.srst2_vibrio_biotype
+    # this output mainly for vibrio, but also for non-vibrio samples. prioritize vibrio output; but otherwise pass along user-defined input, or use 2 single quotes (trick mlst software into using auto-scheme detection feature)
+    String ts_mlst_scheme_out = select_first([ts_mlst_scheme_vibrio, ts_mlst_scheme, "''"])
     # theiaeuk
     # c auris 
     String? clade_type = cladetyper.gambit_cladetype


### PR DESCRIPTION
This PR closes #58 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Vibrio cholerae has two MLST schemes, one for O1 or O139 serogroups, and one for non-O1/non-O139 serogroups. The latter is always being used regardless of serogroup, because `mlst`'s software auto scheme detection feature seems to always choose the non-O1 & non-O139 scheme. `mlst` also has a few default schemes that are excluded by default and `vcholerae_2` scheme is one of them, so perhaps that is why `vcholerae` is default.

The `mlst` command-line tool calls these schemes as such:

- Non-O1 & Non-O139 serogroup samples : `vcholerae`
- O1 & O139 serogroup samples, `vcholerae_2`

By default, the `mlst` auto-scheme detection chooses the non-O1 & O139 scheme so this is a way of automatically forcing `mlst` to use `vcholerae_2` for samples detected as O1 or O139 via the SRST2 task.

More info on the 2 mlst schemes can be found here: https://pubmlst.org/organisms/vibrio-cholerae

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **No, but the exception is if they are analyzing V. cholerae samples that are O1 or O139 serogroups. The mlst results will change if analyzed w/ a previous version of TheiaProk wf**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No**

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: **No**

Databases or database versions changed: **No**

Data processing/commands changed: **No**

File processing changed: **No**

Compute resources changed: **No**

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

- `ts_mlst.scheme` has been exposed as an optional input for the TheiaProk_Illumina_PE workflow

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated. **No need to update docs unless we want to add a caveat/note about the auto-scheme selection for Vcholerae O1 and O139 samples**
- [x] Workflow diagrams have been updated to reflect changes. **No need to update wf diagram**
