### PR TITLE
update default midas_db location to requester pays bucket

### DIFF
--- a/tasks/taxon_id/contamination/task_midas.wdl
+++ b/tasks/taxon_id/contamination/task_midas.wdl
@@ -4,7 +4,7 @@ task midas {
   input {
     File read1
     File? read2
-    File midas_db = "gs://theiagen-public-files-rp/terra/theiaprok-files/midas/midas_db_v1.2.tar.gz"
+    File midas_db = "gs://theiagen-large-public-files-rp/terra/theiaprok-files/midas/midas_db_v1.2.tar.gz"
     Int disk_size = 100
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/fhcrc-microbiome/midas:v1.3.2--6"

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -629,7 +629,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_kraken2.wdl
       md5sum: 4cfdd99bcc2015237a4a07d621576e60
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
-      md5sum: c6f3b8b3e3894208f7b247709944c9bc
+      md5sum: c83147d66fdf4ae14214c0a7683452e0
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -592,7 +592,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_kraken2.wdl
       md5sum: 4cfdd99bcc2015237a4a07d621576e60
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
-      md5sum: c6f3b8b3e3894208f7b247709944c9bc
+      md5sum: c83147d66fdf4ae14214c0a7683452e0
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
       md5sum: ea141ba65f2948ae2abed7ca791e872b
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl


### PR DESCRIPTION
This PR closes #447 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

Changed default `midas_db` (required for running Midas) to a requester-pays bucket location to save on costs. The user's GCP account/GCP project will assume the cost of using this database when running TheiaProk workflows

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **No**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing : **No** 

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

**Nothing has changed except the location of the midas_db. It's the same db as before**

Docker/software or software versions changed: **No**

Databases or database versions changed: **No**

Data processing/commands changed: **No**

File processing changed: **No**

Compute resources changed: **No**

#### ➡️ Inputs 

`gs://theiagen-public-files-rp/terra/theiaprok-files/midas/midas_db_v1.2.tar.gz` moved 

to

`gs://theiagen-large-public-files-rp/terra/theiaprok-files/midas/midas_db_v1.2.tar.gz`


#### ⬅️ Outputs 

N/A

## :test_tube: Testing 
#### Test Dataset

Tested on one bacterial sample

#### Commandline Testing with MiniWDL or Cromwell (optional)

only tested in Terra

#### Terra Testing

- [one bacterial sample through theiaprok_illumina_PE with call caching off](https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/2f4f55ce-f122-422e-8240-0611964d039c)
  - This workspace ^ is located in us-central1 (Iowa), which is the same region as the requester pays bucket
  - ✅ MIDAS ran as expected with new bucket location

- [same bacterial sample through theiaprok_illumina_PE with call caching off, but this time in a workspace with a us-multi-region location](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/dataAnalysis_SARS-CoV-2_County_Labs_Master/job_history/d9e85cee-6e3c-4b41-9ce0-b636f3f2e6ba)
  - ✅ MIDAS ran as expected with new bucket location



#### Suggested Scenarios for Reviewer to Test

Any TheiaProk workflow with MIDAS turned on. Might be good to note which GCP region the Terra workspace is located in, just to ensure that Terra/Cromwell is able to download the midas_db from the new bucket location.

#### Theiagen Version Release Testing (optional)

No

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
