### PR TITLE
[TheiaProk] Update amrfinderplus to v3.12.8; DB: v2024-05-02.2; reduce compute resources

### DIFF
--- a/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
@@ -11,10 +11,10 @@ task amrfinderplus_nuc {
     Float? minid
     Float? mincov
     Boolean detailed_drug_class = false
-    Int cpu = 4
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.11.20-2023-09-26.1"
-    Int disk_size = 100
-    Int memory = 16
+    Int cpu = 2
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:3.12.8-2024-05-02.2"
+    Int disk_size = 50
+    Int memory = 8
     Boolean hide_point_mutations = false
     Boolean separate_betalactam_genes = false
   }
@@ -55,7 +55,7 @@ task amrfinderplus_nuc {
     if [[ -v amrfinder_organism ]] ; then
       # always use --plus flag, others may be left out if param is optional and not supplied 
       amrfinder --plus \
-        --organism ${amrfinder_organism} \
+        --organism "${amrfinder_organism}" \
         ~{'--name ' + samplename} \
         ~{'--nucleotide ' + assembly} \
         ~{'-o ' + samplename + '_amrfinder_all.tsv'} \
@@ -198,7 +198,7 @@ task amrfinderplus_nuc {
     docker: docker
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    preemptible: 0
+    preemptible: 1
     maxRetries: 3
   }
 }

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -17,7 +17,7 @@
     - wf_theiaprok_illumina_pe_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: 51f02263973b62c5fc2fde0b45056231
+      md5sum: 6c2c570754a616e7ac032109d8ffe71c
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json
@@ -29,9 +29,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 54ebef28014734172bfeeb798d0e7873
+      md5sum: af6e77e015582e10a0cadb800726bb4b
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
+      md5sum: 326a7d8c0e1f7435f5ae5c9153171036
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES
@@ -551,7 +551,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_abricate.wdl
       md5sum: 0a8e80d9c835a712936eac2cc6e3a05d
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
-      md5sum: 3afe9dcac768bf6f62e8b69714ce8b86
+      md5sum: 654c31055b807b3cd2aee9d5ceeea766
     - path: miniwdl_run/wdl/tasks/gene_typing/annotation/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/plasmid_detection/task_plasmidfinder.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -516,7 +516,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_abricate.wdl
       md5sum: 0a8e80d9c835a712936eac2cc6e3a05d
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
-      md5sum: 3afe9dcac768bf6f62e8b69714ce8b86
+      md5sum: 654c31055b807b3cd2aee9d5ceeea766
     - path: miniwdl_run/wdl/tasks/gene_typing/annotation/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/plasmid_detection/task_plasmidfinder.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -17,7 +17,7 @@
     - wf_theiaprok_illumina_se_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: 51f02263973b62c5fc2fde0b45056231
+      md5sum: 6c2c570754a616e7ac032109d8ffe71c
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json
@@ -29,9 +29,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_se", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: 54ebef28014734172bfeeb798d0e7873
+      md5sum: af6e77e015582e10a0cadb800726bb4b
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: 8e8e52e7e47bb3f44f866b41fe825422
+      md5sum: 326a7d8c0e1f7435f5ae5c9153171036
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CLASSES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_CORE_GENES


### PR DESCRIPTION
This PR closes #511 

🗑️ This dev branch should  be deleted after merging to main.

## :brain: Aim, Context and Functionality

- update default docker image for amrfinderplus
- reduce default compute resources & enable preemptible VMs to be used (cheaper)

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No** 

**Workflows impacted**

- TheiaProk_illumina_PE
- TheiaProk_illumina_PE
- TheiaProk_ONT
- TheiaProk_FASTA
- NCBI-AMRFinderPlus_PHB

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: v3.11.20 & DB v2023-09-26.1 ➡️ v3.12.8 & DB v2024-05-02.2

Databases or database versions changed: see above

Data processing/commands changed: double quotes added to one option (does not impact how it runs at all)

File processing changed: none

Compute resources changed: reduced cpus to 2, disk_size to 50, and memory to 8. also allow for preemptible VMs to be used

#### ➡️ Inputs 

- updated default runtime params & docker

#### ⬅️ Outputs 

N/A

## :test_tube: Testing 
#### Test Dataset

I use a diverse dataset ILMN PE data of bacteria that are known to have point mutations or other organism-specific acquired resistance genes. Almost every species that is part of the `amrfinder --organism` flag for organism-specific results. See the data table `amrfinderplus_testing_sample` for full list of species & accessions.

I have also gathered data (reads or genome assemblies only) for 3 organisms we do not yet have support for (Enterobacter asburiae, vibrio vulnificus, vibrio parahaemolyticus) just to see how they behave.

#### Commandline Testing with MiniWDL or Cromwell (optional)

Tested WDL task successfully with miniwdl. 

#### Terra Testing

- TheiaProk_Illumina_PE on diverse test set, many with expected point mutations (organism specific) and acquired resistance genes: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/711a4e15-16e8-46c3-8a7f-98b9bf2a6455
  - ~~⚠️ Need to review outputs~~
  - ✅ outputs look good, successfully ran with new docker image & runtime params
- TheiaProk_FASTA on a diverse test set: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/dae9cffb-6862-4348-b9b6-e597ee7fde02
  - ~~⚠️ need to review outputs~~
  - initial 5 failures due to assemblies not being present in the correct column, ~~will relaunch those separately~~
  - ✅ outputs look good, successfully ran with new docker image & runtime params
- TheiaProk_FASTA on 5 samples: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/c34317bc-8456-4b1d-8282-ec7283af263a
  - ~~⚠️ need to review outputs~~
  - ✅ outputs look good, successfully ran with new docker image & runtime params


#### Suggested Scenarios for Reviewer to Test

Test on as diverse a set of species as possible. Good to test any of the TheiaProk workflows.

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **functional, when results are compared to last version of PHB wfs, would be good to check if there are differences**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes. **Not necessary to update diagrams**
