### PR TITLE
Augur_PHB: Set sample_metadata_tsvs input to optional

### DIFF
--- a/tasks/phylogenetic_inference/augur/task_augur_export.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_export.wdl
@@ -3,7 +3,7 @@ version 1.0
 task augur_export {
   input {
     File refined_tree
-    File metadata
+    File? metadata
     Array[File] node_data_jsons
     String build_name
 
@@ -22,7 +22,7 @@ task augur_export {
   command <<<
     augur export v2 \
       --tree ~{refined_tree} \
-      --metadata ~{metadata} \
+      ~{"--metadata " + metadata} \
       --node-data ~{sep=' ' node_data_jsons} \
       --output ~{build_name}_auspice.json \
       ~{"--auspice-config " + auspice_config} \

--- a/tasks/phylogenetic_inference/augur/task_augur_refine.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_refine.wdl
@@ -4,7 +4,7 @@ task augur_refine {
   input {
     File aligned_fasta
     File draft_augur_tree
-    File metadata
+    File? metadata
     String build_name
 
     Int? gen_per_year # number of generations per year (default: 50)
@@ -31,7 +31,7 @@ task augur_refine {
     AUGUR_RECURSION_LIMIT=10000 augur refine \
       --tree "~{draft_augur_tree}" \
       --alignment "~{aligned_fasta}" \
-      --metadata "~{metadata}" \
+      ~{'--metadata ' + metadata} \
       --output-tree "~{build_name}_timetree.nwk" \
       --output-node-data "~{build_name}_branch_lengths.json" \
       --timetree \

--- a/tasks/phylogenetic_inference/augur/task_augur_traits.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_traits.wdl
@@ -3,7 +3,7 @@ version 1.0
 task augur_traits {
   input {
     File refined_tree
-    File metadata
+    File? metadata
     File? weights
     #Boolean confidence = true
     String? metadata_id_columns
@@ -18,7 +18,7 @@ task augur_traits {
   command <<<
     AUGUR_RECURSION_LIMIT=10000 augur traits \
       --tree "~{refined_tree}" \
-      --metadata "~{metadata}" \
+      ~{'--metadata ' + metadata} \
       ~{'--columns {' + columns + '}'} \
       --confidence \
       ~{'--metadata-id-columns ' + metadata_id_columns} \

--- a/tasks/utilities/data_handling/task_augur_utilities.wdl
+++ b/tasks/utilities/data_handling/task_augur_utilities.wdl
@@ -245,12 +245,12 @@ task set_sc2_defaults { # establish sars-cov-2 default values for augur
 task prep_augur_metadata {
   input {
     File assembly
-    String collection_date
-    String country
-    String state
-    String continent
+    String? collection_date
+    String? country
+    String? state
+    String? continent
 
-    String county = ""
+    String? county = ""
     String? pango_lineage
     String? nextclade_clade
     String? organism = "sars-cov-2"

--- a/tasks/utilities/data_handling/task_augur_utilities.wdl
+++ b/tasks/utilities/data_handling/task_augur_utilities.wdl
@@ -33,7 +33,7 @@ task tsv_join {
     description: "Perform a full left outer join on multiple TSV tables. Each input tsv must have a header row, and each must must contain the value of id_col in its header. Inputs may or may not be gzipped. Unix/Mac/Win line endings are tolerated on input, Unix line endings are emitted as output. Unicode text safe. Copied from the Broad Institute"
   }
   input {
-    Array[File]+ input_tsvs
+    Array[File?] input_tsvs
     String id_col
     String out_basename = "merged"
     String out_suffix = ".tsv"

--- a/tasks/utilities/data_handling/task_augur_utilities.wdl
+++ b/tasks/utilities/data_handling/task_augur_utilities.wdl
@@ -33,7 +33,7 @@ task tsv_join {
     description: "Perform a full left outer join on multiple TSV tables. Each input tsv must have a header row, and each must must contain the value of id_col in its header. Inputs may or may not be gzipped. Unix/Mac/Win line endings are tolerated on input, Unix line endings are emitted as output. Unicode text safe. Copied from the Broad Institute"
   }
   input {
-    Array[File?] input_tsvs
+    Array[File] input_tsvs
     String id_col
     String out_basename = "merged"
     String out_suffix = ".tsv"

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -22,7 +22,7 @@ import "../utilities/wf_organism_parameters.wdl" as set_organism_defaults
 workflow augur {
   input {
     Array[File]+ assembly_fastas # use the HA or NA segment files for flu
-    Array[File] sample_metadata_tsvs # created with Augur_Prep
+    Array[File?] sample_metadata_tsvs # created with Augur_Prep
     String build_name
     String build_name_updated = sub(build_name, " ", "_")
     File? reference_fasta

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -22,7 +22,7 @@ import "../utilities/wf_organism_parameters.wdl" as set_organism_defaults
 workflow augur {
   input {
     Array[File]+ assembly_fastas # use the HA or NA segment files for flu
-    Array[File?] sample_metadata_tsvs # created with Augur_Prep
+    Array[File]? sample_metadata_tsvs # created with Augur_Prep
     String build_name
     String build_name_updated = sub(build_name, " ", "_")
     File? reference_fasta

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -75,7 +75,7 @@ workflow augur {
   if (defined(sample_metadata_tsvs)) {
     call augur_utils.tsv_join { # merge the metadata files
       input:
-        input_tsvs = sample_metadata_tsvs,
+        input_tsvs = select_first([sample_metadata_tsvs]),
         id_col = "strain",
         out_basename = "metadata-merged"
     }

--- a/workflows/phylogenetics/wf_augur.wdl
+++ b/workflows/phylogenetics/wf_augur.wdl
@@ -22,7 +22,7 @@ import "../utilities/wf_organism_parameters.wdl" as set_organism_defaults
 workflow augur {
   input {
     Array[File]+ assembly_fastas # use the HA or NA segment files for flu
-    Array[File]+ sample_metadata_tsvs # created with Augur_Prep
+    Array[File] sample_metadata_tsvs # created with Augur_Prep
     String build_name
     String build_name_updated = sub(build_name, " ", "_")
     File? reference_fasta
@@ -72,11 +72,13 @@ workflow augur {
       input:
     }
   }
-  call augur_utils.tsv_join { # merge the metadata files
-    input:
-      input_tsvs = sample_metadata_tsvs,
-      id_col = "strain",
-      out_basename = "metadata-merged"
+  if (defined(sample_metadata_tsvs)) {
+    call augur_utils.tsv_join { # merge the metadata files
+      input:
+        input_tsvs = sample_metadata_tsvs,
+        id_col = "strain",
+        out_basename = "metadata-merged"
+    }
   }
   if (! skip_alignment) { # by default, continue
     call file_handling.cat_files { # concatenate all of the input fasta files together
@@ -107,7 +109,7 @@ workflow augur {
       aligned_fasta = select_first([augur_align.aligned_fasta, filter_sequences_by_length.filtered_fasta]),
       build_name = build_name_updated
   }
-  if (! distance_tree_only) { # by default, continue
+  if (! distance_tree_only && defined(tsv_join.out_tsv)) { # by default, continue
     call refine_task.augur_refine { # create a timetree (aka, refine augur tree)
       input:
         aligned_fasta = select_first([augur_align.aligned_fasta, filter_sequences_by_length.filtered_fasta]),
@@ -129,7 +131,7 @@ workflow augur {
         build_name = build_name_updated
     }
     if (flu_segment == "HA") { # we only have clade information for HA segments (but SC2 defaults will be selected first)
-      if (run_traits) { # by default do not run traits and clades will be assigned based on the clades_tsv
+      if (run_traits && defined(tsv_join.out_tsv)) { # by default do not run traits and clades will be assigned based on the clades_tsv
         call traits_task.augur_traits {
           input:
             refined_tree = augur_refine.refined_tree,
@@ -193,7 +195,7 @@ workflow augur {
     File distance_tree = augur_tree.aligned_tree
     File aligned_fastas = select_first([augur_align.aligned_fasta, alignment_fasta])
     File combined_assemblies = filter_sequences_by_length.filtered_fasta
-    File metadata_merged = tsv_join.out_tsv
+    File? metadata_merged = tsv_join.out_tsv
     File? traits_json = augur_traits.traits_assignments_json
 
     # list of samples that were kept and met the length filters    

--- a/workflows/phylogenetics/wf_augur_prep.wdl
+++ b/workflows/phylogenetics/wf_augur_prep.wdl
@@ -6,10 +6,10 @@ import "../../tasks/utilities/data_handling/task_augur_utilities.wdl" as augur_u
 workflow augur_prep {
   input {
     File assembly
-    String collection_date
-    String country
-    String state
-    String continent
+    String? collection_date
+    String? country
+    String? state
+    String? continent
     String? pango_lineage
     String? nextclade_clade
     String? county


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #458.

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->
This PR features updates to the Augur_Prep_PHB and Augur_PHB workflows enabling a user to run these workflows with only the sequence information and not requiring associated metadata. The use case is such as when a user needs to only generate a distance tree in the newick format.

At present, in addition to sequence data, one can only run Augur_Prep_PHB when continent, country, state and collection date information is available. After this update, only the sequence information will be required.

For Augur_PHB workflow, in addition to assemblies and build name, associated metadata is a requirement. With this update, only the assemblies and build name will be required.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: No, the user will obtain the same results if they saved the required inputs that will be optional.

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed:  No

Databases or database versions changed: No

Data processing/commands changed: Yes, made some inputs optional

File processing changed: No

Compute resources changed: No

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

For `Augur_Prep_PHB`, the following inputs have been made optional:
```
collection_date
country
state
continent
```

For `Augur_PHB`, the following inputs have been made optional:
`sample_metadata_tsvs`

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->
The following Tests were done with flu H1N1:
`Augur_Prep_PHB` with the above mentioned inputs as required: https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/82bffbed-ca40-4023-870e-78802528a56f

`Augur_Prep_PHB` with the above mentioned inputs not included: https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/f630f152-89d9-4fbf-b977-c28303a165da

`Augur_PHB` with metadata: https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/88d1aefa-8a4c-4283-b978-bb0d21e7e119

`Augur_PHB` without metadata (but available from prep): https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/bf835e21-1292-4fe3-a0f1-4e2f9f54ea45

`Augur_PHB` without metadata (also none from prep): https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/b672ec5f-09c4-451d-88e7-a088c889c3d5

The distance trees in all scenarios were the same, with auspice tree only output when metadata is provided.

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

Test with non-flu pathogens.

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [ ] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [X] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [X] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
