### PR TITLE
Add MPXV mutation context to Augur_PHB

### DIFF
--- a/tasks/phylogenetic_inference/augur/task_augur_mutation_context.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_mutation_context.wdl
@@ -1,0 +1,37 @@
+version 1.0
+
+task mutation_context {
+  input {
+    File refined_tree
+    File ancestral_nt_muts_json
+    String build_name
+    
+    Int cpu = 4
+    Int memory = 64
+    Int disk_size = 100
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/nextstrain-mpox-mutation-context:2024-06-27"
+  }
+  command <<<
+    # capture version information
+    
+
+    # run augur align
+    python3 /scripts/mutation_context.py \
+      --tree ~{refined_tree} \
+      --mutations ~{ancestral_nt_muts_json} \
+      --output "~{build_name}_mpox_mutation_context.json"
+  >>>
+  output {
+    File mutation_context_json = "~{build_name}_mpox_mutation_context.json"
+  }
+  runtime {
+    docker: docker
+    memory: memory + " GB"
+    cpu: cpu
+    disks: "local-disk " + disk_size + " LOCAL"
+    disk: disk_size + " GB" # TES
+    preemptible: 0
+    dx_instance_type: "mem3_ssd1_v2_x4"
+    maxRetries: 3
+  }
+}

--- a/tasks/phylogenetic_inference/augur/task_augur_mutation_context.wdl
+++ b/tasks/phylogenetic_inference/augur/task_augur_mutation_context.wdl
@@ -6,20 +6,22 @@ task mutation_context {
     File ancestral_nt_muts_json
     String build_name
     
-    Int cpu = 4
-    Int memory = 64
-    Int disk_size = 100
+    Int cpu = 1
+    Int memory = 4
+    Int disk_size = 50
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/nextstrain-mpox-mutation-context:2024-06-27"
   }
   command <<<
     # capture version information
     
-
-    # run augur align
+    echo "DEBUG: Running mutation_context.py script now..."
+    # run mutation_context.py script
     python3 /scripts/mutation_context.py \
       --tree ~{refined_tree} \
       --mutations ~{ancestral_nt_muts_json} \
       --output "~{build_name}_mpox_mutation_context.json"
+
+    echo "DEBUG: Finished running mutation_context.py script."
   >>>
   output {
     File mutation_context_json = "~{build_name}_mpox_mutation_context.json"
@@ -30,8 +32,7 @@ task mutation_context {
     cpu: cpu
     disks: "local-disk " + disk_size + " LOCAL"
     disk: disk_size + " GB" # TES
-    preemptible: 0
-    dx_instance_type: "mem3_ssd1_v2_x4"
+    preemptible: 1
     maxRetries: 3
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #499.

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->
This PR adds the mutation fraction of G->A or C->T changes to the **Augur_PHB** output `auspice_input_json` when the organism is `MPXV`. These mutations have been shown to be a characteristic of APOBEC3-type editing, which indicate adaptation of the virus to circulation among humans as was observed with the 2022 clade IIb outbreak, and more recently with the clade I outbreak in South Kivu, Democratic Republic of the Congo.

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: Yes, is organism is MPXV, there will be additional annotation in the auspice tree

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: new docker image created `us-docker.pkg.dev/general-theiagen/theiagen/nextstrain-mpox-mutation-context:2024-06-27`

Databases or database versions changed: No

Data processing/commands changed: Yes, a new task `task_augur_mutation_context.wdl` that computes the mutation fraction of G->A or C->T changes

File processing changed: Yes, addition of a new JSON file `mutation_context_json` to `augur_export` step in the Augur_PHB workflow

Compute resources changed: No

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

No inputs changed

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

No new outputs. However, the existing output `auspice_input_json` will have additional annotation in the JSON file when the organism is MPXV.

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->
The testing dataset comprised outbreak clade IIb B lineages, and an old single clade I sequence from 1985.

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->
Local testing initially tested that the script `https://github.com/nextstrain/mpox/blob/master/nextclade/scripts/mutation_context.py` works, given an input tree, mutations JSON file and an output file name.

This script was then added to a docker image: `us-docker.pkg.dev/general-theiagen/theiagen/nextstrain-mpox-mutation-context:2024-06-27`

The docker image was added to a new WDL task, `task_augur_mutation_context.wdl`, and worked as expected locally.

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

The updated Augur_PHB workflow was tested on the same dataset here:
Augur_Prep_PHB: https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/3b800707-4696-466f-af48-97d790999542
Augur_PHB: https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Otieno_Sandbox/job_history/2ec2d8da-6070-43d8-96bf-dd6f9fffd84c

The output `auspice_input_json` had the G->A or C->T fraction as expected.

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

Additional testing on the recent clade I MPXV from South Kivu would be great.

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [X] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [X] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [X] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [X] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [x] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [x] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [x] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [X] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
