### PR TITLE
IRMA bug fixes & improvements; theiacov_illumina_pe wf updates for Flu

### DIFF
--- a/tasks/alignment/task_mafft.wdl
+++ b/tasks/alignment/task_mafft.wdl
@@ -3,19 +3,18 @@ version 1.0
 task mafft {
   input {
     Array[File] genomes
-    Int cpu = 16
-    Int memory = 32
-    Int disk_size = 100
+    Int cpu = 2
+    Int memory = 8
+    Int disk_size = 50
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/mafft:7.450"
   }
   command <<<
     # date and version control
     date | tee DATE
-    mafft_vers=$(mafft --version)
-    echo Mafft $(mafft_vers) | tee VERSION
+    mafft --version | tee VERSION
 
     cat ~{sep=" " genomes} | sed 's/Consensus_//;s/.consensus_threshold.*//' > assemblies.fasta
-    mafft --thread -~{cpu} assemblies.fasta > msa.fasta
+    mafft --thread ~{cpu} assemblies.fasta > msa.fasta
   >>>
   output {
     String date = read_string("DATE")

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -8,7 +8,7 @@ task irma {
     String samplename
     Boolean keep_ref_deletions = true
     String read_basename = basename(read1)
-    String docker = "cdcgov/irma:v1.1.3"
+    String docker = "us-docker.pkg.dev/general-theiagen/cdcgov/irma:v1.1.5"
     Int memory = 16
     Int cpu = 8
     Int disk_size = 100

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -132,14 +132,14 @@ task irma {
       touch IRMA_SUBTYPE_NOTES
     fi
 
-    echo "DEBUG: Renaming HA BAM files...."
     if ls "~{samplename}"_HA?*.bam 1> /dev/null 2>&1; then
+      echo "DEBUG: Renaming HA BAM files...."
       for file in "~{samplename}"_HA?*.bam; do
         mv -v "$file" "${file%_HA*.bam}_HA.bam"
       done
     fi
-    echo "DEBUG: Renaming NA BAM files...."
     if ls "~{samplename}"_NA?*.bam 1> /dev/null 2>&1; then
+      echo "DEBUG: Renaming NA BAM files...."
       for file in "~{samplename}"_NA?*.bam; do
         mv -v "$file" "${file%_NA*.bam}_NA.bam"
       done

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -164,11 +164,12 @@ task irma {
     fi
     
     echo "DEBUG: Creating padded FASTA files for each individual segment...."
-    # this loop looks in the PWD for files ending in .fasta, and creates a copy of the file with periods replaced by Ns
+    # this loop looks in the PWD for files ending in .fasta, and creates a copy of the file with periods replaced by Ns and dashes are deleted (since they represent gaps)
     for FASTA in ./*.fasta; do
-      # if the renamed file ends in .fasta; then create copy of the file with periods replaced by Ns
+      # if the renamed file ends in .fasta; then create copy of the file with periods replaced by Ns and dashes removed in all lines except FASTA headers that begin with '>'
         echo "DEBUG: creating padded FASTA file for ${FASTA}...."
-        sed '/^>/! s/\./N/g' "${FASTA}" > "${FASTA%.fasta}.pad.fasta"
+        sed '/^>/! s/\./N/g' "${FASTA}" > "${FASTA%.fasta}.temp.fasta"
+        sed '/^>/! s/-//g' "${FASTA%.fasta}.temp.fasta" > "${FASTA%.fasta}.pad.fasta"
     done
   >>>
   output {

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -154,12 +154,15 @@ task irma {
     File? seg_pb1_assembly = "~{samplename}_PB1.fasta"
     File? seg_pb2_assembly = "~{samplename}_PB2.fasta"
     File? seg_mp_assembly = "~{samplename}_MP.fasta"
+    File? seg_np_assembly = "~{samplename}_NP.fasta"
+    File? seg_ns_assembly = "~{samplename}_NS.fasta"
     String irma_type = read_string("IRMA_TYPE")
     String irma_subtype = read_string("IRMA_SUBTYPE")
     String irma_subtype_notes = read_string("IRMA_SUBTYPE_NOTES")
     Array[File] irma_assemblies = glob("~{samplename}*.fasta")
     Array[File] irma_vcfs = glob("~{samplename}*.vcf")
     Array[File] irma_bams = glob("~{samplename}*.bam")
+    String irma_docker = docker
     String irma_version = read_string("VERSION")
     String irma_pipeline_date = read_string("DATE")
     # for now just adding bams for these segments for mean coverage calculation

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -18,7 +18,10 @@ task irma {
 
     # as per suggestion from IRMA author for skipping the disk size check step of IRMA
     export ALLOW_DISK_CHECK=0
-    echo "ALLOW_DISK_CHECK is set to: ${ALLOW_DISK_CHECK}"
+    echo "DEBUG: ALLOW_DISK_CHECK is set to: ${ALLOW_DISK_CHECK}"
+
+    echo "DEBUG: here's the available disk space of all root directories:"
+    df -h /*
 
     #capture reads as bash variables
     read1=~{read1}

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -94,8 +94,8 @@ task irma {
       sed -i "s/>/>~{samplename}_/g" ~{samplename}.irma.consensus.fasta
 
       echo "DEBUG: creating copy of consensus FASTA with periods replaced by Ns...."
-      # use sed to create copy of FASTA file where periods are replaced by Ns, except in the FASTA header lines that begin with '>'
-      sed '/^>/! s/\./N/g' ~{samplename}.irma.consensus.fasta > ~{samplename}.irma.consensus.pad.fasta
+      # use sed to create copy of FASTA file where periods & dashes are replaced by Ns, except in the FASTA header lines that begin with '>'
+      sed '/^>/! s/[-\.]/N/g' ~{samplename}.irma.consensus.fasta > ~{samplename}.irma.consensus.pad.fasta
     else
       echo "No IRMA assembly generated for flu type prediction" | tee IRMA_TYPE
     fi

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -16,15 +16,13 @@ task irma {
   command <<<
     date | tee DATE
 
-    # as per suggestion from IRMA author for skipping the disk size check step of IRMA
-    export ALLOW_DISK_CHECK=0
-    echo "DEBUG: ALLOW_DISK_CHECK is set to: ${ALLOW_DISK_CHECK}"
+    ## CAUTION: this step is specific to cdcgov/irma docker image
+    # this is done so that IRMA used PWD as the TMP directory instead of /tmp/root that it tries by default; cromwell doesn't allocate much disk space here
+    echo "DEBUG: editing /flu-amd/IRMA_RES/defaults.sh IRMA configuration file to set TMP directory to $(pwd)"
+    sed "s|TMP=/tmp|TMP=$(pwd)|" /flu-amd/IRMA_RES/defaults.sh
 
     echo "DEBUG: here's the available disk space of all root directories:"
     df -h /*
-
-    echo "creating softlink between PWD and /tmp/${USER} which is used by IRMA for temporary files"
-    ln -s "$(pwd)" /tmp/${USER}
 
     #capture reads as bash variables
     read1=~{read1}

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -16,10 +16,9 @@ task irma {
   command <<<
     date | tee DATE
 
-    ## CAUTION: this step is specific to cdcgov/irma docker image
-    # this is done so that IRMA used PWD as the TMP directory instead of /tmp/root that it tries by default; cromwell doesn't allocate much disk space here
-    echo "DEBUG: editing /flu-amd/IRMA_RES/defaults.sh IRMA configuration file to set TMP directory to $(pwd)"
-    sed "s|TMP=/tmp|TMP=$(pwd)|" /flu-amd/IRMA_RES/defaults.sh
+    # this is done so that IRMA used PWD as the TMP directory instead of /tmp/root that it tries by default; cromwell doesn't allocate much disk space here (64MB or some small amount)
+    echo "DEBUG: creating an optional IRMA configuration file to set TMP directory to $(pwd)"
+    echo "TMP=$(pwd)" >> irma_config.sh
 
     echo "DEBUG: here's the available disk space of all root directories:"
     df -h /*
@@ -64,9 +63,9 @@ task irma {
 
     # set IRMA module depending on sequencing technology
     if [[ ~{seq_method} == "OXFORD_NANOPORE" ]]; then
-      IRMA "FLU-minion" "${read1}" ~{samplename}
+      IRMA "FLU-minion" "${read1}" ~{samplename} --external-config irma_config.sh
     else
-      IRMA "FLU" "${read1}" "${read2}" ~{samplename}
+      IRMA "FLU" "${read1}" "${read2}" ~{samplename} --external-config irma_config.sh
     fi
 
     # capture IRMA type

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -94,8 +94,8 @@ task irma {
       sed -i "s/>/>~{samplename}_/g" ~{samplename}.irma.consensus.fasta
 
       echo "DEBUG: creating copy of consensus FASTA with periods replaced by Ns...."
-      # use sed to create copy of FASTA file where periods & dashes are replaced by Ns, except in the FASTA header lines that begin with '>'
-      sed '/^>/! s/[-\.]/N/g' ~{samplename}.irma.consensus.fasta > ~{samplename}.irma.consensus.pad.fasta
+      # use sed to create copy of FASTA file where periods are replaced by Ns, except in the FASTA header lines that begin with '>'
+      sed '/^>/! s/\./N/g' ~{samplename}.irma.consensus.fasta > ~{samplename}.irma.consensus.pad.fasta
     else
       echo "No IRMA assembly generated for flu type prediction" | tee IRMA_TYPE
     fi

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -23,6 +23,9 @@ task irma {
     echo "DEBUG: here's the available disk space of all root directories:"
     df -h /*
 
+    echo "creating softlink between PWD and /tmp/${USER} which is used by IRMA for temporary files"
+    ln -s "$(pwd)" /tmp/${USER}
+
     #capture reads as bash variables
     read1=~{read1}
     if [[ "~{read2}" ]]; then 

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -18,6 +18,7 @@ task irma {
 
     # as per suggestion from IRMA author for skipping the disk size check step of IRMA
     export ALLOW_DISK_CHECK=0
+    echo "ALLOW_DISK_CHECK is set to: ${ALLOW_DISK_CHECK}"
 
     #capture reads as bash variables
     read1=~{read1}

--- a/tasks/assembly/task_irma.wdl
+++ b/tasks/assembly/task_irma.wdl
@@ -16,6 +16,9 @@ task irma {
   command <<<
     date | tee DATE
 
+    # as per suggestion from IRMA author for skipping the disk size check step of IRMA
+    export ALLOW_DISK_CHECK=0
+
     #capture reads as bash variables
     read1=~{read1}
     if [[ "~{read2}" ]]; then 

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -181,7 +181,7 @@ workflow theiacov_illumina_pe {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "NA",
-              flu_subtype = irma.irma_subtype,
+              flu_subtype = abricate_flu.abricate_flu_subtype,
               # including these to block from terra
               reference_gff_file = reference_gff,
               reference_genome = reference_genome,
@@ -202,7 +202,7 @@ workflow theiacov_illumina_pe {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "HA",
-              flu_subtype = irma.irma_subtype,
+              flu_subtype = abricate_flu.abricate_flu_subtype,
               # including these to block from terra
               reference_gff_file = reference_gff,
               reference_genome = reference_genome,

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -475,6 +475,7 @@ workflow theiacov_illumina_pe {
     String? irma_version = irma.irma_version
     String? irma_type = irma.irma_type
     String? irma_subtype = irma.irma_subtype
+    String? irma_subtype_notes = irma.irma_subtype_notes
     File? irma_ha_segment = irma.seg_ha_assembly
     File? irma_na_segment = irma.seg_na_assembly
     String? abricate_flu_type = abricate_flu.abricate_flu_type

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -473,11 +473,18 @@ workflow theiacov_illumina_pe {
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
     # Flu IRMA and Abricate Outputs
     String? irma_version = irma.irma_version
+    String? irma_docker = irma.irma_docker
     String? irma_type = irma.irma_type
     String? irma_subtype = irma.irma_subtype
     String? irma_subtype_notes = irma.irma_subtype_notes
-    File? irma_ha_segment = irma.seg_ha_assembly
-    File? irma_na_segment = irma.seg_na_assembly
+    File? irma_ha_segment_fasta = irma.seg_ha_assembly
+    File? irma_na_segment_fasta = irma.seg_na_assembly
+    File? irma_pa_segment_fasta = irma.seg_pa_assembly
+    File? irma_pb1_segment_fasta = irma.seg_pb1_assembly
+    File? irma_pb2_segment_fasta = irma.seg_pb2_assembly
+    File? irma_mp_segment_fasta = irma.seg_mp_assembly
+    File? irma_np_segment_fasta = irma.seg_np_assembly
+    File? irma_ns_segment_fasta = irma.seg_ns_assembly
     String? abricate_flu_type = abricate_flu.abricate_flu_type
     String? abricate_flu_subtype =  abricate_flu.abricate_flu_subtype
     File? abricate_flu_results = abricate_flu.abricate_flu_results

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -231,12 +231,12 @@ workflow theiacov_illumina_pe {
         }       
         call flu_antiviral.flu_antiviral_substitutions {
           input:
-            na_segment_assembly = irma.seg_na_assembly,
-            ha_segment_assembly = irma.seg_ha_assembly,
-            pa_segment_assembly = irma.seg_pa_assembly,
-            pb1_segment_assembly = irma.seg_pb1_assembly,
-            pb2_segment_assembly = irma.seg_pb2_assembly,
-            mp_segment_assembly = irma.seg_mp_assembly,
+            na_segment_assembly = irma.seg_na_assembly_padded,
+            ha_segment_assembly = irma.seg_ha_assembly_padded,
+            pa_segment_assembly = irma.seg_pa_assembly_padded,
+            pb1_segment_assembly = irma.seg_pb1_assembly_padded,
+            pb2_segment_assembly = irma.seg_pb2_assembly_padded,
+            mp_segment_assembly = irma.seg_mp_assembly_padded,
             abricate_flu_subtype = select_first([abricate_flu.abricate_flu_subtype, ""]),
             irma_flu_subtype = select_first([irma.irma_subtype, ""]),
         }
@@ -303,7 +303,7 @@ workflow theiacov_illumina_pe {
         # tasks specific to MPXV, sars-cov-2, WNV, flu rsv_a and rsv_b
         call vadr_task.vadr {
           input:
-            genome_fasta = select_first([ivar_consensus.assembly_fasta, irma.irma_assembly_fasta]),
+            genome_fasta = select_first([ivar_consensus.assembly_fasta, irma.irma_assembly_fasta_padded]),
             assembly_length_unambiguous = consensus_qc.number_ATCG,
             vadr_opts = organism_parameters.vadr_opts,
             max_length = organism_parameters.vadr_maxlength,

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -177,11 +177,14 @@ workflow theiacov_illumina_pe {
               assembly = select_first([irma.irma_assembly_fasta]),
               samplename = samplename
           }
+          # if IRMA cannot predict a subtype (like with Flu B samples), then set the flu_subtype to the abricate_flu_subtype String output (e.g. "Victoria" for Flu B)
+          String flu_subtype = if irma.irma_subtype == "No subtype predicted by IRMA" then abricate_flu.abricate_flu_subtype else irma.irma_subtype
+
           call set_organism_defaults.organism_parameters as set_flu_na_nextclade_values {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "NA",
-              flu_subtype = abricate_flu.abricate_flu_subtype,
+              flu_subtype = flu_subtype,
               # including these to block from terra
               reference_gff_file = reference_gff,
               reference_genome = reference_genome,
@@ -202,7 +205,7 @@ workflow theiacov_illumina_pe {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "HA",
-              flu_subtype = abricate_flu.abricate_flu_subtype,
+              flu_subtype = flu_subtype,
               # including these to block from terra
               reference_gff_file = reference_gff,
               reference_genome = reference_genome,

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -156,11 +156,16 @@ workflow theiacov_ont {
               assembly = select_first([irma.irma_assembly_fasta]),
               samplename = samplename
           } 
+
+           # if IRMA cannot predict a subtype (like with Flu B samples),
+           # then set the flu_subtype to the abricate_flu_subtype String output (e.g. "Victoria" for Flu B)
+          String flu_subtype = if irma.irma_subtype == "No subtype predicted by IRMA" then abricate_flu.abricate_flu_subtype else irma.irma_subtype
+
           call set_organism_defaults.organism_parameters as set_flu_na_nextclade_values {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "NA",
-              flu_subtype = irma.irma_subtype,
+              flu_subtype = flu_subtype,
               # including these to block from terra
               reference_genome = reference_genome,
               genome_length_input = genome_length,
@@ -179,7 +184,7 @@ workflow theiacov_ont {
             input:
               organism = organism_parameters.standardized_organism,
               flu_segment = "HA",
-              flu_subtype = irma.irma_subtype,
+              flu_subtype = flu_subtype,
                # including these to block from terra
               reference_genome = reference_genome,
               genome_length_input = genome_length,

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -443,10 +443,20 @@ workflow theiacov_ont {
     File? qc_standard = qc_check_task.qc_standard
     # Flu Outputs
     String? irma_version = irma.irma_version
+    String? irma_docker = irma.irma_docker
     String? irma_type = irma.irma_type
     String? irma_subtype = irma.irma_subtype
+    String? irma_subtype_notes = irma.irma_subtype_notes
     File? irma_ha_segment = irma.seg_ha_assembly
     File? irma_na_segment = irma.seg_na_assembly
+    File? irma_ha_segment_fasta = irma.seg_ha_assembly
+    File? irma_na_segment_fasta = irma.seg_na_assembly
+    File? irma_pa_segment_fasta = irma.seg_pa_assembly
+    File? irma_pb1_segment_fasta = irma.seg_pb1_assembly
+    File? irma_pb2_segment_fasta = irma.seg_pb2_assembly
+    File? irma_mp_segment_fasta = irma.seg_mp_assembly
+    File? irma_np_segment_fasta = irma.seg_np_assembly
+    File? irma_ns_segment_fasta = irma.seg_ns_assembly
     String? abricate_flu_type = abricate_flu.abricate_flu_type
     String? abricate_flu_subtype =  abricate_flu.abricate_flu_subtype
     File? abricate_flu_results = abricate_flu.abricate_flu_results

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -230,12 +230,12 @@ workflow theiacov_ont {
       if (organism_parameters.standardized_organism == "flu") {
         call flu_antiviral.flu_antiviral_substitutions {
           input:
-            na_segment_assembly = irma.seg_na_assembly,
-            ha_segment_assembly = irma.seg_ha_assembly,
-            pa_segment_assembly = irma.seg_pa_assembly,
-            pb1_segment_assembly = irma.seg_pb1_assembly,
-            pb2_segment_assembly = irma.seg_pb2_assembly,
-            mp_segment_assembly = irma.seg_mp_assembly,
+            na_segment_assembly = irma.seg_na_assembly_padded,
+            ha_segment_assembly = irma.seg_ha_assembly_padded,
+            pa_segment_assembly = irma.seg_pa_assembly_padded,
+            pb1_segment_assembly = irma.seg_pb1_assembly_padded,
+            pb2_segment_assembly = irma.seg_pb2_assembly_padded,
+            mp_segment_assembly = irma.seg_mp_assembly_padded,
             abricate_flu_subtype = select_first([abricate_flu.abricate_flu_subtype, ""]),
             irma_flu_subtype = select_first([irma.irma_subtype, ""]),
         }
@@ -296,7 +296,7 @@ workflow theiacov_ont {
         # tasks specific to MPXV, sars-cov-2, WNV, flu, rsv_a and rsv_b
         call vadr_task.vadr {
           input:
-            genome_fasta = select_first([consensus.consensus_seq, irma.irma_assembly_fasta]),
+            genome_fasta = select_first([consensus.consensus_seq, irma.irma_assembly_fasta_padded]),
             assembly_length_unambiguous = consensus_qc.number_ATCG,
             vadr_opts = organism_parameters.vadr_opts,
             max_length = organism_parameters.vadr_maxlength,
@@ -452,8 +452,6 @@ workflow theiacov_ont {
     String? irma_type = irma.irma_type
     String? irma_subtype = irma.irma_subtype
     String? irma_subtype_notes = irma.irma_subtype_notes
-    File? irma_ha_segment = irma.seg_ha_assembly
-    File? irma_na_segment = irma.seg_na_assembly
     File? irma_ha_segment_fasta = irma.seg_ha_assembly
     File? irma_na_segment_fasta = irma.seg_na_assembly
     File? irma_pa_segment_fasta = irma.seg_pa_assembly


### PR DESCRIPTION
~~Starting a draft while doing testing in Terra. Will update this message periodically~~

This PR closes #412 closes #437 and closes #457

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

The aim of this PR is to resolve a few different issues/bugs and make general improvements & upgrades to the TheiaCoV workflows for Flu analysis. Much of these changes impact the IRMA task, used in TheiaCoV_Illumina_PE wf, but some changes impact other workflows like TheiaCoV_ONT for Flu analysis.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No** 




## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

- added many `DEBUG` statements throughout
- Fixed issue #412 by use of `irma_config.sh` config file by setting `$TMP` used by IRMA to the present working directory. This impacted samples where FASTQ files were large and is no longer an issue

Docker/software or software versions changed: `cdcgov/irma:v1.1.3` ➡️ `"us-docker.pkg.dev/general-theiagen/cdcgov/irma:v1.1.5"`

Databases or database versions changed: **N/A**

Data processing/commands changed: **lots of changes to IRMA task & data processing**
 
- Fixed usage of `mafft --thread` flag and updated how version is captured
- added `--external-config irma_config.sh` to `IRMA` command to use custom config file created in beginning of task.

File processing changed: **lots of changes to output files & file renaming & FASTA header replacement**

- FASTA with all segments now contains headers with `~{samplename}`
```bash
# example where samplename == ERR11656083-FluB-ONT_B
$ grep '>' 20240509_155808_theiacov_ont/call-irma/work/ERR11656083-FluB-ONT.irma.consensus.fasta 
>ERR11656083-FluB-ONT_B_HA
>ERR11656083-FluB-ONT_B_MP
>ERR11656083-FluB-ONT_B_NA
>ERR11656083-FluB-ONT_B_NP
>ERR11656083-FluB-ONT_B_NS
>ERR11656083-FluB-ONT_B_PA
>ERR11656083-FluB-ONT_B_PB1
>ERR11656083-FluB-ONT_B_PB2
```

- Fix for empty HA segment for Flu B (Issue #437) on line 103. Adjusted `sed` command to modify file in place instead of redirecting into file. 
  - Also applied same change to line 117 for renaming NA FASTA file when it includes the subtype number in output FASTA file name. This only applies to Flu A samples as B do not have subtype numbers int output HA and NA segment FASTA filenames.

Compute resources changed:

- IRMA task reduced default cpus to `4`
  - Additionally - updated `irma_config.sh` file created in task to include 2 variables for multi-threading IRMA
- MAFFT task: reduced cpu to 2, memory to 8 and disk_size to 50

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

- defaults for docker and cpu were changed

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

New IRMA task outputs: 

- added `seg_np_assembly` & `seq_ns_assembly` which are the FASTA files corresponding with the NP (Nucleoprotein) and NS (nonstructural) segment
- `String irma_docker`
- `String irma_subtype_notes` which is either: `IRMA does not differentiate Victoria and Yamagata Flu B lineages. See abricate_flu_subtype output column` for Flu B samples and blank/empty for non Flu B samples.
  - (EXISTING BEHAVIOR, THIS OUTPUT HAS NOT CHANGED) `String irma_subtype` will either say `H1N1` (or whatever Flu A subtype) for example with Flu A and for Flu B it will say `No subtype predicted by IRMA` 
- adding these "padded" assemblies as outputs to be passed to VADR and MAFFT (antiviral substitutions tasks). "Padded" in this context means that periods `.` have been replaced with `N`'s.
```wdl
    File? irma_assembly_fasta_padded = "~{samplename}.irma.consensus.pad.fasta"
    File? seg_ha_assembly_padded = "~{samplename}_HA.pad.fasta"
    File? seg_na_assembly_padded = "~{samplename}_NA.pad.fasta"
    File? seg_pa_assembly_padded = "~{samplename}_PA.pad.fasta"
    File? seg_pb1_assembly_padded = "~{samplename}_PB1.pad.fasta"
    File? seg_pb2_assembly_padded = "~{samplename}_PB2.pad.fasta"
    File? seg_mp_assembly_padded = "~{samplename}_MP.pad.fasta"
    File? seg_np_assembly_padded = "~{samplename}_NP.pad.fasta"
    File? seg_ns_assembly_padded = "~{samplename}_NS.pad.fasta"
```

New TheiaCoV_Illumina_PE & ONT outputs:

- `String irma_docker = irma.irma_docker`
- `String? irma_subtype_notes = irma.irma_subtype_notes`
- `File? irma_ha_segment_fasta = irma.seg_ha_assembly`
- `File? irma_na_segment_fasta = irma.seg_na_assembly`
- `File? irma_pa_segment_fasta = irma.seg_pa_assembly`
- `File? irma_pb1_segment_fasta = irma.seg_pb1_assembly`
- `File? irma_pb2_segment_fasta = irma.seg_pb2_assembly`
- `File? irma_mp_segment_fasta = irma.seg_mp_assembly`
- `File? irma_np_segment_fasta = irma.seg_np_assembly`
- `File? irma_ns_segment_fasta = irma.seg_ns_assembly`

⚠️ NOTE: I have opted to NOT output the padded FASTA files to the workflow level (i.e. Terra output column) as it would add lots of clutter and likely confuse the user. They are saved as intermediate files during the IRMA task and can be retrieved from the execution directory if necessary.

## :test_tube: Testing 
#### Test Dataset

Described below.

#### Commandline Testing with MiniWDL or Cromwell (optional)

tested lots with miniwdl locally, but don't have output saved.

#### Terra Testing

- [x] TheiaCoV_illumina_PE with H1N1, H3N2, B Victoria, B Yamagata (I don't have data available)
  - 96 Illumina PE samples with H1N1, H3N2, B Victoria, but NO Yamagata samples: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/f47caabd-8ca2-4fe7-8c2e-9d60eb6f5e35
  - ~~⚠️ Need to review outputs, especially the all-segment FASTA files & the HA segment FASTA in particular~~
  - outputs look good, HA FASTA files (especially the type B HA segment FASTAs) and all-segment FASTA files look good.  
  - for B samples, nextclade datasets are appropriately being selected now that ABRicate-predicted subtype (Victoria or yamagata) is used appropriately to pick the correct nextclade datasets
- [x] TheiaCoV_ONT with H1N1 & B Victoria samples: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/1128454d-f8e1-4558-9fe9-2c1903fea4c4
  - ~~⚠️ need to review outputs, especially the all-segment FASTA files & the HA segment FASTA in particular~~
  - outputs look good, HA FASTA files (especially the type B HA segment FASTAs) and all-segment FASTA files look good.
  - for B samples, nextclade datasets are appropriately being selected now that ABRicate-predicted subtype (Victoria or yamagata) is used appropriately to pick the correct nextclade datasets 

#### Suggested Scenarios for Reviewer to Test

Would be good to test as many types/subtypes as possible and even test with poor quality data to see how the workflow behaves when IRMA cannot produce an assembly.

Need to test ONT as I've primarily been testing the IRMA WDL task updates with Illumina data. I tested 5 ONT samples, but would be good to do more if data is available

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes. **Updates to workflow diagram are not necessary**
