### PR TITLE
[SRA-Fetch] Detect SRA-Lite when it's low quality file

### DIFF
--- a/tasks/utilities/data_import/task_sra_fetch.wdl
+++ b/tasks/utilities/data_import/task_sra_fetch.wdl
@@ -36,15 +36,15 @@ task fastq_dl_sra {
     fi
     
     # check if the first quality control string is set to SRA-Lite
-    # SRA-Lite filetype has all the quality enconding set to the '?' character
-    # corresponding to a phred-score of 30
-    # awk is checking the 4th line of the file and if it starts with and contains only '?' characters
+    # SRA-Lite filetype has all the quality enconding set to the '?' or '$' character
+    # corresponding to a phred-score of 30 or 3
+    # awk is checking the 4th line of the file and if it starts with and contains only '?' or '$' characters
     #   NR==4 on the fourth line,
     #   if $0 ~ /.../ this will evaluate to true only if the entire line matches this regular expression, which is:
     #   ^ at the start of the line
     #   [?] look for this character
     #   +$ and only this character until the end of the line
-    zcat "~{sra_accession}_1.fastq.gz" | head -n 4 | awk 'NR==4 {if ($0 ~ /^[?]+$/) {print "Potential SRA-Lite FASTQ detected"} else {print ""}}' > WARNING
+    zcat "~{sra_accession}_1.fastq.gz" | head -n 4 | awk 'NR==4 {if ($0 ~ /^[?$]+$/) {print "Potential SRA-Lite FASTQ detected"} else {print ""}}' > WARNING
     
   >>>
   output {


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #480 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

In SRA-Lite format, reject reads have a set quality encoding of 3, which is represented by the '$' character. This was not taken into consideration by our previous attempt to auto-detect this format by checking the quality-encoding range.

This is a fix to also report SRA-Lite when just the `?` or `$` characters are detected in the first line of quality-encoding characters. 

**Note:** If the read quality only contains `?` and `$` characters, it will be reported as SRA-Lite. Given that one encodes for Q-30 and the other for Q-3, it is extremely unlikely that this would occur naturally. 

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: No

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: N/A

Databases or database versions changed: N/A

Data processing/commands changed: N/A

File processing changed: N/A

Compute resources changed: N/A

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

Nothing changed

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

Nothing changed

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

The `^[?$]+$` regex was tested individually: 

![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/f05948e8-96de-45e7-ac39-bf3240f549a2)

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

- Dataset with known SRA-Lite samples (Q30): https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/f786bc54-6779-41ba-945a-1baddb64c11e
  - SRR5666427 Sample (Potential SRA-Lite FASTQ detected) 
  - ![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/4556af85-8452-45a3-85ad-88c4ea2923cc)

- Dataset with known SRA-Lite samples (Q3): https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/34def1d1-23b6-4fa4-aaa9-53c1efa6c6e3
  - Sample with low-quality reads that fail the SRA-Lite quality threshold. Forced SRA-Lite download with `
"--sra-lite --provider sra --only-provider"` input options.
  - ERR3039961 Sample (Potential SRA-Lite FASTQ detected) 
  - ![image](https://github.com/theiagen/public_health_bioinformatics/assets/15690332/58b5613b-5d6f-45cb-a709-8bf0806bc24a)


#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

Samples with Q30, Q3 and normal quality encoding
To "force" the SRA-Lite format download, use "--sra-lite --provider sra --only-provider" as fastq_dl_opts input argument on SRA_Fetch. 

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
