### PR TITLE
update default pangolin docker image to image with pangolin-data v1.26

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -38,11 +38,11 @@ jobs:
         # For every workflow, test it with MiniWDL and Cromwell
         tag: ["${{ fromJson(needs.changes.outputs.workflows) }}"]
         engine: ["miniwdl", "cromwell"]
-        exclude:
-          - tag: "wf_theiacov_illumina_pe"
-            engine: "miniwdl"
-          - tag: "wf_theiacov_illumina_se"
-            engine: "miniwdl"
+        #exclude:
+        #  - tag: "wf_theiacov_illumina_pe"
+        #    engine: "miniwdl"
+        #  - tag: "wf_theiacov_illumina_se"
+        #    engine: "miniwdl"
     defaults:
       run:
         # Play nicely with miniconda

--- a/tests/config/pytest_filter.yml
+++ b/tests/config/pytest_filter.yml
@@ -11,6 +11,7 @@ wf_theiacov_clearlabs:
   - tasks/species_typing/betacoronavirus/task_pangolin.wdl
   - tasks/quality_control/basic_statistics/task_gene_coverage.wdl
   - tasks/task_versioning.wdl
+  - workflows/utilities/wf_organism_parameters.wdl
 
 wf_theiacov_fasta:
   - workflows/theiacov/wf_theiacov_fasta.wdl
@@ -19,6 +20,7 @@ wf_theiacov_fasta:
   - tasks/taxon_id/task_nextclade.wdl
   - tasks/species_typing/betacoronavirus/task_pangolin.wdl
   - tasks/task_versioning.wdl
+  - workflows/utilities/wf_organism_parameters.wdl
 
 wf_theiacov_illumina_pe:
   - workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -39,6 +41,7 @@ wf_theiacov_illumina_pe:
   - tasks/gene_typing/drug_resistance/task_abricate.wdl
   - tasks/quality_control/basic_statistics/task_gene_coverage.wdl
   - tasks/task_versioning.wdl
+  - workflows/utilities/wf_organism_parameters.wdl
 
 wf_theiacov_illumina_se:
   - workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -57,6 +60,7 @@ wf_theiacov_illumina_se:
   - tasks/species_typing/betacoronavirus/task_pangolin.wdl
   - tasks/quality_control/basic_statistics/task_gene_coverage.wdl
   - tasks/task_versioning.wdl
+  - workflows/utilities/wf_organism_parameters.wdl
 
 wf_theiacov_ont:
   - workflows/theiacov/wf_theiacov_ont.wdl
@@ -74,6 +78,7 @@ wf_theiacov_ont:
   - tasks/species_typing/lentivirus/task_quasitools.wdl
   - tasks/quality_control/basic_statistics/task_gene_coverage.wdl
   - tasks/task_versioning.wdl
+  - workflows/utilities/wf_organism_parameters.wdl
 
 wf_theiaprok_illumina_pe:
   - workflows/theiaprok/wf_theiaprok_illumina_pe.wdl

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -319,13 +319,13 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 59478efddde2191ead1b46b1f121bbc9
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 11c4566a2424e70dd45cf3e4bcd91651
+      md5sum: 96a8bfc71da50efd0aa7c381c65168a6
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 7cb68886c2a1b4308be17d69dcb32d9a
+      md5sum: 1d2a65adcf34aa03ed8bf67f9db67d3e
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/clearlabs.pangolin_report.csv
-      md5sum: 4e171371a605e170e59acb1d9e4b38bd
+      md5sum: 8b21a4e30011a2e435b7a0f432b8997a
     - path: miniwdl_run/call-stats_n_coverage/command
       md5sum: 51da320ddc7de2ffeb263f0ddd85ced6
     - path: miniwdl_run/call-stats_n_coverage/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -138,12 +138,12 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 71eba5c871bca955ab2a69dbd2c3c62e
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 9cc18e8dd4fd8078dafc5e83729ccc14
+      md5sum: 3c54ab4d9130868a7f28c68c4626d964
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 7cb68886c2a1b4308be17d69dcb32d9a
+      md5sum: 1d2a65adcf34aa03ed8bf67f9db67d3e
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-pangolin4/work/fasta.pangolin_report.csv
-      md5sum: b9583856dad826856fec1383588ad50e
+      md5sum: dcca9a907f727cff5c387afc14ff7cc4
     - path: miniwdl_run/call-vadr/command
       md5sum: f4ad614b7ad39f28a8145cec280a93c0
     - path: miniwdl_run/call-vadr/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -22,7 +22,7 @@
     - path: miniwdl_run/call-raw_check_reads/task.log
     # trimmomatic
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/command
-      md5sum: 0dfaeb241ed0f54c3d5d0c4c4bea0491
+      md5sum: c90581958fb9b922c1bec6bfb7559d36
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/inputs.json
       contains: ["read1", "read2", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/outputs.json
@@ -33,7 +33,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/task.log
       contains: ["wdl", "illumina_pe", "trimmomatic", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/SRR13687078.trim.stats.txt
-      md5sum: 9b28eaac90cbeba38eab41de4d95d564
+      md5sum: f7f3616ddeed21cbe619ca25e2e22697
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR13687078_R1_dehosted.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR13687078_R2_dehosted.fastq.gz
@@ -84,7 +84,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/VERSION
     # kraken2 dehosted
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/command
-      md5sum: 369cf3223137d6ecbb52b3b7d388916c
+      md5sum: 2031501aaf268d2987b6dbc3b8b32dfa
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/inputs.json
       contains: ["read1", "read2", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/outputs.json
@@ -104,7 +104,7 @@
       md5sum: 3544d9ca35d45093c03cdead46677765
     # kraken2 raw
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/command
-      md5sum: 9e5d32b2ffaa86b58a72e5ca7a2e6c20
+      md5sum: a16205bdb8cf133a112c4552e8f67f97
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/outputs.json
@@ -167,7 +167,7 @@
       contains: ["wdl", "theiacov_illumina_pe", "done"]
     # bwa
     - path: miniwdl_run/call-ivar_consensus/call-bwa/command
-      md5sum: c8b657b063274b3fed05368202a11128
+      md5sum: 162511708c7e6395c29a453f5f3f120e
     - path: miniwdl_run/call-ivar_consensus/call-bwa/inputs.json
       contains: ["read1", "read2", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-bwa/outputs.json
@@ -178,9 +178,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-bwa/task.log
       contains: ["wdl", "illumina_pe", "bwa", "done"]
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/SRR13687078.sorted.bam
-      md5sum: 3fc9f001deb173d93649c233d5b50f04
+      md5sum: 9ab89984a72a15e743ac7cc2d0916e8a
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/SRR13687078.sorted.bam.bai
-      md5sum: e1797a57e629a8f68d4809ec09529f7c
+      md5sum: 0ca8583831d082323c268ddbe37b19a6
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/_miniwdl_inputs/0/SRR13687078_1.clean.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/_miniwdl_inputs/0/SRR13687078_2.clean.fastq.gz
@@ -202,9 +202,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/PRIMER_NAME
       md5sum: 3ca99445df901950128cddd3e58d2c52
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/SRR13687078.primertrim.sorted.bam
-      md5sum: 7bcde5413038eafbdc9be356de9218ab
+      md5sum: b35a6f0c5d34dbf5b4cf0e1b86c744a4
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/SRR13687078.primertrim.sorted.bam.bai
-      md5sum: f7d5dd441a2987d7827f6e1d18d761b4
+      md5sum: 511e696afe25f8b96a84d68ec5a8af8a
     # stats n coverage primer trim
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/command
       md5sum: 260c3887be6d99b18caf6d3914c5737f
@@ -238,11 +238,11 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 9f94171eaef6d3079bbd93cd38de5d7b
+      md5sum: bc40f95c8c990dbf25a8d8408a7e0195
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json
-      contains: ["variant_call", "pipeline_date", "variant_proportion"]
+      contains: ["variant_call", "variant_proportion"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stderr.txt
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stderr.txt.offset
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stdout.txt
@@ -269,7 +269,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # consensus
     - path: miniwdl_run/call-ivar_consensus/call-consensus/command
-      md5sum: 46445e4be1f3fee443715dc222a56728
+      md5sum: ccdea44d43b85395ac64135a9fbe3e08
     - path: miniwdl_run/call-ivar_consensus/call-consensus/inputs.json
       contains: ["bamfile", "samplename", "min_depth"]
     - path: miniwdl_run/call-ivar_consensus/call-consensus/outputs.json
@@ -367,9 +367,9 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: e98d2fc28664c0622f6b490433286e32
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 9ef080806165555f383b49f1fa9df47c
+      md5sum: 96a8bfc71da50efd0aa7c381c65168a6
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: a7b44501d440ba66c62168d53108d2a1
+      md5sum: 1d2a65adcf34aa03ed8bf67f9db67d3e
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/SRR13687078.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -22,7 +22,7 @@
     - path: miniwdl_run/call-raw_check_reads/task.log
     # trimmomatic
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/command
-      md5sum: 9e7284285a7e003f7eb0f4608ebbf363
+      md5sum: 5fede8253d813dc0f99cce1acf161e93
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/outputs.json
@@ -74,7 +74,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/VERSION
     # kraken2
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/command
-      md5sum: f583f0c554f2d0facfd78f1bb9a4682e
+      md5sum: 0efd43fc9f7079a38e5b094245c97f59
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/outputs.json
@@ -120,7 +120,7 @@
       contains: ["wdl", "theiacov_illumina_se", "done"]
     # bwa
     - path: miniwdl_run/call-ivar_consensus/call-bwa/command
-      md5sum: 1c5e2670f7b91c6edf651c915943de93
+      md5sum: e61cd94e94a850627c3b2d3cdeebcd46
     - path: miniwdl_run/call-ivar_consensus/call-bwa/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-bwa/outputs.json
@@ -131,9 +131,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-bwa/task.log
       contains: ["wdl", "illumina_se", "bwa", "done"]
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/ERR6319327.sorted.bam
-      md5sum: b95dc3ef632e526a037c0743f90b6391
+      md5sum: f3c321b2400607dae1bfd5af670f1440
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/ERR6319327.sorted.bam.bai
-      md5sum: e9f53c647576bb10be44258e9272fe55
+      md5sum: 1d83092dca706321a70dd36c68807947
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # primer trim
@@ -153,9 +153,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/PRIMER_NAME
       md5sum: 3ca99445df901950128cddd3e58d2c52
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/ERR6319327.primertrim.sorted.bam
-      md5sum: c5a848053c8d9cb0a7901e708e70f783
+      md5sum: 56261e6657e54e1f3cfddd8d1f4d18cc
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/ERR6319327.primertrim.sorted.bam.bai
-      md5sum: 7498f388dcfd6e3bb65b542672bcc6cc
+      md5sum: ca4ceda7d146a8c2f0370cdbaca1091b
     # stats n coverage primer trim
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/command
       md5sum: 67cac223adcf059a9dfaa9f28ed34f68
@@ -189,11 +189,11 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 22442fa59dbd6fb6c782808ff1248d8a
+      md5sum: b19b644c97a1e267664bc334622471a4
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json
-      contains: ["variant_call", "pipeline_date", "variant_proportion"]
+      contains: ["variant_call", "variant_proportion"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stderr.txt
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stderr.txt.offset
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/stdout.txt
@@ -220,7 +220,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # consensus
     - path: miniwdl_run/call-ivar_consensus/call-consensus/command
-      md5sum: 6d53d39ecc8bf4e11c076eb076a1fa0c
+      md5sum: 043ae7ecbd31d90be3e92cdc9fd55c10
     - path: miniwdl_run/call-ivar_consensus/call-consensus/inputs.json
       contains: ["bamfile", "samplename", "min_depth"]
     - path: miniwdl_run/call-ivar_consensus/call-consensus/outputs.json
@@ -318,9 +318,9 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 0b1f8fb5b938fe71631f61234cbf7ab3
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 9ef080806165555f383b49f1fa9df47c
+      md5sum: 96a8bfc71da50efd0aa7c381c65168a6
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: a7b44501d440ba66c62168d53108d2a1
+      md5sum: 1d2a65adcf34aa03ed8bf67f9db67d3e
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -221,9 +221,9 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 35aa27af5fb90d54561ee9d45a3163d5
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 11c4566a2424e70dd45cf3e4bcd91651
+      md5sum: 96a8bfc71da50efd0aa7c381c65168a6
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 7cb68886c2a1b4308be17d69dcb32d9a
+      md5sum: 1d2a65adcf34aa03ed8bf67f9db67d3e
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/ont.pangolin_report.csv

--- a/workflows/utilities/wf_organism_parameters.wdl
+++ b/workflows/utilities/wf_organism_parameters.wdl
@@ -43,7 +43,7 @@ workflow organism_parameters {
     String sc2_nextclade_ds_tag = "2023-12-03T12:00:00Z"
     String sc2_nextclade_ref = "MN908947"
     String sc2_nextclade_ds_name = "sars-cov-2"
-    String sc2_pangolin_docker = "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.25.1"
+    String sc2_pangolin_docker = "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.26"
     Int sc2_genome_len = 29903
     Int sc2_vadr_max_length = 30000
     String sc2_vadr_options = "--noseqnamemax --glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn --out_allfasta"


### PR DESCRIPTION
This PR closes #390 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Update default docker image used for running `pangolin` across all TheiaCov workflows & Pangolin_update standalone workflow

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

**Updated the default docker image in organism_parameters subwf. tested successfully with `miniwdl`**

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No**

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
Nothing has changed other than the docker image

Docker/software or software versions changed: `us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.25.1` ➡️ us-`docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.26`. This is a copy of StaPH-B's docker image for pangolin.

Databases or database versions changed: **pangolin-data (database) upgraded to v1.26**

Data processing/commands changed: **No**

File processing changed: **No**

Compute resources changed: **No**

#### ➡️ Inputs 


**N/A**

#### ⬅️ Outputs 

**N/A**

## :test_tube: Testing 
#### Test Dataset

Tested on random sars-cov-2 pulled from gisaid

#### Commandline Testing with MiniWDL or Cromwell (optional)

theiacov_fasta local test:
```
$ miniwdl run ~/github/public_health_bioinformatics/workflows/theiacov/wf_theiacov_fasta.wdl samplename=EPI_ISL_18606234 assembly_fasta= EPI_ISL_18606234.fasta seq_method="unknown" input_assembly_method="unknown"

[most output redacted for brevity]

2024-03-26 15:45:12.570 wdl.w:theiacov_fasta done
{
  "dir": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta",
  "outputs": {
    "theiacov_fasta.abricate_flu_database": null,
    "theiacov_fasta.abricate_flu_results": null,
    "theiacov_fasta.abricate_flu_subtype": null,
    "theiacov_fasta.abricate_flu_type": null,
    "theiacov_fasta.abricate_flu_version": null,
    "theiacov_fasta.assembly_length_unambiguous": 29737,
    "theiacov_fasta.assembly_method": "unknown",
    "theiacov_fasta.auspice_json": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/auspice_json/EPI_ISL_18606234.nextclade.auspice.json",
    "theiacov_fasta.nextclade_aa_dels": "S:N211-",
    "theiacov_fasta.nextclade_aa_subs": "E:T9I,M:D3H,M:Q19E,M:A63T,M:A104V,N:P13L,N:R203K,N:G204R,N:Q229K,N:S413R,ORF1a:S135R,ORF1a:A211D,ORF1a:T842I,ORF1a:V1056L,ORF1a:G1307S,ORF1a:T1542I,ORF1a:N2526S,ORF1a:A2710T,ORF1a:L3027F,ORF1a:T3090I,ORF1a:T3255I,ORF1a:P3395H,ORF1a:V3593F,ORF1a:T4175I,ORF1b:P314L,ORF1b:R1315C,ORF1b:I1566V,ORF1b:T2163I,ORF3a:T223I,ORF6:D61L,ORF9b:P10S,S:T19I,S:R21T,S:S50L,S:V127F,S:G142D,S:F157S,S:R158G,S:I197V,S:L212I,S:V213G,S:L216F,S:H245N,S:A264D,S:I332V,S:G339H,S:K356T,S:S371F,S:S373P,S:S375F,S:T376A,S:D405N,S:R408S,S:K417N,S:N440K,S:V445H,S:G446S,S:N450D,S:L452W,S:N460K,S:S477N,S:T478K,S:N481K,S:E484K,S:F486P,S:Q498R,S:N501Y,S:Y505H,S:E554K,S:A570V,S:D614G,S:P621S,S:H655Y,S:N679K,S:P681R,S:N764K,S:D796Y,S:S939F,S:Q954H,S:N969K,S:P1143L",
    "theiacov_fasta.nextclade_clade": "23I (Omicron)",
    "theiacov_fasta.nextclade_docker": "us-docker.pkg.dev/general-theiagen/nextstrain/nextclade:2.14.0",
    "theiacov_fasta.nextclade_ds_tag": "2023-12-03T12:00:00Z",
    "theiacov_fasta.nextclade_json": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/nextclade_json/EPI_ISL_18606234.nextclade.json",
    "theiacov_fasta.nextclade_lineage": "BA.2.86.5",
    "theiacov_fasta.nextclade_qc": "good",
    "theiacov_fasta.nextclade_tsv": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/nextclade_tsv/EPI_ISL_18606234.nextclade.tsv",
    "theiacov_fasta.nextclade_version": "nextclade 2.14.0",
    "theiacov_fasta.number_Degenerate": 3,
    "theiacov_fasta.number_N": 66,
    "theiacov_fasta.number_Total": 29806,
    "theiacov_fasta.pango_lineage": "BA.2.86.5",
    "theiacov_fasta.pango_lineage_expanded": "B.1.1.529.2.86.5",
    "theiacov_fasta.pango_lineage_report": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/pango_lineage_report/EPI_ISL_18606234.pangolin_report.csv",
    "theiacov_fasta.pangolin_assignment_version": "pangolin 4.3.1; PUSHER-v1.26",
    "theiacov_fasta.pangolin_conflicts": "0.0",
    "theiacov_fasta.pangolin_docker": "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.26",
    "theiacov_fasta.pangolin_notes": "Usher placements: BA.2.86.5(1/1)",
    "theiacov_fasta.pangolin_versions": "pangolin: 4.3.1;pangolin-data: 1.26;constellations: v0.1.12;scorpio: 0.3.19;pangolin-assignment: 1.26;usher 0.6.3",
    "theiacov_fasta.percent_reference_coverage": 99.44,
    "theiacov_fasta.qc_check": null,
    "theiacov_fasta.qc_standard": null,
    "theiacov_fasta.seq_platform": "unknown",
    "theiacov_fasta.theiacov_fasta_analysis_date": "2024-02-23",
    "theiacov_fasta.theiacov_fasta_version": "PHB v1.3.0-main",
    "theiacov_fasta.vadr_alerts_list": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/vadr_alerts_list/EPI_ISL_18606234.vadr.alt.list",
    "theiacov_fasta.vadr_docker": "us-docker.pkg.dev/general-theiagen/staphb/vadr:1.5.1",
    "theiacov_fasta.vadr_fastas_zip_archive": "/home/curtis_kapsak/tests-galore/testdata/sarscov2/20240326_154444_theiacov_fasta/out/vadr_fastas_zip_archive/EPI_ISL_18606234_vadr-fasta-files.zip",
    "theiacov_fasta.vadr_num_alerts": "0"
  }
}
```

#### Terra Testing

Tested with 33 sars-cov-2 genomes from GISAID: ✅   https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/027b31a6-2fb6-4e13-8b40-3dcfc53a0a87
- **outputs look good and as expected; new docker image was used**

#### Suggested Scenarios for Reviewer to Test

Test with any sars-cov-2 sample (assembly, reads, anything will be fine)

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **No**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
