### PR TITLE
pangolin_update wf bug fix and hiding one input param related to Flu and organism_parameters subwf

### DIFF
--- a/workflows/theiacov/updates/wf_pangolin_update.wdl
+++ b/workflows/theiacov/updates/wf_pangolin_update.wdl
@@ -26,12 +26,12 @@ workflow pangolin_update {
       reference_gff_file = "gs://theiagen-public-files/terra/theiacov-files/empty.gff3",
       reference_genome = "gs://theiagen-public-files/terra/theiacov-files/empty.fasta",
       genome_length_input = 0,
-      nextclade_dataset_reference_input = "",
       nextclade_dataset_tag_input = "",
       nextclade_dataset_name_input = "",     
       vadr_max_length = 0,
       vadr_options = "",
       primer_bed_file = "gs://theiagen-public-files/terra/theiacov-files/empty.bed",
+      gene_locations_bed_file = "gs://theiagen-public-files/terra/theiacov-files/empty.bed",
       kraken_target_organism_input = "",
       hiv_primer_version = ""
   }

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -184,11 +184,12 @@ workflow theiacov_illumina_pe {
               reference_genome = reference_genome,
               genome_length_input = genome_length,
               nextclade_dataset_tag_input = nextclade_dataset_tag,
-              nextclade_dataset_name_input = nextclade_dataset_name,     
+              nextclade_dataset_name_input = nextclade_dataset_name,
               vadr_max_length = vadr_max_length,
               vadr_options = vadr_options,
               vadr_mem = vadr_memory,
               primer_bed_file = primer_bed,
+              gene_locations_bed_file = reference_gene_locations_bed,
               pangolin_docker_image = pangolin_docker_image,
               kraken_target_organism_input = target_organism,
               hiv_primer_version = "N/A"
@@ -207,6 +208,7 @@ workflow theiacov_illumina_pe {
               vadr_max_length = vadr_max_length,
               vadr_options = vadr_options,
               primer_bed_file = primer_bed,
+              gene_locations_bed_file = reference_gene_locations_bed,
               pangolin_docker_image = pangolin_docker_image,
               kraken_target_organism_input = target_organism,
               hiv_primer_version = "N/A"

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -163,10 +163,11 @@ workflow theiacov_ont {
               reference_genome = reference_genome,
               genome_length_input = genome_length,
               nextclade_dataset_tag_input = nextclade_dataset_tag,
-              nextclade_dataset_name_input = nextclade_dataset_name,     
+              nextclade_dataset_name_input = nextclade_dataset_name,
               vadr_max_length = vadr_max_length,
               vadr_options = vadr_options,
               primer_bed_file = primer_bed,
+              gene_locations_bed_file = reference_gene_locations_bed,
               pangolin_docker_image = pangolin_docker_image,
               kraken_target_organism_input = target_organism,
               hiv_primer_version = "N/A"
@@ -184,6 +185,7 @@ workflow theiacov_ont {
               vadr_max_length = vadr_max_length,
               vadr_options = vadr_options,
               primer_bed_file = primer_bed,
+              gene_locations_bed_file = reference_gene_locations_bed,
               pangolin_docker_image = pangolin_docker_image,
               kraken_target_organism_input = target_organism,
               hiv_primer_version = "N/A"


### PR DESCRIPTION
This PR closes #<Issue number>.

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

1. Pangolin_Update workflow: We missed deleting the `nextclade_dataset_reference_input` from org param call block when updating to nextclade V3 in #375 . This caused an error in Terra since the workflow was non-functional and did not pass `miniwdl check` or `womtools validate`

2. Additionally, for theiacov_ONT and TheiaCoV_Illumina_PE workflows: added `gene_locations_bed_file` to org param call blocks to hide optional input from user. This input should be hidden from the user in Terra because it will not be used even if a File is provided by the user.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **No**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No** 

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

**Nothing has changed, these are just workflow level Input changes**

Docker/software or software versions changed: **No**

Databases or database versions changed: **No**

Data processing/commands changed: **No**

File processing changed: **No**

Compute resources changed: **No**

#### ➡️ Inputs 

1. for theiacov_ONT and TheiaCoV_Illumina_PE workflows: added `gene_locations_bed_file` to org param call blocks to hide optional input from user
2. `nextclade_dataset_reference_input` from org param call block for Pangolin_Update workflow

#### ⬅️ Outputs 

**N/A**

## :test_tube: Testing 
#### Test Dataset

Pangolin_Update test: 4 sars-cov-2 samples

TheiaCoV_Illumina_PE and ONT: Not sure? Perhaps test with Flu samples through both?

#### Commandline Testing with MiniWDL or Cromwell (optional)

**N/A**

#### Terra Testing

1. Pangolin_Update test: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/8ef17805-b8d8-4094-9018-401cf7b53e7e ✅ 

workflow ran successfully:
![image](https://github.com/theiagen/public_health_bioinformatics/assets/8172086/b1ab22a7-0b18-4548-aa62-b7983a0e4aa4)


3. TheiaCoV_Illumina_PE: https://app.terra.bio/#workspaces/theiagen-validations/PHB_Validation_nextcladeV3testing/job_history/521e50b0-db79-4396-b401-6a350def0a0b ~~⚠️  Just need to check that the workflows ran successfully~~ Workflows ran successfully ✅ 
5. TheiaCoV_ONT: https://app.terra.bio/#workspaces/theiagen-validations/PHB_Validation_nextcladeV3testing/job_history/723f8545-f8df-4eb8-9166-c829bfcc19fd ~~⚠️ Just need to check that the workflows ran successfully~~ Workflows ran successfully ✅ 

For both of these workflows ⬆️ , the `gene_locations_bed_file` input has been hidden from the user, as expected:
![image](https://github.com/theiagen/public_health_bioinformatics/assets/8172086/65e69ab7-384f-4f8b-93c2-a9f444ff5f9e)


#### Suggested Scenarios for Reviewer to Test

For pangolin_update, any sars-cov-2 samples that have been previously run through Pangolin (via TheiaCoV workflows)

Likely test Flu samples through ILMN PE and ONT workflows

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **functional**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [ ] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
