### PR TITLE
Change relative paths to absolute paths in .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -4,232 +4,232 @@ workflows:
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Cauris_CladeTyper_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaeuk/wf_cauris_cladetyper.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Snippy_Variants_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_snippy_variants.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Snippy_Tree_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_snippy_tree.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Nullarbor_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_nullarbor.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_ClearLabs_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_clearlabs.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_ONT_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_ont.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_Illumina_PE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_illumina_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_Illumina_SE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_illumina_se.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_FASTA_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_fasta.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaCoV_FASTA_Batch_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/wf_theiacov_fasta_batch.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Mercury_Prep_N_Batch_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/submission/wf_mercury_prep_n_batch.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Terra_2_NCBI_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/submission/wf_terra_2_ncbi.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Augur_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_augur.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Augur_Prep_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_augur_prep.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Pangolin_Update_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/updates/wf_pangolin_update.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: VADR_Update_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/updates/wf_vadr_update.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: NCBI_Scrub_SE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/updates/wf_ncbi_scrub_se.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: NCBI_Scrub_PE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiacov/updates/wf_ncbi_scrub_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Freyja_FASTQ_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/freyja/wf_freyja_fastq.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Freyja_Plot_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/freyja/wf_freyja_plot.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Freyja_Dashboard_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/freyja/wf_freyja_dashboard.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Freyja_Update_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/freyja/wf_freyja_update.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: kSNP3_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_ksnp3.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: MashTree_FASTA_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_mashtree_fasta.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Core_Gene_SNP_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_core_gene_snp.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaProk_Illumina_PE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaProk_Illumina_SE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaprok/wf_theiaprok_illumina_se.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaProk_FASTA_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaprok/wf_theiaprok_fasta.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaProk_ONT_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiaprok/wf_theiaprok_ont.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Gambit_Query_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_gambit_query.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: NCBI-AMRFinderPlus_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_amrfinderplus.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Kraken2_PE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_kraken2_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Kraken2_SE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_kraken2_se.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: RASUSA_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/standalone_modules/wf_rasusa.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: BaseSpace_Fetch_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/data_import/wf_basespace_fetch.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: SRA_Fetch_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/data_import/wf_sra_fetch.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Terra_2_BQ_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/data_import/wf_terra_2_bq.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Concatenate_Column_Content_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/file_handling/wf_concatenate_column.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Transfer_Column_Content_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/file_handling/wf_transfer_column.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Zip_Column_Content_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/file_handling/wf_zip_column.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Lyve_SET_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_lyveset.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaMeta_Illumina_PE_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/theiameta/wf_theiameta_illumina_pe.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Snippy_Streamline_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_snippy_streamline.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Assembly_Fetch_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/data_import/wf_assembly_fetch.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: TheiaValidate_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/wf_theiavalidate.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Samples_to_Ref_Tree_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_nextclade_addToRefTree.wdl
@@ -237,19 +237,19 @@ workflows:
    subclass: WDL
    primaryDescriptorPath: /workflows/submission/wf_terra_2_gisaid.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Usher_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/phylogenetics/wf_usher.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: CZGenEpi_Prep_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/wf_czgenepi_prep.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json
  - name: Rename_FASTQ_PHB
    subclass: WDL
    primaryDescriptorPath: /workflows/utilities/file_handling/wf_rename_fastq_files.wdl
    testParameterFiles:
-    - empty.json
+    - /empty.json


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->



Hello,

I am a software developer at Dockstore. This PR addresses the issue in https://github.com/dockstore/dockstore/issues/5806 that was reported by @cimendes.

Prior to Dockstore's 1.15 release, relative paths were being inconsistently and unreliably processed in various parts of our system.
Therefore, in this release, we have more explicitly deprecated the use of relative file paths in our .dockstore.yml so all workflows with relative paths are now considered as invalid. This change has impacted your workflows because your test parameter file paths are relative which is invalid and prevents Dockstore from updating your workflows.

Thus, I have created this PR to change the relative file paths to absolute paths so that your workflows are considered valid again in this new release.

Thank you!
Kathy - Dockstore

