### PR TITLE
update to latest nextclade_dataset release for SC2 `2024-04-15--15-08-22Z`

### DIFF
--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -236,7 +236,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
       md5sum: 4dff84d2d6ada820e0e3a8bc6798d402
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: 9f99ba19333ff907af307611fbb73e21
+      md5sum: dda3aab1fe21777e3478411d165aee90
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -37,7 +37,7 @@
       md5sum: 6808ca805661622ad65ae014a4b2a094
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: 2cd5aabef6c3aaa89a503e59a3b6b36c
+      md5sum: f86098bed0ac60b6f9dfa107d10d891f
     - path: miniwdl_run/call-nextclade_v3/inputs.json
     - path: miniwdl_run/call-nextclade_v3/outputs.json
     - path: miniwdl_run/call-nextclade_v3/stderr.txt
@@ -50,22 +50,22 @@
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.auspice.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.tsv
-      md5sum: 3aeae954ba64b8ad7db55e08f9c7131c
+      md5sum: a54041ca32d454f226191595518687f5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
       md5sum: bf487271d506418ea23fe30fc033e44d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
-      md5sum: 50ca5404982b62cbdf077c5d16543e6f
+      md5sum: 7415cb5b9edba7602c0d6a14e34eb305
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
       md5sum: 4dff84d2d6ada820e0e3a8bc6798d402
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: 9f99ba19333ff907af307611fbb73e21
+      md5sum: dda3aab1fe21777e3478411d165aee90
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
       md5sum: c2a4d6cbb837dce22d81f9c36dd0629e
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
-      md5sum: ae2f621cbd025d28389282ed5403fedc
+      md5sum: fd0ee9f7e312ad0c7e173e51141daff5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.E.fasta
       md5sum: dc43b1e98245a25c142aec52b29a07df
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.M.fasta
@@ -111,7 +111,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.fasta.gz.nextclade.tsv
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
-      md5sum: 3aeae954ba64b8ad7db55e08f9c7131c
+      md5sum: a54041ca32d454f226191595518687f5
     - path: miniwdl_run/call-pangolin4/command
       md5sum: b9c36681b77c5e007bf7e890265d70eb
     - path: miniwdl_run/call-pangolin4/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -22,7 +22,7 @@
     - path: miniwdl_run/call-raw_check_reads/task.log
     # trimmomatic
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/command
-      md5sum: c90581958fb9b922c1bec6bfb7559d36
+      md5sum: fcc0e853c3719e41f3d169c291dc3927
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/inputs.json
       contains: ["read1", "read2", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/outputs.json
@@ -374,7 +374,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: 2c430469c2ae6ef311ccd1dd11e6dbe5
+      md5sum: 915fc8002e078606d55dac2ee94ee2a1
     - path: miniwdl_run/call-nextclade_v3/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_v3/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -325,7 +325,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: 9c7d2beb32ea16dc9e893908285fded5
+      md5sum: 8177062fb9e79be3cd69836bc03262d1
     - path: miniwdl_run/call-nextclade_v3/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_v3/outputs.json
@@ -374,7 +374,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: 9f99ba19333ff907af307611fbb73e21
+      md5sum: dda3aab1fe21777e3478411d165aee90
     - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade output parsing

--- a/workflows/utilities/wf_organism_parameters.wdl
+++ b/workflows/utilities/wf_organism_parameters.wdl
@@ -40,7 +40,7 @@ workflow organism_parameters {
     String sc2_org_name = "sars-cov-2"
     String sc2_reference_genome = "gs://theiagen-public-files-rp/terra/augur-sars-cov-2-references/MN908947.fasta"
     String sc2_gene_locations_bed = "gs://theiagen-public-files-rp/terra/sars-cov-2-files/sc2_gene_locations.bed"
-    String sc2_nextclade_ds_tag = "2024-02-16--04-00-32Z"
+    String sc2_nextclade_ds_tag = "2024-04-15--15-08-22Z"
     String sc2_nextclade_ds_name = "nextstrain/sars-cov-2/wuhan-hu-1/orfs"
     String sc2_pangolin_docker = "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.26"
     Int sc2_genome_len = 29903


### PR DESCRIPTION
~~Will update this PR message later.~~

~~This PR closes #<Issue number>.~~

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Update to latest nextclade_dataset tag that was released for SARS-CoV-2 today: https://github.com/nextstrain/nextclade_data/releases/tag/2024-04-15--15-08-22Z


## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

This will impact all workflows that run nextclade on sars-cov-2 samples (so all TheiaCoV workflows)

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing: **No** 


## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

Docker/software or software versions changed: **N/A**

Databases or database versions changed: `String sc2_nextclade_ds_tag = "2024-02-16--04-00-32Z"` updated to ➡️ `String sc2_nextclade_ds_tag = "2024-04-15--15-08-22Z"`

Data processing/commands changed: **N/A**

File processing changed: **N/A**

Compute resources changed: **N/A**

#### ➡️ Inputs 

**N/A**

#### ⬅️ Outputs 

Will impact results of nextclade as far as the nextclade_clade and nextclade_pango_lineage outputs go since there are newer pango lineages and nextclade clades included with the update:

- Nextstrain clades 24A (JN.1) and 24B (JN.1.11.1) are now included.
- All 83 Pango lineages designated between 2024-02-13 and 2024-04-12 are now included. full list here: https://github.com/nextstrain/nextclade_data/releases/tag/2024-04-15--15-08-22Z

## :test_tube: Testing 
#### Test Dataset

Early Omicron sars-cov-2 samples pulled from GISAID

#### Commandline Testing with MiniWDL or Cromwell (optional)

did not test locally.

#### Terra Testing

sars-cov-2 samples from GISAID through theiacov_fasta: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/404343fc-2f76-4502-96ae-84f62ee96a9e


#### Suggested Scenarios for Reviewer to Test

sars-cov-2 samples run through the nextclade v3 task (can be any workflow [FASTA, ILMN_PE, ILMN_SE, etc.] that uses organism_parameters workflow to set the nextclade dataset tag for sars-cov-2)

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **functional**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
