### PR TITLE
[TheiaProk] Add emmtyper task for Streptococcus pyogenes

### DIFF
--- a/tasks/species_typing/streptococcus/task_emmtyper.wdl
+++ b/tasks/species_typing/streptococcus/task_emmtyper.wdl
@@ -1,5 +1,8 @@
 version 1.0
 
+# task adapted with some modifications from Neranjan Perera's GAS_identification task_emmtyper.wdl
+# https://github.com/neranjan007/GAS_identification/blob/454ef3b0cc8a90950b48342cde87136962f9adb1/tasks/task_emmtyper.wdl
+
 task emmtyper {
   meta {
     description: "emm-typing of Streptococcus pyogenes assemblies"

--- a/tasks/species_typing/streptococcus/task_emmtyper.wdl
+++ b/tasks/species_typing/streptococcus/task_emmtyper.wdl
@@ -53,10 +53,15 @@ task emmtyper {
       ~{'--max-size' + max_size} \
       ~{assembly} \
       > ~{samplename}.tsv
+
+      # emm type is in column 4 for verbose output
+      awk -F "\t" '{print $4}' ~{samplename}.tsv > EMM_TYPE
   >>>
   output {
-    File emmtyper_results = "~{samplename}.tsv"
+    String emmtyper_emm_type = read_string("EMM_TYPE")
+    File emmtyper_results_tsv = "~{samplename}_emmtyper.tsv"
     String emmtyper_version = read_string("VERSION")
+    String emmtyper_docker = docker
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/species_typing/streptococcus/task_emmtyper.wdl
+++ b/tasks/species_typing/streptococcus/task_emmtyper.wdl
@@ -40,6 +40,7 @@ task emmtyper {
   }
   command <<<
     echo $(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//' | tee VERSION
+
     emmtyper \
       ~{'--workflow' + wf} \
       ~{'--cluster-distance' + cluster_distance} \
@@ -51,10 +52,11 @@ task emmtyper {
       ~{'--min-perfect' + min_perfect} \
       ~{'--min-good' + min_good} \
       ~{'--max-size' + max_size} \
+      --output-format verbose
       ~{assembly} \
       > ~{samplename}.tsv
 
-      # emm type is in column 4 for verbose output
+      # emm type is in column 4 for verbose output format
       awk -F "\t" '{print $4}' ~{samplename}.tsv > EMM_TYPE
   >>>
   output {

--- a/tasks/species_typing/streptococcus/task_emmtyper.wdl
+++ b/tasks/species_typing/streptococcus/task_emmtyper.wdl
@@ -42,22 +42,22 @@ task emmtyper {
     echo $(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//' | tee VERSION
 
     emmtyper \
-      ~{'--workflow' + wf} \
-      ~{'--cluster-distance' + cluster_distance} \
-      ~{'--percent-identity' + percid} \
-      ~{'--culling-limit' + culling_limit} \
-      ~{'--mismatch' + mismatch} \
-      ~{'--align-diff' + align_diff} \
-      ~{'--gap' + gap} \
-      ~{'--min-perfect' + min_perfect} \
-      ~{'--min-good' + min_good} \
-      ~{'--max-size' + max_size} \
-      --output-format verbose
+      ~{'--workflow ' + wf} \
+      ~{'--cluster-distance ' + cluster_distance} \
+      ~{'--percent-identity ' + percid} \
+      ~{'--culling-limit ' + culling_limit} \
+      ~{'--mismatch ' + mismatch} \
+      ~{'--align-diff ' + align_diff} \
+      ~{'--gap ' + gap} \
+      ~{'--min-perfect ' + min_perfect} \
+      ~{'--min-good ' + min_good} \
+      ~{'--max-size ' + max_size} \
+      --output-format verbose \
       ~{assembly} \
-      > ~{samplename}.tsv
+      > ~{samplename}_emmtyper.tsv
 
       # emm type is in column 4 for verbose output format
-      awk -F "\t" '{print $4}' ~{samplename}.tsv > EMM_TYPE
+      awk -F "\t" '{print $4}' ~{samplename}_emmtyper.tsv > EMM_TYPE
   >>>
   output {
     String emmtyper_emm_type = read_string("EMM_TYPE")

--- a/tasks/utilities/data_export/task_broad_terra_tools.wdl
+++ b/tasks/utilities/data_export/task_broad_terra_tools.wdl
@@ -312,6 +312,10 @@ task export_taxon_tables {
     String? seroba_ariba_serotype
     String? seroba_ariba_identity
     File? seroba_details
+    String? emmtyper_emm_type
+    File? emmtyper_results_tsv
+    String? emmtyper_version
+    String? emmtyper_docker
     String? emmtypingtool_emm_type
     File? emmtypingtool_results_xml
     String? emmtypingtool_version
@@ -722,6 +726,10 @@ task export_taxon_tables {
       "seroba_ariba_serotype": "~{seroba_ariba_serotype}",
       "seroba_ariba_identity": "~{seroba_ariba_identity}",
       "seroba_details": "~{seroba_details}",
+      "emmtyper_emm_type": "~{emmtyper_emm_type}",
+      "emmtyper_results_tsv": "~{emmtyper_results_tsv}",
+      "emmtyper_version": "~{emmtyper_version}",
+      "emmtyper_docker": "~{emmtyper_docker}",
       "emmtypingtool_emm_type": "~{emmtypingtool_emm_type}",
       "emmtypingtool_reults_xml": "~{emmtypingtool_results_xml}",
       "emmtypingtool_version": "~{emmtypingtool_version}",

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -631,11 +631,11 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
       md5sum: 64caaaff5910ac0036e2659434500962
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
-      md5sum: 52556169654cfa3e5de47c1987e83475
+      md5sum: 14565031f96d01ee6480bb0f9d19551d
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 0b4ef1f3f2711a0460050a1a09d44911
+      md5sum: 646e726beb68fc61f84a428bf2fb7244
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 6c125054324cd3597f8291baefb54694
+      md5sum: 43367523b9140ca0d2ac15869046343c
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -594,11 +594,11 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
       md5sum: 64caaaff5910ac0036e2659434500962
     - path: miniwdl_run/wdl/tasks/utilities/data_export/task_broad_terra_tools.wdl
-      md5sum: 52556169654cfa3e5de47c1987e83475
+      md5sum: 14565031f96d01ee6480bb0f9d19551d
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: e2015675a4f53e0e4492e8c6a43dcb37
+      md5sum: 347c054f9850e885e6a130d1655765d7
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 6c125054324cd3597f8291baefb54694
+      md5sum: 43367523b9140ca0d2ac15869046343c
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 963090bb29184f61c7025e2bc487de4b
     - path: miniwdl_run/workflow.log

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -410,6 +410,10 @@ workflow theiaprok_fasta {
         seroba_ariba_serotype = merlin_magic.seroba_ariba_serotype,
         seroba_ariba_identity = merlin_magic.seroba_ariba_identity,
         seroba_details = merlin_magic.seroba_details,
+        emmtyper_emm_type = merlin_magic.emmtyper_emm_type,
+        emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv,
+        emmtyper_version = merlin_magic.emmtyper_version,
+        emmtyper_docker = merlin_magic.emmtyper_docker,
         pasty_serogroup = merlin_magic.pasty_serogroup,
         pasty_serogroup_coverage = merlin_magic.pasty_serogroup_coverage,
         pasty_serogroup_fragments = merlin_magic.pasty_serogroup_fragments,
@@ -678,6 +682,11 @@ workflow theiaprok_fasta {
     String? poppunk_GPS_db_version = merlin_magic.poppunk_GPS_db_version
     String? poppunk_version = merlin_magic.poppunk_version
     String? poppunk_docker = merlin_magic.poppunk_docker
+    # Streptococcus pyogenes Typing
+    String? emmtyper_emm_type = merlin_magic.emmtyper_emm_type
+    File? emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv
+    String? emmtyper_version = merlin_magic.emmtyper_version
+    String? emmtyper_docker = merlin_magic.emmtyper_docker
     # Haemophilus influenzae Typing
     String? hicap_serotype = merlin_magic.hicap_serotype
     String? hicap_genes = merlin_magic.hicap_genes

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -541,6 +541,10 @@ workflow theiaprok_illumina_pe {
             seroba_ariba_serotype = merlin_magic.seroba_ariba_serotype,
             seroba_ariba_identity = merlin_magic.seroba_ariba_identity,
             seroba_details = merlin_magic.seroba_details,
+            emmtyper_emm_type = merlin_magic.emmtyper_emm_type,
+            emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv,
+            emmtyper_version = merlin_magic.emmtyper_version,
+            emmtyper_docker = merlin_magic.emmtyper_docker,
             emmtypingtool_emm_type = merlin_magic.emmtypingtool_emm_type,
             emmtypingtool_results_xml = merlin_magic.emmtypingtool_results_xml,
             emmtypingtool_version = merlin_magic.emmtypingtool_version,
@@ -973,6 +977,10 @@ workflow theiaprok_illumina_pe {
     String? seroba_ariba_identity = merlin_magic.seroba_ariba_identity
     File? seroba_details = merlin_magic.seroba_details
     # Streptococcus pyogenes Typing
+    String? emmtyper_emm_type = merlin_magic.emmtyper_emm_type
+    File? emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv
+    String? emmtyper_version = merlin_magic.emmtyper_version
+    String? emmtyper_docker = merlin_magic.emmtyper_docker
     String? emmtypingtool_emm_type = merlin_magic.emmtypingtool_emm_type
     File? emmtypingtool_results_xml = merlin_magic.emmtypingtool_results_xml
     String? emmtypingtool_version = merlin_magic.emmtypingtool_version

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -504,6 +504,10 @@ workflow theiaprok_illumina_se {
             agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts,
             agrvate_version = merlin_magic.agrvate_version,
             agrvate_docker = merlin_magic.agrvate_docker,
+            emmtyper_emm_type = merlin_magic.emmtyper_emm_type,
+            emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv,
+            emmtyper_version = merlin_magic.emmtyper_version,
+            emmtyper_docker = merlin_magic.emmtyper_docker,
             midas_docker = read_QC_trim.midas_docker,
             midas_report = read_QC_trim.midas_report,
             midas_primary_genus = read_QC_trim.midas_primary_genus,
@@ -899,6 +903,11 @@ workflow theiaprok_illumina_se {
     String? poppunk_GPS_db_version = merlin_magic.poppunk_GPS_db_version
     String? poppunk_version = merlin_magic.poppunk_version
     String? poppunk_docker = merlin_magic.poppunk_docker
+    # Streptococcus pyogenes Typing
+    String? emmtyper_emm_type = merlin_magic.emmtyper_emm_type
+    File? emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv
+    String? emmtyper_version = merlin_magic.emmtyper_version
+    String? emmtyper_docker = merlin_magic.emmtyper_docker
     # Haemophilus influenzae Typing
     String? hicap_serotype = merlin_magic.hicap_serotype
     String? hicap_genes = merlin_magic.hicap_genes

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -510,6 +510,10 @@ workflow theiaprok_ont {
             agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts,
             agrvate_version = merlin_magic.agrvate_version,
             agrvate_docker = merlin_magic.agrvate_docker,
+            emmtyper_emm_type = merlin_magic.emmtyper_emm_type,
+            emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv,
+            emmtyper_version = merlin_magic.emmtyper_version,
+            emmtyper_docker = merlin_magic.emmtyper_docker,
             pasty_serogroup = merlin_magic.pasty_serogroup,
             pasty_serogroup_coverage = merlin_magic.pasty_serogroup_coverage,
             pasty_serogroup_fragments = merlin_magic.pasty_serogroup_fragments,
@@ -882,6 +886,11 @@ workflow theiaprok_ont {
     String? poppunk_GPS_db_version = merlin_magic.poppunk_GPS_db_version
     String? poppunk_version = merlin_magic.poppunk_version
     String? poppunk_docker = merlin_magic.poppunk_docker
+    # Streptococcus pyogenes Typing
+    String? emmtyper_emm_type = merlin_magic.emmtyper_emm_type
+    File? emmtyper_results_tsv = merlin_magic.emmtyper_results_tsv
+    String? emmtyper_version = merlin_magic.emmtyper_version
+    String? emmtyper_docker = merlin_magic.emmtyper_docker
     # Haemophilus influenzae Typing
     String? hicap_serotype = merlin_magic.hicap_serotype
     String? hicap_genes = merlin_magic.hicap_genes

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -25,6 +25,7 @@ import "../../tasks/species_typing/salmonella/task_sistr.wdl" as sistr_task
 import "../../tasks/species_typing/staphylococcus/task_agrvate.wdl" as agrvate_task
 import "../../tasks/species_typing/staphylococcus/task_spatyper.wdl" as spatyper_task
 import "../../tasks/species_typing/staphylococcus/task_staphopiasccmec.wdl" as staphopia_sccmec_task
+import "../../tasks/species_typing/streptococcus/task_emmtyper.wdl" as emmtyper_task
 import "../../tasks/species_typing/streptococcus/task_emmtypingtool.wdl" as emmtypingtool_task
 import "../../tasks/species_typing/streptococcus/task_pbptyper.wdl" as pbptyper
 import "../../tasks/species_typing/streptococcus/task_poppunk_streppneumo.wdl" as poppunk_spneumo
@@ -51,6 +52,17 @@ workflow merlin_magic {
     Int? pasty_min_coverage
     String? hicap_docker_image
     String? pasty_docker_image
+    String? emmtyper_wf
+    Int? emmtyper_cluster_distance
+    Int? emmtyper_percid
+    Int? emmtyper_culling_limit
+    Int? emmtyper_mismatch
+    Int? emmtyper_align_diff
+    Int? emmtyper_gap
+    Int? emmtyper_min_perfect
+    Int? emmtyper_min_good
+    Int? emmtyper_max_size
+    String? emmtyper_docker_image
     String? emmtypingtool_docker_image
     String? shigeifinder_docker_image
     String? shigatyper_docker_image
@@ -338,6 +350,22 @@ workflow merlin_magic {
     }
   }
   if (merlin_tag == "Streptococcus pyogenes") {
+    call emmtyper_task.emmtyper {
+      input:
+        assembly = assembly,
+        samplename = samplename,
+        docker = emmtyper_docker_image,
+        wf = emmtyper_wf,
+        cluster_distance = emmtyper_cluster_distance,
+        percid = emmtyper_percid,
+        culling_limit = emmtyper_culling_limit,
+        mismatch = emmtyper_mismatch,
+        align_diff = emmtyper_align_diff,
+        gap = emmtyper_gap,
+        min_perfect = emmtyper_min_perfect,
+        min_good = emmtyper_min_good,
+        max_size = emmtyper_max_size,
+    }
     if (paired_end && !ont_data) {
       call emmtypingtool_task.emmtypingtool {
         input:
@@ -668,6 +696,10 @@ workflow merlin_magic {
     String? seroba_ariba_identity = seroba_task.seroba_ariba_identity
     File? seroba_details = seroba_task.seroba_details
     # Streptococcus pyogenes Typing
+    String? emmtyper_emm_type = emmtyper.emmtyper_emm_type
+    File? emmtyper_results_tsv = emmtyper.emmtyper_results_tsv
+    String? emmtyper_version = emmtyper.emmtyper_version
+    String? emmtyper_docker = emmtyper.emmtyper_docker
     String? emmtypingtool_emm_type = emmtypingtool.emmtypingtool_emm_type
     File? emmtypingtool_results_xml = emmtypingtool.emmtypingtool_results_xml
     String? emmtypingtool_version = emmtypingtool.emmtypingtool_version


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #413.

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->
This PR adds [emmtyper](https://github.com/MDU-PHL/emmtyper) to the TheiaProk workflows to perform emm gene typing on Streptococcus pyogenes assemblies. TheiaProk_Illumina_PE_PHB already contains a similar task using the read-based [emmtyping_tool](https://github.com/ukhsa-collaboration/emm-typing-tool), which is only compatible with paired-end reads. Since emmtyper works on assemblies, it is compatible with the paired-end, single-end, FASTA, and ONT versions of the TheiaProk workflows. Also, there are sometimes differences between the two tools' outputs (see validation test results below), so I think it is useful to make both tools available.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: Yes, there are now a few additional outputs that will be filled if the species is identified as Streptococcus pyogenes, but the change will not affect existing results.

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes
`task_emmtyper.wdl` already existed in this repo, but was not being used in any workflows. I made some changes to the existing task and updated the TheiaProk workflows to use the task.

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: None

Databases or database versions changed: None

Data processing/commands changed: The task now parses and outputs the "final" emm type from the output TSV. The task now uses `--output-format verbose` TSV format instead of the default short format. 

File processing changed: None

Compute resources changed: None

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.--> None.

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

The TheiaProk workflows have these new outputs: `emmtyper_emm_type`, `emmtyper_results_tsv`, `emmtyper_version`, and `emmtyper_docker`.

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->
The workflows were tested using 32-sample validation set of isolates with known emm types provided by the CDC Strep Lab. The reads were fetched from NCBI using the SRA_Fetch_PHB workflow.

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->
None.

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->
I performed Terra testing for the TheiaProk_Illumina_PE_PHB, TheiaProk_Illumina_SE_PHB, and TheiaProk_FASTA_PHB workflows in separate data tables with call caching turned off. For testing TheiaProk_Illumina_SE_PHB, only `read1` was used. For testing TheiaProk_FASTA_PHB, the `assembly_fasta` outputs from TheiaProk_Illumina_PE were used.

![image](https://github.com/theiagen/public_health_bioinformatics/assets/110497932/673cc1c5-78af-4255-bc88-a04b7b0121fd)

**Comparison table of emm type results**
| BioSample    | Expected emm type | TheiaProk PE emmtyper | TheiaProk PE emmtypingtool          | TheiaProk SE emmtyper | TheiaProk FASTA emmtyper |
| ------------ | ----------------- | ----------- | ------------------------- | ----------- | -------------- |
| SAMN26504544 | 83.1              | EMM83.1     | emm83.1.sds               | EMM83.1     | EMM83.1        |
| SAMN26504545 | 76.0              | EMM76.0     | emm76.0.sds               | EMM76.0     | EMM76.0        |
| SAMN26504546 | 4.0               | EMM4.0      | emm4.0.sds                | EMM4.0      | EMM4.0         |
| SAMN26504547 | 73.7              | EMM73.7     | emm73 ⚠️                    | EMM73.7     | EMM73.7        |
| SAMN26504548 | 12.0              | EMM12.0     | emm12.0.sds               | EMM12.0     | EMM12.0        |
| SAMN26504549 | 4.0               | EMM4.0      | emm4.0.sds                | EMM4.0      | EMM4.0         |
| SAMN26504550 | 183.1             | EMM183.1    | emm183.1.sds/emm149.0.sds ⚠️ | EMM183.1    | EMM183.1       |
| SAMN26504551 | 77.0              | EMM77.0     | emm77.0.sds               | EMM77.0     | EMM77.0        |
| SAMN26504568 | 28.0              | EMM28.0     | emm28.0.sds               | EMM28.0     | EMM28.0        |
| SAMN26504569 | 2.0               | EMM2.0      | emm2.0.sds                | EMM2.0      | EMM2.0         |
| SAMN26504552 | 12.0              | EMM12.0     | emm12.0.sds               | EMM12.0     | EMM12.0        |
| SAMN26504553 | 89.0              | EMM89.0     | emm89.0.sds               | EMM89.0     | EMM89.0        |
| SAMN26504554 | 89.0              | EMM89.0     | emm89.0.sds               | EMM89.0     | EMM89.0        |
| SAMN26504570 | 2.0               | EMM2.0      | emm2.0.sds                | EMM2.0      | EMM2.0         |
| SAMN26504571 | 2.0               | EMM2.0      | emm2.0.sds                | EMM2.0      | EMM2.0         |
| SAMN26504555 | 75.0              | EMM75.0     | emm75.0.sds               | EMM75.0     | EMM75.0        |
| SAMN26504556 | 77.0              | EMM77.0     | emm77.0.sds               | EMM77.0     | EMM77.0        |
| SAMN26504557 | 77.0              | EMM77.0     | emm77.0.sds               | EMM77.0     | EMM77.0        |
| SAMN26504558 | 92.0              | EMM92.0     | emm92.0.sds               | EMM92.0     | EMM92.0        |
| SAMN26504559 | 92.0              | EMM92.0     | emm92.0.sds               | EMM92.0     | EMM92.0        |
| SAMN26504560 | 90.2              | EMM90.2     | emm90.2.sds               | EMM90.2     | EMM90.2        |
| SAMN26504562 | 59.0              | EMM59.0     | emm59.0.sds               | EMM59.0     | EMM59.0        |
| SAMN26504563 | 83.1              | EMM83.1     | emm83.1.sds               | EMM83.1     | EMM83.1        |
| SAMN26504564 | 77.0              | EMM77.0     | emm77.0.sds               | EMM77.0     | EMM77.0        |
| SAMN26504572 | 11.0              | EMM11.0     | emm11.0.sds               | EMM11.0     | EMM11.0        |
| SAMN26504573 | 11.0              | EMM11.0     | emm11.0.sds               | EMM11.0     | EMM11.0        |
| SAMN26504565 | 28.0              | EMM28.0     | emm28.0.sds               | EMM28.0     | EMM28.0        |
| SAMN26504566 | 92.0              | EMM92.0     | emm92.0.sds               | EMM92.0     | EMM92.0        |
| SAMN26504567 | 73.0              | EMM73.0     | emm73.0.sds               | EMM73.0     | EMM73.0        |
| SAMN26504574 | 1.0               | EMM1.0      | emm1.0.sds                | EMM1.0      | EMM1.0         |
| SAMN26504575 | 6.4               | EMM6.4      | emm6.4.sds                | EMM6.4      | EMM6.4         |
| SAMN26504576 | 89.0              | EMM89.0     | emm89.0.sds               | EMM89.0     | EMM89.0        |

⚠️: SAMN26504547 and SAMN26504550 showed different results between emmtypingtool and emmtyper. Specifically, emmtypingtool did not report the subtype for SAMN26504547, reporting "73" instead of "73.7". emmtypingtool reported two subtypes "183.1/149.0" instead of "183.1" for SAMN26504550. The SAMN26504547 emmtypingtool BAM alignment showed a 3-bp deletion when aligned to emm73.7. This looks to be an artifact caused by emmtypingtool adding 100bp flanking sequences from a reference genome to the 180bp trimmed fragment. The added flanking sequences appear to have caused a change in alignment for a majority of the reads resulting in the 3 bp deletion at the 3' end of the 180 bp region. For SAMN26504550, the extra emm type 149.0 is a known emm-like gene (according to the source code for emmtyper), so this looks like 149.0 should have been excluded.

At least for this dataset, emmtyper seemed to be more accurate since it matched all of the expected emm types.

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->
I did not test TheiaProk_ONT_PHB workflow.

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [ ] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
