### PR TITLE
[New workflow - internal] Gambitcore for assembly quality assessment with GAMBIT

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -268,3 +268,8 @@ workflows:
    primaryDescriptorPath: /workflows/utilities/file_handling/wf_rename_fastq_files.wdl
    testParameterFiles:
     - /tests/inputs/empty.json
+ - name: Gambit_Core_PHB
+   subclass: WDL
+   primaryDescriptorPath: /workflows/standalone_modules/wf_gambitcore.wdl
+   testParameterFiles:
+    - /tests/inputs/empty.json

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -42,15 +42,15 @@ task gambitcore {
 
   >>>
   output {
-    File gambitcore_check_report_file = "~{samplename}_gambitcore_report.tsv"
+    File gambitcore_report_file = "~{samplename}_gambitcore_report.tsv"
     String gambitcore_species = read_string("SPECIES")
     String gambitcore_completeness = read_string("COMPLETNESS")
     String gambitcore_kmers_ratio = read_string("ASSEMBLY_SPECIES_CORE_KMERS")
     String gambitcore_closest_accession = read_string("CLOSEST_ACCESSION")
-    String gambitcore_closest_distance = read_string("CLOSEST_DISTANCE")
-    String gambitcore_assembly_kmers = read_string("ASSEMBLY_KMERS")
-    String gambitcore_species_kmers = read_string("SPECIES_KMERS")
-    String gambitcore_species_std_kmers = read_string("SPECIES_STD_KMERS")
+    Float gambitcore_closest_distance = read_string("CLOSEST_DISTANCE")
+    Int gambitcore_assembly_kmers = read_string("ASSEMBLY_KMERS")
+    Int gambitcore_species_kmers = read_string("SPECIES_KMERS")
+    Int gambitcore_species_std_kmers = read_string("SPECIES_STD_KMERS")
     String gambitcore_assembly_qc = read_string("ASSEMBLY_QC")
     String gambitcore_db_version = read_string("GAMBIT_DB_VERSION")
     String gambitcore_docker = docker

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -15,6 +15,8 @@ task gambit_core_check {
     # capture date
     date | tee DATE
     
+    # copy database to a findable location within the execution directory
+    # also, capture the version of the database used
     gambit_db_version="$(basename -- '~{gambit_db_genomes}'); $(basename -- '~{gambit_db_signatures}')"
     gambit_db_dir="${PWD}/gambit_database"
     mkdir ${gambit_db_dir}
@@ -23,11 +25,25 @@ task gambit_core_check {
 
     echo ${gambit_db_version} | tee GAMBIT_DB_VERSION
     
+    # run gambit core check on the assembly
     echo "Running gambit core check with: gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly}"
-    gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly} | tee ~{samplename}_gambit_core_report.txt
+    gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly} | tee ~{samplename}_gambit_core_report.tsv
+
+    # parse output file
+    cat ~{samplename}_gambit_core_report.tsv | cut -f 2 | tail -n 1 | tee SPECIES
+    cat ~{samplename}_gambit_core_report.tsv | cut -f 3 | tail -n 1 | tee COMPLETNESS
+    cat ~{samplename}_gambit_core_report.tsv | cut -f 4 | tail -n 1 | tee CORE_KMERS
+    cat ~{samplename}_gambit_core_report.tsv | cut -f 5 | tail -n 1 | tee CLOSEST_ACCESSION
+    cat ~{samplename}_gambit_core_report.tsv | cut -f 6 | tail -n 1 | tee CLOSEST_DISTANCE
+
   >>>
   output {
-    File gambit_core_check_report_file = "~{samplename}_gambit_core_report.txt"
+    File gambit_core_check_report_file = "~{samplename}_gambit_core_report.tsv"
+    String gambit_core_check_species = read_string("SPECIES")
+    String gambit_core_check_completeness = read_string("COMPLETNESS")
+    String gambit_core_check_core_kmers = read_string("CORE_KMERS")
+    String gambit_core_check_closest_accession = read_string("CLOSEST_ACCESSION")
+    String gambit_core_check_closest_distance = read_string("CLOSEST_DISTANCE")
     String gambit_core_check_db_version = read_string("GAMBIT_DB_VERSION")
     String gambit_core_check_docker = docker
   }

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -45,7 +45,7 @@ task gambitcore {
     File gambitcore_check_report_file = "~{samplename}_gambitcore_report.tsv"
     String gambitcore_species = read_string("SPECIES")
     String gambitcore_completeness = read_string("COMPLETNESS")
-    String gambitcore_assembly_and_species_core_kmers = read_string("ASSEMBLY_SPECIES_CORE_KMERS")
+    String gambitcore_kmers_ratio = read_string("ASSEMBLY_SPECIES_CORE_KMERS")
     String gambitcore_closest_accession = read_string("CLOSEST_ACCESSION")
     String gambitcore_closest_distance = read_string("CLOSEST_DISTANCE")
     String gambitcore_assembly_kmers = read_string("ASSEMBLY_KMERS")

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -31,7 +31,7 @@ task gambitcore {
 
     # parse output file
     cat ~{samplename}_gambitcore_report.tsv | cut -f 2 | tail -n 1 | tee SPECIES
-    cat ~{samplename}_gambitcore_report.tsv | cut -f 3 | tail -n 1 | tee COMPLETNESS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 3 | tail -n 1 | tee COMPLETENESS
     cat ~{samplename}_gambitcore_report.tsv | cut -f 4 | tail -n 1 | tee ASSEMBLY_SPECIES_CORE_KMERS
     cat ~{samplename}_gambitcore_report.tsv | cut -f 5 | tail -n 1 | tee CLOSEST_ACCESSION
     cat ~{samplename}_gambitcore_report.tsv | cut -f 6 | tail -n 1 | tee CLOSEST_DISTANCE
@@ -44,7 +44,7 @@ task gambitcore {
   output {
     File gambitcore_report_file = "~{samplename}_gambitcore_report.tsv"
     String gambitcore_species = read_string("SPECIES")
-    String gambitcore_completeness = read_string("COMPLETNESS")
+    String gambitcore_completeness = read_string("COMPLETENESS")
     String gambitcore_kmers_ratio = read_string("ASSEMBLY_SPECIES_CORE_KMERS")
     String gambitcore_closest_accession = read_string("CLOSEST_ACCESSION")
     Float gambitcore_closest_distance = read_string("CLOSEST_DISTANCE")

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
-task gambit_core_check {
+task gambitcore {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/internal/gambittools:1.0.0"
+    String docker = "us-docker.pkg.dev/general-theiagen/internal/gambitcore:0.0.1"
     File gambit_db_genomes = "gs://gambit-databases-rp/2.0.0/gambit-metadata-2.0.0-20240415.gdb"
     File gambit_db_signatures = "gs://gambit-databases-rp/2.0.0/gambit-signatures-2.0.0-20240415.gs"
     Int disk_size = 100
@@ -26,26 +26,34 @@ task gambit_core_check {
     echo ${gambit_db_version} | tee GAMBIT_DB_VERSION
     
     # run gambit core check on the assembly
-    echo "Running gambit core check with: gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly}"
-    gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly} | tee ~{samplename}_gambit_core_report.tsv
+    echo "Running gambitcore with: gambitcore ${gambit_db_dir} ~{assembly}"
+    gambitcore ${gambit_db_dir} ~{assembly} | tee ~{samplename}_gambitcore_report.tsv
 
     # parse output file
-    cat ~{samplename}_gambit_core_report.tsv | cut -f 2 | tail -n 1 | tee SPECIES
-    cat ~{samplename}_gambit_core_report.tsv | cut -f 3 | tail -n 1 | tee COMPLETNESS
-    cat ~{samplename}_gambit_core_report.tsv | cut -f 4 | tail -n 1 | tee CORE_KMERS
-    cat ~{samplename}_gambit_core_report.tsv | cut -f 5 | tail -n 1 | tee CLOSEST_ACCESSION
-    cat ~{samplename}_gambit_core_report.tsv | cut -f 6 | tail -n 1 | tee CLOSEST_DISTANCE
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 2 | tail -n 1 | tee SPECIES
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 3 | tail -n 1 | tee COMPLETNESS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 4 | tail -n 1 | tee ASSEMBLY_SPECIES_CORE_KMERS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 5 | tail -n 1 | tee CLOSEST_ACCESSION
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 6 | tail -n 1 | tee CLOSEST_DISTANCE
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 7 | tail -n 1 | tee ASSEMBLY_KMERS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 8 | tail -n 1 | tee SPECIES_KMERS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 9 | tail -n 1 | tee SPECIES_STD_KMERS
+    cat ~{samplename}_gambitcore_report.tsv | cut -f 10 | tail -n 1 | tee ASSEMBLY_QC
 
   >>>
   output {
-    File gambit_core_check_report_file = "~{samplename}_gambit_core_report.tsv"
-    String gambit_core_check_species = read_string("SPECIES")
-    String gambit_core_check_completeness = read_string("COMPLETNESS")
-    String gambit_core_check_core_kmers = read_string("CORE_KMERS")
-    String gambit_core_check_closest_accession = read_string("CLOSEST_ACCESSION")
-    String gambit_core_check_closest_distance = read_string("CLOSEST_DISTANCE")
-    String gambit_core_check_db_version = read_string("GAMBIT_DB_VERSION")
-    String gambit_core_check_docker = docker
+    File gambitcore_check_report_file = "~{samplename}_gambitcore_report.tsv"
+    String gambitcore_species = read_string("SPECIES")
+    String gambitcore_completeness = read_string("COMPLETNESS")
+    String gambitcore_assembly_and_species_core_kmers = read_string("ASSEMBLY_SPECIES_CORE_KMERS")
+    String gambitcore_closest_accession = read_string("CLOSEST_ACCESSION")
+    String gambitcore_closest_distance = read_string("CLOSEST_DISTANCE")
+    String gambitcore_assembly_kmers = read_string("ASSEMBLY_KMERS")
+    String gambitcore_species_kmers = read_string("SPECIES_KMERS")
+    String gambitcore_species_std_kmers = read_string("SPECIES_STD_KMERS")
+    String gambitcore_assembly_qc = read_string("ASSEMBLY_QC")
+    String gambitcore_db_version = read_string("GAMBIT_DB_VERSION")
+    String gambitcore_docker = docker
   }
   runtime {
     docker:  "~{docker}"

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -1,0 +1,43 @@
+version 1.0
+
+task gambit_core_check {
+  input {
+    File assembly
+    String samplename
+    String docker = "us-docker.pkg.dev/general-theiagen/internal/gambittools:1.0.0"
+    File gambit_db_genomes = "gs://gambit-databases-rp/2.0.0/gambit-metadata-2.0.0-20240415.gdb"
+    File gambit_db_signatures = "gs://gambit-databases-rp/2.0.0/gambit-signatures-2.0.0-20240415.gs"
+    Int disk_size = 100
+    Int memory = 2
+    Int cpu = 1
+  }
+  command <<<
+    # capture date
+    date | tee DATE
+    
+    gambit_db_version="$(basename -- '~{gambit_db_genomes}'); $(basename -- '~{gambit_db_signatures}')"
+    gambit_db_dir="${PWD}/gambit_database"
+    mkdir ${gambit_db_dir}
+    cp ~{gambit_db_genomes} ${gambit_db_dir}
+    cp ~{gambit_db_signatures} ${gambit_db_dir}
+
+    echo ${gambit_db_version} | tee GAMBIT_DB_VERSION
+    
+    echo "Running gambit core check with: gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly}"
+    gambit-core-check -e -v ${gambit_db_dir} ${gambit_db_dir}/$(basename -- '~{gambit_db_signatures}') ${gambit_db_dir}/$(basename -- '~{gambit_db_genomes}') ~{assembly} | tee ~{samplename}_gambit_core_report.txt
+  >>>
+  output {
+    File gambit_core_check_report_file = "~{samplename}_gambit_core_report.txt"
+    String gambit_core_check_db_version = read_string("GAMBIT_DB_VERSION")
+    String gambit_core_check_docker = docker
+  }
+  runtime {
+    docker:  "~{docker}"
+    memory:  "~{memory} GB"
+    cpu:   "~{cpu}"
+    disks: "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    maxRetries: 3
+    preemptible:  0
+  }
+}

--- a/workflows/standalone_modules/wf_gambitcore.wdl
+++ b/workflows/standalone_modules/wf_gambitcore.wdl
@@ -1,0 +1,36 @@
+version 1.0
+
+import "../../tasks/task_versioning.wdl" as versioning
+import "../../tasks/quality_control/advanced_metrics/task_gambittools.wdl" as gambittools_task
+
+workflow gambitcore_wf {
+  input {
+    File assembly_fasta
+    String samplename
+  }
+  call gambittools_task.gambitcore {
+    input:
+      assembly = assembly_fasta,
+      samplename = samplename
+  }
+  call versioning.version_capture {
+    input:
+  }
+  output {
+    String gambitcore_wf_version = version_capture.phb_version
+    String gambitcore_wf_analysis_date = version_capture.date
+    # Gambitcore output files
+    File gambitcore_report_file = gambitcore.gambitcore_report_file
+    String gambitcore_species = gambitcore.gambitcore_species
+    String gambitcore_completeness = gambitcore.gambitcore_completeness
+    String gambitcore_kmers_ratio = gambitcore.gambitcore_kmers_ratio
+    String gambitcore_closest_accession = gambitcore.gambitcore_closest_accession
+    Float gambitcore_closest_distance = gambitcore.gambitcore_closest_distance
+    Int gambitcore_assembly_kmers = gambitcore.gambitcore_assembly_kmers
+    Int gambitcore_species_kmers = gambitcore.gambitcore_species_kmers
+    Int gambitcore_species_std_kmers = gambitcore.gambitcore_species_std_kmers
+    String gambitcore_assembly_qc = gambitcore.gambitcore_assembly_qc
+    String gambitcore_db_version = gambitcore.gambitcore_db_version
+    String gambitcore_docker = gambitcore.gambitcore_docker
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #328

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

This new workflow is an implementation of the gambitcore utility, available at https://github.com/gambit-suite/gambitcore. 

> This application takes in assemblies, identifies the species, then calculates the completeness of the assemblies against the species core genome. This is a good quality control step. It is acheived by looking at the GAMBIT k-mers in the assembly and comparing them to the GAMBIT k-mers in the core genome. If the assembly is poor quality, it is expected that the completeness of the assembly will be lower.

The container for this utility is available at `us-docker.pkg.dev/general-theiagen/internal/gambitcore:0.0.1`

The GAMBIT metadata and signatures files is required for gambitcore, and by default it's set to use the latest version of the database, available here:
- gs://gambit-databases-rp/2.0.0/gambit-metadata-2.0.0-20240415.gdb
- gs://gambit-databases-rp/2.0.0/gambit-signatures-2.0.0-20240415.gs

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: No, it's a new workflow

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: New container, available at `us-docker.pkg.dev/general-theiagen/internal/gambitcore:0.0.1`

Databases or database versions changed: GAMBIT db 2.0.0-20240415 (used for testing)

Data processing/commands changed: New workflow

File processing changed: New workflow

Compute resources changed: New workflow

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/64d22074-0cc5-43e6-be65-aac78d686197)


#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/5a47b4da-940e-4f23-8559-647f568f593c)

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

- **Local Testing:** Assembly of run accession ERR10146580 (_V. cholerae_)

- **Testing on Terra:** Set of 20 bacterial assemblies from diverse species 

| entity:extended_validation_dataset_kraken_id | Accession   | Carbapenemase_Identified | Genus_and_Species     |
|----------------------------------------------|-------------|--------------------------|-----------------------|
| DHQP1200524                                  | SRR3981083  | None                     | Klebsiella aerogenes  |
| DHQP1200525                                  | SRR3981084  | None                     | Klebsiella pneumoniae |
| DHQP1200916                                  | SRR3981086  | KPC-3                    | Klebsiella pneumoniae |
| DHQP1201148                                  | SRR3982095  | KPC-3                    | Enterobacter cloacae  |
| DHQP1201149                                  | SRR3982096  | VIM-1                    | Enterobacter cloacae  |
| DHQP1201152                                  | SRR3982098  | KPC-2                    | Klebsiella pneumoniae |
| DHQP1201153                                  | SRR3982099  | None                     | Escherichia coli      |
| DHQP1300309                                  | SRR3982279  | NMC-A                    | Enterobacter ludwigii |
| DHQP1301282                                  | SRR3467253  | None                     | Enterobacter cloacae  |
| DHQP1402081                                  | SRR11193642 | OXA-48                   | Klebsiella pneumoniae |
| DHQP1500333                                  | SRR4065668  | NDM-1                    | Klebsiella pneumoniae |
| DHQP1500337                                  | SRR4065672  | None                     | Enterobacter asburiae |
| DHQP1500518                                  | SRR5666499  | NDM-4                    | Escherichia coli      |
| DHQP1500538                                  | SRR5666438  | None                     | Enterobacter cloacae  |
| DHQP1501280                                  | SRR5666580  | KPC-4                    | Escherichia coli      |
| DHQP1502506                                  | SRR5666559  | KPC-6                    | Enterobacter cloacae  |
| DHQP1600755                                  | SRR5666555  | NDM-4                    | Klebsiella pneumoniae |
| DHQP1600790                                  | SRR5666572  | NDM-5                    | Escherichia coli      |
| DHQP1604376                                  | SRR5666426  | KPC-4                    | Enterobacter cloacae  |
| DHQP1606599                                  | SRR5666427  | NDM-1                    | Escherichia coli      |

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->
Tested with a _Vibrio cholerae_ assembly
`miniwdl run /home/ines_mendes/Git/public_health_bioinformatics/workflows/standalone_modules/wf_gambitcore.wdl assembly_fasta= ERR10146580_contigs.fasta samplename="ERR10146580" gambitcore.gambit_db_genomes= database_gambit_200_patch/gambit-metadata-2.0.0-20240415.gdb gambitcore.gambit_db_signatures= database_gambit_200_patch/gambit-signatures-2.0.0-20240415.gs`
![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/f9dacd49-7e83-4b0e-9849-8fa0739a5e54)

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/1bcd2611-ddc8-4c2b-af8e-a8de39084c90

| entity:extended_validation_dataset_kraken_id | gambitcore_assembly_qc | gambitcore_species | Genus_and_Species | gambit_predicted_taxon |
|---|---|---|---|---|
| DHQP1200524 | green | Klebsiella aerogenes | Klebsiella aerogenes | Klebsiella aerogenes |
| DHQP1200525 | green | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1200916 | green | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1201148 | green | Enterobacter hormaechei_A subspecies 2 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1201149 | green | Enterobacter hormaechei_A subspecies 2 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1201152 | green | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1201153 | green | Escherichia coli subspecies 6 | Escherichia coli | Escherichia coli |
| DHQP1300309 | green | Enterobacter ludwigii | Enterobacter ludwigii | Enterobacter ludwigii |
| DHQP1301282 | green | Enterobacter hormaechei_A subspecies 3 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1402081 | amber | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1500333 | green | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1500337 | green | Enterobacter cloacae_M | Enterobacter asburiae | Enterobacter asburiae |
| DHQP1500518 | green | Escherichia coli subspecies 12 | Escherichia coli | Escherichia coli |
| DHQP1500538 | green | Enterobacter hormaechei_A subspecies 3 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1501280 | green | Escherichia coli subspecies 8 | Escherichia coli | Escherichia coli |
| DHQP1502506 | green | Enterobacter hormaechei_A subspecies 2 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1600755 | green | Klebsiella pneumoniae | Klebsiella pneumoniae | Klebsiella pneumoniae |
| DHQP1600790 | amber | Escherichia coli subspecies 16 | Escherichia coli | Escherichia coli |
| DHQP1604376 | green | Enterobacter hormaechei_A subspecies 2 | Enterobacter cloacae | Enterobacter hormaechei |
| DHQP1606599 | green | Escherichia coli subspecies 16 | Escherichia coli | Escherichia coli |

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

- Test with GAMBIT database version 1.3.0, located at:
  - gs://gambit-databases-rp/1.3.0/gambit-metadata-1.3-231016.gdb
  - gs://gambit-databases-rp/1.3.0/gambit-signatures-1.3-231016.gs

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] ~~Relevant documentation on the Public Health Resources "PHB Main" has been updated~~ Internal workflow
- [ ] ~~Workflow diagrams have been updated to reflect changes~~ Internal workflow
