### PR TITLE
add Flu NA Nextclade outputs to theiacov_illumina_pe

### DIFF
--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -443,16 +443,21 @@ workflow theiacov_illumina_pe {
     String? pangolin_versions = pangolin4.pangolin_versions
     # Nextclade outputs
     String nextclade_json = select_first([nextclade_v3.nextclade_json, ""])
+    String nextclade_json_flu_na = select_first([nextclade_flu_na.nextclade_json, ""])
     String auspice_json = select_first([ nextclade_v3.auspice_json, ""])
+    String auspice_json_flu_na = select_first([nextclade_flu_na.auspice_json, ""])
     String nextclade_tsv = select_first([nextclade_v3.nextclade_tsv, ""])
+    String nextclade_tsv_flu_na = select_first([nextclade_flu_na.nextclade_tsv, ""])
     String nextclade_version = select_first([nextclade_v3.nextclade_version, ""])
     String nextclade_docker = select_first([nextclade_v3.nextclade_docker, ""])
     String nextclade_ds_tag = select_first([ha_na_nextclade_ds_tag, set_flu_ha_nextclade_values.nextclade_dataset_tag, organism_parameters.nextclade_dataset_tag, ""])
     String nextclade_aa_subs = select_first([ha_na_nextclade_aa_subs, nextclade_output_parser.nextclade_aa_subs, ""])
     String nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels, nextclade_output_parser.nextclade_aa_dels, ""])
     String nextclade_clade = select_first([nextclade_output_parser.nextclade_clade, ""])
+    String nextclade_clade_flu_na = select_first([nextclade_output_parser_flu_na.nextclade_clade, ""])
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
     String? nextclade_qc = nextclade_output_parser.nextclade_qc
+    String? nextclade_qc_flu_na = nextclade_output_parser_flu_na.nextclade_qc
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -404,16 +404,21 @@ workflow theiacov_ont {
     String? pangolin_versions = pangolin4.pangolin_versions
     # Nextclade outputs
     String nextclade_json = select_first([nextclade_v3.nextclade_json, ""])
+    String nextclade_json_flu_na = select_first([nextclade_flu_na.nextclade_json, ""])
     String auspice_json = select_first([ nextclade_v3.auspice_json, ""])
+    String auspice_json_flu_na = select_first([nextclade_flu_na.auspice_json, ""])
     String nextclade_tsv = select_first([nextclade_v3.nextclade_tsv, ""])
+    String nextclade_tsv_flu_na = select_first([nextclade_flu_na.nextclade_tsv, ""])
     String nextclade_version = select_first([nextclade_v3.nextclade_version, ""])
     String nextclade_docker = select_first([nextclade_v3.nextclade_docker, ""])
     String nextclade_ds_tag = select_first([ha_na_nextclade_ds_tag, set_flu_ha_nextclade_values.nextclade_dataset_tag, organism_parameters.nextclade_dataset_tag, ""])
     String nextclade_aa_subs = select_first([ha_na_nextclade_aa_subs, nextclade_output_parser.nextclade_aa_subs, ""])
     String nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels, nextclade_output_parser.nextclade_aa_dels, ""])
     String nextclade_clade = select_first([nextclade_output_parser.nextclade_clade, ""])
+    String nextclade_clade_flu_na = select_first([nextclade_output_parser_flu_na.nextclade_clade, ""])
     String? nextclade_lineage = nextclade_output_parser.nextclade_lineage
     String? nextclade_qc = nextclade_output_parser.nextclade_qc
+    String? nextclade_qc_flu_na = nextclade_output_parser_flu_na.nextclade_qc
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts


### PR DESCRIPTION
This PR closes #405 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

The TheiaCoV_Illumina_PE_PHB and TheiaCoV_ONT_PHB workflows run Nextclade on the NA segment, which provides a clade for this segment, but this output is not populated back to the Terra data table unfortunately. You will have to look into the output files on the step that is specific to running nextclade on the NA segment. 

Additionally, the output files produced by nextclade (auspice_input_json, nextclade_json, nextclade_tsv) are not populated back to the Terra data table either.

And lastly, the `nextclade_qc` output string is also not populated to the Terra data table.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **No**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing: **No** 

Impacted workflows:

- TheiaCoV_Illumina_PE_PHB
- TheiaCoV_ONT_PHB

I don't believe this impacts TheiaCoV_FASTA_PHB workflow, as the user must provide either `HA` or `NA` for the optional input called `flu_segment`. TheiaCoV_FASTA_PHB is not currently set up to run both HA and NA segments through in parallel. It only runs nextclade once. So I have skipped making these changes to that workflow because that will be a much more involved change that requires extensive dev and testing.

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

Docker/software or software versions changed: **N/A**

Databases or database versions changed: **N/A**

Data processing/commands changed: **N/A**

File processing changed: **N/A**

Compute resources changed: **N/A**

#### ➡️ Inputs 

**N/A**

#### ⬅️ Outputs 

Added 5 new outputs to the TheiaCoV_Illumina_PE_PHB and TheiaCoV_ONT_PHB workflows:

- `String nextclade_json_flu_na = select_first([nextclade_flu_na.nextclade_json, ""])`
- `String auspice_json_flu_na = select_first([nextclade_flu_na.auspice_json, ""])`
- `String nextclade_tsv_flu_na = select_first([nextclade_flu_na.nextclade_tsv, ""])`
- `String nextclade_clade_flu_na = select_first([nextclade_output_parser_flu_na.nextclade_clade, ""])`
- `String? nextclade_qc_flu_na = nextclade_output_parser_flu_na.nextclade_qc`

## :test_tube: Testing 
#### Test Dataset

I used the validation sets for ILMN PE and ONT workflows. I added 2 new H1N1 ONT datasets since the 5 we have currently available are not the best.

#### Commandline Testing with MiniWDL or Cromwell (optional)

Skipped testing locally except for TheiaCoV_ONT, which was successful (log not shown)

#### Terra Testing

See below comments for links and screenshots

#### Suggested Scenarios for Reviewer to Test

Test the 2 impacted workflows with Flu samples

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **validation**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **I used 2 H1N1 ONT samples from this publication: https://link.springer.com/article/10.1186/s12879-020-05367-y . They have been added to the correct bucket and Terra data table TSV is shared via slack. We can update the PHB_Validation_TEMPLATE workspace data table during validation efforts**
- Are there any output files that should be checked after running the version release testing? **nextclade output TSV, nextclade output JSON, and auspice_input_json**

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
