### PR TITLE
[TheiaProk] upgrade mlst docker image to 2024-06-01 staphb build; reduced runtime parameters; enable preemptible

### DIFF
--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -10,7 +10,7 @@ task ts_mlst {
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-06-01"
     Int disk_size = 50
     Int cpu = 1
-    Int memory = 4
+    Int memory = 2
     # Parameters
     # --nopath          Strip filename paths from FILE column (default OFF)
     # --scheme [X]      Don't autodetect, force this scheme on all inputs (default '')

--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -7,10 +7,10 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-03-11"
-    Int disk_size = 100
-    Int cpu = 4
-    Int memory = 8
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-06-01"
+    Int disk_size = 50
+    Int cpu = 1
+    Int memory = 4
     # Parameters
     # --nopath          Strip filename paths from FILE column (default OFF)
     # --scheme [X]      Don't autodetect, force this scheme on all inputs (default '')
@@ -81,6 +81,6 @@ task ts_mlst {
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3
-    preemptible: 0
+    preemptible: 1
   }
 }

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -516,7 +516,7 @@
     - path: miniwdl_run/call-shovill_pe/work/out/skesa.fasta
     - path: miniwdl_run/call-shovill_pe/work/out/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/command
-      md5sum: df3b08d5ed6403b5ef3ae9b854fd3858
+      md5sum: c306b6501c0d41704cc559b09bd95e98
     - path: miniwdl_run/call-ts_mlst/inputs.json
       contains: ["assembly", "fasta", "sample", "test"]
     - path: miniwdl_run/call-ts_mlst/outputs.json
@@ -621,7 +621,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/mycobacterium/task_tbprofiler.wdl
       md5sum: 97ccec2e7a8499a8b82077321c62f804
     - path: miniwdl_run/wdl/tasks/species_typing/multi/task_ts_mlst.wdl
-      md5sum: c84e37ca77732b2ffa6a32629a4b6d6f
+      md5sum: cfc0b5212cdf70300497bce58d295539
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a7fd1295e5759277b3a1e43253881b12
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -481,7 +481,7 @@
     - path: miniwdl_run/call-shovill_se/work/out/skesa.fasta
     - path: miniwdl_run/call-shovill_se/work/out/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/command
-      md5sum: df3b08d5ed6403b5ef3ae9b854fd3858
+      md5sum: c306b6501c0d41704cc559b09bd95e98
     - path: miniwdl_run/call-ts_mlst/inputs.json
       contains: ["assembly", "fasta", "sample", "test"]
     - path: miniwdl_run/call-ts_mlst/outputs.json
@@ -584,7 +584,7 @@
     - path: miniwdl_run/wdl/tasks/species_typing/mycobacterium/task_tbprofiler.wdl
       md5sum: 97ccec2e7a8499a8b82077321c62f804
     - path: miniwdl_run/wdl/tasks/species_typing/multi/task_ts_mlst.wdl
-      md5sum: c84e37ca77732b2ffa6a32629a4b6d6f
+      md5sum: cfc0b5212cdf70300497bce58d295539
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a7fd1295e5759277b3a1e43253881b12
     - path: miniwdl_run/wdl/tasks/taxon_id/task_gambit.wdl


### PR DESCRIPTION
This PR closes #510

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

- upgrade default docker image to StaPH-B's June 2024 build of the `mlst` docker image
- reduce compute resources requested & enabled premptible VMs. `mlst` is super lightweight (runs very fast) and only needs 1 cpu.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes, if the mlst scheme has changed for the given organism**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No** 

Impacted workflows:

- TheiaProk_illumina_pe
- TheiaProk_illumina_se
- TheiaProk_ont
- TheiaProk_fasta

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: upgraded to copy of StaPH-B's mlst docker image built 2024-06-01 `staphb/mlst:2.23.0-2024-06-01`. previously used build from 2024-03-11

Databases or database versions changed: `mlst` database built on 2024-06-01

Data processing/commands changed: **N/A**

File processing changed: **N/A**

Compute resources changed: reduced cpu to 1, memory to 2, disk_size to 50; enabled preemptible VMs

#### ➡️ Inputs 

- upgraded docker image default
- lowered compute resources

#### ⬅️ Outputs 

N/A

## :test_tube: Testing 
#### Test Dataset

Testing on Terra with 2 A. baummannii samples. No obligate need to test other species, but would be beneficial if the reviewer can test more species

#### Commandline Testing with MiniWDL or Cromwell (optional)

Tested successfully w `miniwdl` on a Shigella sample

#### Terra Testing

- TheiaProk_Illumina_PE test on 2 A. baummannii samples: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/0f28f3b6-4260-48a0-b0ec-10fc0d7df3a4
  - ~~⚠️ need to review outputs~~
  - ✅ outputs look good, new docker image utilized

#### Suggested Scenarios for Reviewer to Test

Diverse set of bacterial species if you have the data readily available

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **functional**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes. **Not necessary to update wf diagrams**
