### PR TITLE
[TheiaProk] Enable plasmidfinder to be skipped 

### DIFF
--- a/tasks/utilities/data_import/task_basespace_cli.wdl
+++ b/tasks/utilities/data_import/task_basespace_cli.wdl
@@ -12,7 +12,6 @@ task fetch_bs {
     Int memory = 8
     Int cpu = 2
     Int disk_size = 100
-    Int preemptible = 1
 
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/basespace_cli:1.2.1"
   }
@@ -102,6 +101,6 @@ task fetch_bs {
     cpu: cpu
     disks: "local-disk ~{disk_size} SSD"
     disk: disk_size + " GB"
-    preemptible: preemptible
+    preemptible: 1
   }
 }

--- a/tasks/utilities/task_rasusa.wdl
+++ b/tasks/utilities/task_rasusa.wdl
@@ -3,6 +3,7 @@ version 1.0
 task rasusa {
   meta {
     description: "Randomly subsample sequencing reads to a specified coverage (https://github.com/mbhall88/rasusa)"
+    volatile: true
   }
   input {
     File read1

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -633,7 +633,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: f118a856fb096fa3ac735dc517a08f4f
+      md5sum: 847810b39e17a473313472d14c1b5d7d
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: d118f2568eefb87ffb8a25edbba96736
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: a35176ac2f894daa5496f5ae9f0c1e94
+      md5sum: 72055172cbfa5f447be9f076fd323db8
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: d118f2568eefb87ffb8a25edbba96736
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -38,6 +38,7 @@ workflow theiaprok_fasta {
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
     Boolean call_kmerfinder = false
     Boolean call_resfinder = false
+    Boolean call_plasmidfinder = true
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
@@ -108,10 +109,12 @@ workflow theiaprok_fasta {
         samplename = samplename
     }
   }
-  call plasmidfinder_task.plasmidfinder {
-    input:
-      assembly = assembly_fasta,
-      samplename = samplename
+  if (call_plasmidfinder) {
+    call plasmidfinder_task.plasmidfinder {
+      input:
+        assembly = assembly_fasta,
+        samplename = samplename
+    }
   }
   call merlin_magic_workflow.merlin_magic {
     input:
@@ -493,11 +496,11 @@ workflow theiaprok_fasta {
     File? bakta_summary = bakta.bakta_txt
     String? bakta_version = bakta.bakta_version
     # Plasmidfinder Results
-    String plasmidfinder_plasmids = plasmidfinder.plasmidfinder_plasmids
-    File plasmidfinder_results = plasmidfinder.plasmidfinder_results
-    File plasmidfinder_seqs = plasmidfinder.plasmidfinder_seqs
-    String plasmidfinder_docker = plasmidfinder.plasmidfinder_docker
-    String plasmidfinder_db_version = plasmidfinder.plasmidfinder_db_version
+    String? plasmidfinder_plasmids = plasmidfinder.plasmidfinder_plasmids
+    File? plasmidfinder_results = plasmidfinder.plasmidfinder_results
+    File? plasmidfinder_seqs = plasmidfinder.plasmidfinder_seqs
+    String? plasmidfinder_docker = plasmidfinder.plasmidfinder_docker
+    String? plasmidfinder_db_version = plasmidfinder.plasmidfinder_db_version
     # QC_Check Results
     String? qc_check = qc_check_task.qc_check
     File? qc_standard = qc_check_task.qc_standard

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -56,6 +56,7 @@ workflow theiaprok_illumina_pe {
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
     Boolean call_kmerfinder = false 
     Boolean call_resfinder = false
+    Boolean call_plasmidfinder = true
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon  # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species    # qc check parameters
     File? qc_check_table
@@ -185,10 +186,12 @@ workflow theiaprok_illumina_pe {
             samplename = samplename
         }
       }
-      call plasmidfinder_task.plasmidfinder {
-        input:
-          assembly = shovill_pe.assembly_fasta,
-          samplename = samplename
+      if (call_plasmidfinder) {
+        call plasmidfinder_task.plasmidfinder {
+          input:
+            assembly = shovill_pe.assembly_fasta,
+            samplename = samplename
+        }
       }
       if (defined(qc_check_table)) {
         call qc_check.qc_check_phb as qc_check_task {

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -55,6 +55,7 @@ workflow theiaprok_illumina_se {
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
     Boolean call_kmerfinder = false 
     Boolean call_resfinder = false
+    Boolean call_plasmidfinder = true
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
@@ -178,10 +179,12 @@ workflow theiaprok_illumina_se {
             samplename = samplename
         }
       }
-      call plasmidfinder_task.plasmidfinder {
-        input:
-          assembly = shovill_se.assembly_fasta,
-          samplename = samplename
+      if (call_plasmidfinder) {
+        call plasmidfinder_task.plasmidfinder {
+          input:
+            assembly = shovill_se.assembly_fasta,
+            samplename = samplename
+        }
       }
       if (defined(qc_check_table)) {
         call qc_check.qc_check_phb as qc_check_task {

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -51,6 +51,7 @@ workflow theiaprok_ont {
     Boolean call_ani = false # by default do not call ANI task, but user has ability to enable this task if working with enteric pathogens or supply their own high-quality reference genome
     Boolean call_kmerfinder = false
     Boolean call_resfinder = false
+    Boolean call_plasmidfinder = true
     String genome_annotation = "prokka" # options: "prokka" or "bakta"
     String? expected_taxon # allow user to provide organism (e.g. "Clostridioides_difficile") string to amrfinder. Useful when gambit does not predict the correct species
     # qc check parameters
@@ -173,10 +174,12 @@ workflow theiaprok_ont {
             samplename = samplename
         }
       }
-      call plasmidfinder_task.plasmidfinder {
-        input:
-          assembly = dragonflye.assembly_fasta,
-          samplename = samplename
+      if (call_plasmidfinder) {
+        call plasmidfinder_task.plasmidfinder {
+          input:
+            assembly = dragonflye.assembly_fasta,
+            samplename = samplename
+        }
       }
       if (defined(qc_check_table)) {
         call qc_check.qc_check_phb as qc_check_task { 


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #280, closes #370 and closes #359.

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

This PR does three things:
1. Provides a user input for users to turn off plasmidfinder
2. Hides the preemptible input parameter for BaseSpace_Fetch (no testing required except for checking the inputs of the workflow on Terra)
3. Disables call caching on RASUSA 

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: Yes (call caching off on RASUSA)

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: Yes (RASUSA is random, but we only want to test to see if call caching is actually off

- volatile: true is added to the RASUSA meta field
- the new input parameter `call_plasmidfinder` (default=`true`) is added to all TheiaProk workflows
- preemptible is now hard-coded in the BaseSpace_Fetch task to the default preemptible value of 1

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.--> No

Docker/software or software versions changed: No

Databases or database versions changed: No

Data processing/commands changed: No

File processing changed: No

Compute resources changed:
- preemptible is now hard-coded to 1 in BaseSpace_Fetch
- volatile:true turns off call caching in RASUSA

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

TheiaProk workflows now have the `call_plasmidfinder` optional workflow input. True by default, no change will be noticed by users of TheiaProk unless they set the value of that variable to false.

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

- [x] preemptible is no longer an input in BaseSpace_Fetch when compared to v1.3.0
- [x] RASUSA did not use call caching (view [initial run here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/a0714299-049d-4af3-b469-df6739ecd2ad) and [running it again to test call-cache off test here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/39e45570-2e53-4df5-8680-4a24661f6c19)
- [ ] PlasmidFinder turned on and off
  - [ ] [TheiaProk_Illumina_PE here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/9ee910fc-c02b-414c-84a4-7a40da05f988)
  - [ ] [TheiaProk_Illumina_SE here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/a82d3ff4-d345-4dbc-b897-37f2be6253a1)
  - [ ] [TheiaProk_ONT here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/d5d7fbbe-9676-4422-8c20-c505585f22a5)
  - [x] [TheiaProk_FASTA here](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Wright_PHBG_Sandbox/job_history/2f5eb14c-ee9c-47dc-90e2-1bc31200b0e4)

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

- New plasmidfinder input variable field with various set to true & false will need to be added to the validation table

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] ~Workflow diagrams have been updated to reflect changes~ NA
