### PR TITLE
update BUSCO to v5.7.1 and small tweaks to WDL task

### DIFF
--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -633,7 +633,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: d835ff7f54e03f72d4af6375e262b726
+      md5sum: c28f17110081694ac36a7695fdebea76
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: cfb407b32bc9436a0f12e29dc2e3b5a1
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -56,7 +56,7 @@
     - path: miniwdl_run/call-amrfinderplus_task/work/test_amrfinder_virulence.tsv
       md5sum: a5cc7b0baa9e11c9a31540800d0a740c
     - path: miniwdl_run/call-busco/command
-      md5sum: 81ed6d55f143b759289e758bdde4091c
+      md5sum: 8a4de431119daee0dfc4f2605413b095
     - path: miniwdl_run/call-busco/inputs.json
     - path: miniwdl_run/call-busco/outputs.json
     - path: miniwdl_run/call-busco/stderr.txt
@@ -67,7 +67,7 @@
     - path: miniwdl_run/call-busco/work/BUSCO_RESULTS
     - path: miniwdl_run/call-busco/work/DATABASE
     - path: miniwdl_run/call-busco/work/VERSION
-      md5sum: 369fefb1c40f16c2a9c34d4903e9f1e2
+      md5sum: 3cfdda0096f0689c9829ed27bdef6b1a
     - path: miniwdl_run/call-busco/work/_miniwdl_inputs/0/test_contigs.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-busco/work/busco_downloads/file_versions.tsv
@@ -565,7 +565,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_bbduk.wdl
       md5sum: aec6ef024d6dff31723f44290f6b9cf5
     - path: miniwdl_run/wdl/tasks/quality_control/advanced_metrics/task_busco.wdl
-      md5sum: 0f8b3fbca316cb940a61b2c3cdf6ebab
+      md5sum: 1e2ccdeac9f2137d8cab70f0de452c4c
     - path: miniwdl_run/wdl/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl
       md5sum: c8e7ae1ed0fff7b14731228db80c6b30
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_fastp.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -56,7 +56,7 @@
     - path: miniwdl_run/call-amrfinderplus_task/work/test_amrfinder_virulence.tsv
       md5sum: a5cc7b0baa9e11c9a31540800d0a740c
     - path: miniwdl_run/call-busco/command
-      md5sum: 81ed6d55f143b759289e758bdde4091c
+      md5sum: 8a4de431119daee0dfc4f2605413b095
     - path: miniwdl_run/call-busco/inputs.json
     - path: miniwdl_run/call-busco/outputs.json
     - path: miniwdl_run/call-busco/stderr.txt
@@ -67,7 +67,7 @@
     - path: miniwdl_run/call-busco/work/BUSCO_RESULTS
     - path: miniwdl_run/call-busco/work/DATABASE
     - path: miniwdl_run/call-busco/work/VERSION
-      md5sum: 369fefb1c40f16c2a9c34d4903e9f1e2
+      md5sum: 3cfdda0096f0689c9829ed27bdef6b1a
     - path: miniwdl_run/call-busco/work/_miniwdl_inputs/0/test_contigs.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-busco/work/busco_downloads/file_versions.tsv
@@ -108,8 +108,6 @@
     - path: miniwdl_run/call-busco/work/busco_downloads/placement_files/supermatrix.aln.bacteria_odb10.2019-12-16.faa
     - path: miniwdl_run/call-busco/work/busco_downloads/placement_files/tree.bacteria_odb10.2019-12-16.nwk
     - path: miniwdl_run/call-busco/work/busco_downloads/placement_files/tree_metadata.bacteria_odb10.2019-12-16.txt
-    - path: miniwdl_run/call-busco/work/test/auto_lineage/run_archaea_odb10/busco_sequences/single_copy_busco_sequences/84684at2157.faa
-    - path: miniwdl_run/call-busco/work/test/auto_lineage/run_archaea_odb10/busco_sequences/single_copy_busco_sequences/84684at2157.fna
     - path: miniwdl_run/call-busco/work/test/auto_lineage/run_archaea_odb10/full_table.tsv
     - path: miniwdl_run/call-busco/work/test/auto_lineage/run_archaea_odb10/hmmer_output/101957at2157.out
     - path: miniwdl_run/call-busco/work/test/auto_lineage/run_archaea_odb10/hmmer_output/102178at2157.out
@@ -532,7 +530,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_bbduk.wdl
       md5sum: aec6ef024d6dff31723f44290f6b9cf5
     - path: miniwdl_run/wdl/tasks/quality_control/advanced_metrics/task_busco.wdl
-      md5sum: 0f8b3fbca316cb940a61b2c3cdf6ebab
+      md5sum: 1e2ccdeac9f2137d8cab70f0de452c4c
     - path: miniwdl_run/wdl/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl
       md5sum: c8e7ae1ed0fff7b14731228db80c6b30
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_fastp.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -596,7 +596,7 @@
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: ae0ad6faa3d9f355d0f1561f62fb2e98
+      md5sum: f920448f13018432be074e3ef06ea4ee
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: cfb407b32bc9436a0f12e29dc2e3b5a1
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -32,6 +32,7 @@ workflow theiaeuk_illumina_pe {
     Int trim_min_length = 75
     Int trim_quality_min_score = 20
     Int trim_window_size = 10
+    Int busco_memory = 24
     Boolean skip_screen = false 
     File? qc_check_table
     String? expected_taxon
@@ -139,7 +140,8 @@ workflow theiaeuk_illumina_pe {
         input:
           assembly = shovill_pe.assembly_fasta,
           samplename = samplename,
-          eukaryote = true
+          eukaryote = true,
+          memory = busco_memory
       }
       if (defined(qc_check_table)) {
         call qc_check.qc_check_phb as qc_check_task {

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -257,6 +257,7 @@ workflow theiaeuk_illumina_pe {
     Float? est_coverage_clean = cg_pipeline_clean.est_coverage
     # Assembly QC - busco outputs
     String? busco_version = busco.busco_version
+    String? busco_docker = busco.busco_docker
     String? busco_database = busco.busco_database
     String? busco_results = busco.busco_results
     File? busco_report = busco.busco_report

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -422,6 +422,7 @@ workflow theiaprok_fasta {
     Float quast_gc_percent = quast.gc_percent
     # Assembly QC - BUSCO outputs
     String busco_version = busco.busco_version
+    String busco_docker = busco.busco_docker
     String busco_database = busco.busco_database
     String busco_results = busco.busco_results
     File? busco_report = busco.busco_report

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -640,6 +640,7 @@ workflow theiaprok_illumina_pe {
     Float? est_coverage_clean = cg_pipeline_clean.est_coverage
     # Assembly QC - busco outputs
     String? busco_version = busco.busco_version
+    String? busco_docker = busco.busco_docker
     String? busco_database = busco.busco_database
     String? busco_results = busco.busco_results
     File? busco_report = busco.busco_report

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -588,6 +588,7 @@ workflow theiaprok_illumina_se {
     Float? est_coverage_clean = cg_pipeline_clean.est_coverage
     # Assembly QC - busco outputs
     String? busco_version = busco.busco_version
+    String? busco_docker = busco.busco_docker
     String? busco_database = busco.busco_database
     String? busco_results = busco.busco_results
     File? busco_report = busco.busco_report

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -542,6 +542,7 @@ workflow theiaprok_ont {
     Float? est_coverage_clean = nanoplot_clean.est_coverage
     # Assembly QC - busco outputs
     String? busco_version = busco.busco_version
+    String? busco_docker = busco.busco_docker
     String? busco_database = busco.busco_database
     String? busco_results = busco.busco_results
     File? busco_report = busco.busco_report


### PR DESCRIPTION
This PR closes #345 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Update BUSCO to the latest available version

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes, BUSCO task auto-downloads their database at runtime and it is periodically updated (not sure how often but last update for enterobacteriales db was 2024-01-08**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **Yes** 

Impacted workflows:

- All TheiaProk workflows (ILMN PE, ILMN SE, ONT, FASTA)
- TheiaEuk_illumina_pe_phb

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

Docker/software or software versions changed: **upgraded to use a Theiagen-hosted copy of the ezlabgva (authors) docker image `us-docker.pkg.dev/general-theiagen/ezlabgva/busco:v5.7.1_cv1`**

Databases or database versions changed: **Database changes without warning**

Data processing/commands changed: **added `-cpu` option to main `busco` command**

File processing changed: **adjustments to parsing of output files; see code for details**

Compute resources changed: **none**

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

#### ⬅️ Outputs 

**Added `String busco_docker` output to WDL task**

TODO:

- [x] add busco_docker output to all impacted workflows
- [x] theiaprok_illumina_pe
- [x] theiaprok_illumina_se
- [x] theiaprok_illumina_fasta
- [x] theiaprok_ont
- [x] theiaeuk_illumina_pe

## :test_tube: Testing 
#### Test Dataset

Will update later, but will likely test across a diverse set of bacterial species and at least one eukaryotic pathogen (candida auris?)

- ✅  TheiaProk_FASTA_PHB on diverse set of bacterial pathogens: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/95178a27-95c1-4dba-91d8-4f2413cad520
  - Results are nearly identical to previous version of busco and we can see the new busco_docker output.
  - Each sample is duplicated in this screenshot, showing previous BUSCO v5.3.2 results with the latest results. Slight discrepancies exist, likely due to slight differences in assemblies or updated BUSCO databases:

![image](https://github.com/theiagen/public_health_bioinformatics/assets/8172086/c987437c-1595-4776-937f-1bf151fb8934)


#### Commandline Testing with MiniWDL or Cromwell (optional)

Tested the WDL task changes locally:
```
2024-04-04 17:12:04.718 wdl.t:busco done
2024-04-04 17:12:04.719 miniwdl-run.CallCache call cache insert :: cache_file: "/home/curtis_kapsak/.cache/miniwdl/busco/x3vxz4e57qtwr25ajw5hutw77eakiukd/vbsofqftg2typeltmjrgqa5cvw26m27k.json"
{
  "outputs": {
    "busco.busco_report": "/home/curtis_kapsak/github/public_health_bioinformatics/20240404_170838_busco/out/busco_report/03-98DDCS_busco-summary.txt",
    "busco.busco_results": "C:99.8%[S:99.3%,D:0.5%],F:0.2%,M:0.0%,n:440",
    "busco.busco_database": "enterobacterales_odb10 (2024-01-08)",
    "busco.busco_docker": "us-docker.pkg.dev/general-theiagen/ezlabgva/busco:v5.7.1_cv1",
    "busco.busco_version": "BUSCO 5.7.1"
  },
  "dir": "/home/curtis_kapsak/github/public_health_bioinformatics/20240404_170838_busco"
}
```

Will test workflows in Terra after code has been updated

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
