### PR TITLE
[TheiaCoV and TheiaMeta] Update hrrt (ncbi-scrub) to version 2.2.1 and optimise task

### DIFF
--- a/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
@@ -7,7 +7,7 @@ task ncbi_scrub_pe {
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
-    Int memory = 8 
+    Int memory = 8
     Int cpu = 4
   }
   command <<<
@@ -57,7 +57,7 @@ task ncbi_scrub_pe {
       docker: "~{docker}"
       memory: memory + " GB"
       cpu: cpu
-      disks:  "local-disk " + disk_size + " SSD"
+      disks: "local-disk " + disk_size + " SSD"
       disk: disk_size + " GB" # TES
       preemptible: 0
       maxRetries: 3
@@ -70,7 +70,7 @@ task ncbi_scrub_se {
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
-    Int memory = 8 
+    Int memory = 8
     Int cpu = 4
   }
   command <<<
@@ -111,7 +111,7 @@ task ncbi_scrub_se {
     docker: "~{docker}"
     memory: memory + " GB"
     cpu: cpu
-    disks:  "local-disk " + disk_size + " SSD"
+    disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB" # TES
     preemptible: 0
     maxRetries: 0

--- a/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
@@ -17,6 +17,7 @@ task ncbi_scrub_pe {
     # detect compression and define cat command
     if [[ "~{read1}" == *.gz ]]
     then
+      echo "DEGUB: Gzipped input reads detected"
       cat_command="zcat"
     else
       cat_command="cat"
@@ -25,21 +26,26 @@ task ncbi_scrub_pe {
     # if compressed, unzip read files as scrub tool does not take in .gz fastq files, and interleave them
     # paste command takes 4 lines at a time and merges them into a single line with tabs
     # tr substitutes the tab separators from paste into new lines, effectively interleaving the reads and keeping the FASTQ format
+    echo "DEGUB: Interleaving reads..."
     paste <($cat_command ~{read1} | paste - - - -) <($cat_command ~{read2} | paste - - - -) | tr '\t' '\n' > interleaved.fastq
 
     # dehost reads
     # -x Remove spots instead of default 'N' replacement.
     # -s ; Input is (collated) interleaved paired-end(read) file AND you wish both reads masked or removed.
+    echo "DEGUB: Running HRRT..."
+    echo "DEBUG: /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -s -i interleaved.fastq"
+    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -s -i interleaved.fastq > STDOUT 2> STDERR
+
     # |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED ; capture the number of spots removed by fetching the first item on the last line of stderr
-    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -s -i interleaved.fastq |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
+    cat STDERR |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
 
     # split interleaved reads and compress files
     # paste takes 8 at a time and merges them into a single line with tabs
     # grouping each pair of reads into one line
+    echo "DEGUB: Splitting interleaved dehosted reads..."
     paste - - - - - - - - < interleaved.fastq.clean \
       | tee >(cut -f 1-4 | tr '\t' '\n' | gzip > ~{samplename}_R1_dehosted.fastq.gz) \
       | cut -f 5-8 | tr '\t' '\n' | gzip > ~{samplename}_R2_dehosted.fastq.gz
-      
   >>>
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
@@ -74,6 +80,8 @@ task ncbi_scrub_se {
     # unzip fwd file as scrub tool does not take in .gz fastq files
     if [[ "~{read1}" == *.gz ]]
     then
+      echo "DEGUB: Gzipped input reads detected"
+      echo "Unzipping reads to r1.fastq"
       gunzip -c ~{read1} > r1.fastq
       read1_unzip=r1.fastq
     else
@@ -83,9 +91,15 @@ task ncbi_scrub_se {
     # dehost reads
     # -x Remove spots instead of default 'N' replacement.
     # |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED ; capture the number of spots removed by fetching the first item on the last line of stderr
-    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -i ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
+    echo "DEGUB: Running HRRT..."
+    echo "DEBUG: /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -i ${read1_unzip}"
+    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -i ${read1_unzip} > STDOUT 2> STDERR
+    
+    #tail -n1 STDERR | awk -F" " '{print $1}' > SPOTS_REMOVED ; capture the number of spots removed by fetching the first item on the last line of stderr
+    tail -n1 STDERR | awk -F" " '{print $1}' > SPOTS_REMOVED
 
     # gzip dehosted reads
+    echo "DEGUB: Renaming dehosted reads..."
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
   >>>
   output {
@@ -100,6 +114,6 @@ task ncbi_scrub_se {
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB" # TES
     preemptible: 0
-    maxRetries: 3
+    maxRetries: 0
   }
 }

--- a/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
@@ -5,60 +5,53 @@ task ncbi_scrub_pe {
     File read1
     File read2
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:1.0.2021-05-05"
+    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
     Int memory = 8 
     Int cpu = 4
   }
-  String r1_filename = basename(read1)
-  String r2_filename = basename(read2)
   command <<<
     # date and version control
     date | tee DATE
 
-    # unzip fwd file as scrub tool does not take in .gz fastq files
+    # detect compression and define cat command
     if [[ "~{read1}" == *.gz ]]
     then
-      gunzip -c ~{read1} > r1.fastq
-      read1_unzip=r1.fastq
+      cat_command="zcat"
     else
-      read1_unzip=~{read1}
+      cat_command="cat"
     fi
 
-    # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
-
-    # gzip dehosted reads
-    gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
-
-    # do the same on read
-    # unzip file if necessary
-    if [[ "~{read2}" == *.gz ]]
-    then
-      gunzip -c ~{read2} > r2.fastq
-      read2_unzip=r2.fastq
-    else
-      read2_unzip=~{read2}
-    fi
+    # if compressed, unzip read files as scrub tool does not take in .gz fastq files, and interleave them
+    # paste command takes 4 lines at a time and merges them into a single line with tabs
+    # tr substitutes the tab separators from paste into new lines, effectively interleaving the reads and keeping the FASTQ format
+    paste <($cat_command ~{read1} | paste - - - -) <($cat_command ~{read2} | paste - - - -) | tr '\t' '\n' > interleaved.fastq
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read2_unzip} |& tail -n1 | awk -F" " '{print $1}' > REV_SPOTS_REMOVED
+    # -x Remove spots instead of default 'N' replacement.
+    # -s ; Input is (collated) interleaved paired-end(read) file AND you wish both reads masked or removed.
+    # |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED ; capture the number of spots removed by fetching the first item on the last line of stderr
+    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -s -i interleaved.fastq |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
 
-    # gzip dehosted reads
-    gzip ${read2_unzip}.clean -c > ~{samplename}_R2_dehosted.fastq.gz
+    # split interleaved reads and compress files
+    # paste takes 8 at a time and merges them into a single line with tabs
+    # grouping each pair of reads into one line
+    paste - - - - - - - - < interleaved.fastq.clean \
+      | tee >(cut -f 1-4 | tr '\t' '\n' | gzip > ~{samplename}_R1_dehosted.fastq.gz) \
+      | cut -f 5-8 | tr '\t' '\n' | gzip > ~{samplename}_R2_dehosted.fastq.gz
+      
   >>>
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
-    Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
-    Int read2_human_spots_removed = read_int("REV_SPOTS_REMOVED")
+    Int human_spots_removed = read_int("SPOTS_REMOVED")
     String ncbi_scrub_docker = docker
   }
   runtime {
       docker: "~{docker}"
       memory: memory + " GB"
       cpu: cpu
-      disks: "local-disk " + disk_size + " SSD"
+      disks:  "local-disk " + disk_size + " SSD"
       disk: disk_size + " GB" # TES
       preemptible: 0
       maxRetries: 3
@@ -69,12 +62,11 @@ task ncbi_scrub_se {
   input {
     File read1
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:1.0.2021-05-05"
+    String docker = "us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1"
     Int disk_size = 100
-    Int memory = 8
+    Int memory = 8 
     Int cpu = 4
   }
-  String r1_filename = basename(read1)
   command <<<
     # date and version control
     date | tee DATE
@@ -89,14 +81,16 @@ task ncbi_scrub_se {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
+    # -x Remove spots instead of default 'N' replacement.
+    # |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED ; capture the number of spots removed by fetching the first item on the last line of stderr
+    /opt/scrubber/scripts/scrub.sh -p ~{cpu} -x -i ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
   >>>
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
-    Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
+    Int read1_human_spots_removed = read_int("SPOTS_REMOVED")
     String ncbi_scrub_docker = docker
   }
   runtime {

--- a/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
@@ -90,7 +90,7 @@ task ncbi_scrub_se {
   >>>
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
-    Int read1_human_spots_removed = read_int("SPOTS_REMOVED")
+    Int human_spots_removed = read_int("SPOTS_REMOVED")
     String ncbi_scrub_docker = docker
   }
   runtime {

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -22,7 +22,7 @@
     - path: miniwdl_run/call-raw_check_reads/task.log
     # trimmomatic
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/command
-      md5sum: 5fede8253d813dc0f99cce1acf161e93
+      md5sum: 20b54af347f1644c099dace802097293
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/inputs.json
       contains: ["read1", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/outputs.json
@@ -34,7 +34,7 @@
       contains: ["wdl", "illumina_se", "trimmomatic", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/work/ERR6319327.trim.stats.txt
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/work/_miniwdl_inputs/0/ERR6319327.fastq.gz
+    - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_se/work/_miniwdl_inputs/0/ERR6319327_R1_dehosted.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # bbduk
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/command
@@ -49,9 +49,9 @@
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/task.log
       contains: ["wdl", "illumina_se", "bbduk", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/work/ERR6319327.adapters.stats.txt
-      md5sum: 28b77243d6e4894c0ed310fc79feb177
+      md5sum: fe785824715a0c03f0dd64464e936b3d
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/work/ERR6319327.phix.stats.txt
-      md5sum: 0547b66c417517f910a50d9dce20973f
+      md5sum: 3fa3fb32416589385197c7a384ebdade
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/work/_miniwdl_inputs/0/ERR6319327_trimmed.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # fastq scan raw
@@ -85,14 +85,14 @@
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/task.log
       contains: ["wdl", "theiacov_illumina_se", "kraken2_raw", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_HUMAN
-      md5sum: 1576d5d341223ea9d44b0b8a213bb9da
+      md5sum: 4fd4dcef994592f9865e9bc8807f32f4
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_SC2
-      md5sum: f850a30d512dad859b6618164dd27031
+      md5sum: 73f7f6bf2257905cb4bee12d23247db3
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_TARGET_ORGANISM
       md5sum: 68b329da9893e34099c7d8ad5cb9c940
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/ERR6319327_kraken2_report.txt
-      md5sum: 7e4fc05efbbc3937b99420e6193be061
+      md5sum: 3d1bab1c5040916642df5baf20a2d6bd
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command
       md5sum: aec6c57452ddff84c325601a780605d2
@@ -131,9 +131,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-bwa/task.log
       contains: ["wdl", "illumina_se", "bwa", "done"]
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/ERR6319327.sorted.bam
-      md5sum: f3c321b2400607dae1bfd5af670f1440
+      md5sum: 0db7c2f7d36144260d6d61f71a2e3cec
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/ERR6319327.sorted.bam.bai
-      md5sum: 1d83092dca706321a70dd36c68807947
+      md5sum: d6d6a9d40f5e2dbc950d43b7593b6964
     - path: miniwdl_run/call-ivar_consensus/call-bwa/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # primer trim
@@ -153,9 +153,9 @@
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/PRIMER_NAME
       md5sum: 3ca99445df901950128cddd3e58d2c52
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/ERR6319327.primertrim.sorted.bam
-      md5sum: 56261e6657e54e1f3cfddd8d1f4d18cc
+      md5sum: 8659490b5bdd979f6420e262cdf3fd62
     - path: miniwdl_run/call-ivar_consensus/call-primer_trim/work/ERR6319327.primertrim.sorted.bam.bai
-      md5sum: ca4ceda7d146a8c2f0370cdbaca1091b
+      md5sum: 603c3cbc771ca910b96d3c032aafe7c9
     # stats n coverage primer trim
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/command
       md5sum: 67cac223adcf059a9dfaa9f28ed34f68
@@ -171,7 +171,7 @@
       md5sum: 57fbf095f19301883daf6c3513ebd2cd
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/DATE
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/DEPTH
-      md5sum: 82edf3a9fe3e9f6edb80ef3f5354b50a
+      md5sum: dbb45be13238542f411e0ba9d9dd650d
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/MEANBASEQ
       md5sum: 88606514c85e100c88b651460a8a6ca9
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/MEANMAPQ
@@ -179,13 +179,13 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/VERSION
       md5sum: 53be85d2ed9fa57ab45424fe071a6672
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/ERR6319327.cov.hist
-      md5sum: cc9ca09387ba45fd16ff15d9e2c89a59
+      md5sum: fd940935d77c03ca847618f640d91ba7
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/ERR6319327.cov.txt
-      md5sum: f1d0d4e1f0045559ce3f1b92a5fee0d6
+      md5sum: a7d09443e6b8a36476806a4fd0e78934
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/ERR6319327.flagstat.txt
-      md5sum: 73655e1cd55ac494fc5760479a339683
+      md5sum: 381332ecf3fb35300e74bda452016c27
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/ERR6319327.stats.txt
-      md5sum: 5655fc8c00e63f49c199e71602bd4e86
+      md5sum: 30880250632e237b82f91ea2ac44b1a6
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
@@ -254,15 +254,15 @@
       md5sum: 57fbf095f19301883daf6c3513ebd2cd
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/DATE
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/DEPTH
-      md5sum: 9558b19c41aaf462ab3b4604d6c6b3c8
+      md5sum: 3c5e45185355d17912214234a62f98de
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/ERR6319327.cov.hist
-      md5sum: 24b9cd6eba15f35e2d5dff8c4891d960
+      md5sum: de831ef19ccda1402f28832025febde2
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/ERR6319327.cov.txt
-      md5sum: b43cc4c708564c641f5c30e6548461d0
+      md5sum: b9c533364a149cc55cad3c1195ebf4f8
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/ERR6319327.flagstat.txt
-      md5sum: 607170bcd36b984168eea6b6a9d9cd37
+      md5sum: 5eba111bff16b151b9a498c1a539d14d
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/ERR6319327.stats.txt
-      md5sum: 98575983ceb693e31fe8692f461859df
+      md5sum: e5ed401d9f60b1c0fe8b3ca4f49a60bd
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/MEANBASEQ
       md5sum: 88606514c85e100c88b651460a8a6ca9
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage/work/MEANMAPQ

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -600,6 +600,6 @@
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: 43367523b9140ca0d2ac15869046343c
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: 963090bb29184f61c7025e2bc487de4b
+      md5sum: a28fda3c3d806eb005e8a4e6cdf7b71b
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -157,8 +157,7 @@ workflow read_QC_trim_pe {
     # NCBI scrubber
     File? read1_dehosted = ncbi_scrub_pe.read1_dehosted
     File? read2_dehosted = ncbi_scrub_pe.read2_dehosted
-    Int? read1_human_spots_removed = ncbi_scrub_pe.read1_human_spots_removed
-    Int? read2_human_spots_removed = ncbi_scrub_pe.read2_human_spots_removed
+    Int? ncbi_scrub_human_spots_removed = ncbi_scrub_pe.human_spots_removed
     String? ncbi_scrub_docker = ncbi_scrub_pe.ncbi_scrub_docker
 
     # bbduk

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -5,6 +5,7 @@ import "../../tasks/quality_control/basic_statistics/task_fastqc.wdl" as fastqc_
 import "../../tasks/quality_control/read_filtering/task_bbduk.wdl" as bbduk_task
 import "../../tasks/quality_control/read_filtering/task_fastp.wdl" as fastp_task
 import "../../tasks/quality_control/read_filtering/task_trimmomatic.wdl" as trimmomatic
+import "../../tasks/quality_control/read_filtering/task_ncbi_scrub.wdl" as ncbi_scrub
 import "../../tasks/taxon_id/contamination/task_kraken2.wdl" as kraken
 import "../../tasks/taxon_id/contamination/task_midas.wdl" as midas_task
 
@@ -35,11 +36,20 @@ workflow read_QC_trim_se {
     String read_qc = "fastq_scan" # options: fastq_scan, fastqc
     String fastp_args = "-g -5 20 -3 20"
   }
+
+  if (("~{workflow_series}" == "theiacov") || ("~{workflow_series}" == "theiameta")) {
+    call ncbi_scrub.ncbi_scrub_se {
+      input:
+        samplename = samplename,
+        read1 = read1
+    }
+  }
+
   if (read_processing == "trimmomatic") {
     call trimmomatic.trimmomatic_se {
       input:
         samplename = samplename,
-        read1 = read1,
+        read1 = select_first([ncbi_scrub_se.read1_dehosted, read1]),
         trimmomatic_min_length = trim_min_length,
         trimmomatic_quality_trim_score = trim_quality_min_score,
         trimmomatic_window_size = trim_window_size,
@@ -50,7 +60,7 @@ workflow read_QC_trim_se {
     call fastp_task.fastp_se {
       input:
         samplename = samplename,
-        read1 = read1,
+        read1 = select_first([ncbi_scrub_se.read1_dehosted, read1]),
         fastp_window_size = trim_window_size,
         fastp_quality_trim_score = trim_quality_min_score,
         fastp_min_length = trim_min_length,
@@ -119,6 +129,11 @@ workflow read_QC_trim_se {
     }
   }
   output {
+    # NCBI scrubber
+    File? read1_dehosted = ncbi_scrub_se.read1_dehosted
+    Int? ncbi_scrub_human_spots_removed = ncbi_scrub_se.human_spots_removed
+    String? ncbi_scrub_docker = ncbi_scrub_se.ncbi_scrub_docker
+
     # bbduk
     File read1_clean = bbduk_se.read1_clean
     String bbduk_docker = bbduk_se.bbduk_docker


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #127 and #528

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

~~Current work in progress! Will update soon!~~

This PR updates [HRRT](https://github.com/ncbi/sra-human-scrubber) (also known as ncbi-scrub) to the **latest stable version v2.2.1**.

This update aims to correct a few issues:
- The paired-information was not being kept with the current processing
- The reads were being masked with 'N' instead of removed, which could save a lot of compute resources downstream

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

The following editions were done to the `ncbi_scrub` task:
- docker has been updated to `us-docker.pkg.dev/general-theiagen/ncbi/sra-human-scrubber:2.2.1`
- In the `ncbi_scrub_pe` task,  the reads are now interleaved before processing with HRRT
- In the `ncbi_scrub_pe` task, the option to remove spots instead of replacing them with 'N' is explicitly passed
- In the `ncbi_scrub_pe` task, the option to mask both pairs and keep interleaved information is explicitly passed
- In the `ncbi_scrub_se` task, the option to remove spots instead of replacing them with 'N' is explicitly passed

These updates are reflected on the following workflows:
- TheiaCoV_Illumina_PE
- TheiaCoV_ClearLabs
- TheiaCoV_ONT
- TheiaMeta_Illumina_PE

Additionally, the scrubbing task has been added to the following workflows for read-processing standardization:
- TheiaCoV_Illumina_SE

Note: https://github.com/ncbi/sra-human-scrubber/issues/30 clarifies the usability of HRRT on ONT data.

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: Yes

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: No 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed:  `sra-human-scrubber:1.0.2021-05-05` -> `sra-human-scrubber:2.2.1`

Databases or database versions changed: N/A

Data processing/commands changed: Added logic to interleave and split the reads with paste

File processing changed: Enabled read-scrubbing on TheiaCoV_Illumina_SE workflows, which impacts results downstream

Compute resources changed: N/A but maybe it's a good opportunity to do so

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

Nothing has changed

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

Nothing has changed

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

Mock Illumina PE data was generated for each TheiaCoV target organism with [ART](https://www.niehs.nih.gov/research/resources/software/biostatistics/art):
- flu: GCF_000865085
- hiv: NC_001722
- mpxv: NC_063383
- rsva: NC_001803
- sc2: NC_045512
- wnv: NC_001563

Additionally, the same was done for a human reference:
- human: GCF_000001405

The Illumina sequences are available at gs://benchmark_data_theiagen/Illumina/human_viral_mix_1000reads and gs://benchmark_data_theiagen/Illumina/human_viral_mix

Mixed Viral and Human ONT sequences are available at gs://benchmark_data_theiagen/ONT/mix_human_viral

#### Evaluation of interleaving FASTQ file

Using SC2 as a test case:

```
miniwdl run --task ncbi_scrub_pe task_ncbi_scrub.wdl read1= sc2_1000_1.fq.gz read2= sc2_1000_2.fq.gz samplename="sc2"
```

Interleaved read file:
![image](https://github.com/user-attachments/assets/3f70c077-7419-4b9c-b0b4-4fc8482056c0)
- Reads are correctly paired, wich each `/1` read being followed by the same id with `/2`

Split read files:
![image](https://github.com/user-attachments/assets/e8194370-f961-4f51-b60e-80ad166bb8bc)
![image](https://github.com/user-attachments/assets/9bd0b4aa-0b68-43e2-9753-fe523531ae1a)
- Resulting file contain only forward reads in the first file, and only reverse reads in the second file


**Edge case scenario:** In the `read_screen` process, we allow reads that have a slight mismatch on the number of lines between forward and reverse reads to pass. This could cause paste command to append singletons to the interleaved file at the bottom separated by newlines. 

```
    paste <($cat_command ~{read1} | paste - - - -) <($cat_command ~{read2} | paste - - - -) | awk '{if (NF == 8) print $1"\n"$2"\n"$3"\n"$4"\n"$5"\n"$6"\n"$7"\n"$8}' | tr '\t' '\n' > interleaved.fastq
```
![image](https://github.com/user-attachments/assets/bf713a45-701f-4c16-a9b3-fe1a45525ca8)
To avoid this, the interleaving block only prints a read pair (a block of 8 columns, 4 belonging to each read) if all fields have content (this is accomplished by using awk).  

By discarding these reads, we ensure that the splitting command works as expected and reads don't get mixed up in the final files.

```
paste - - - - - - - - < interleaved.fastq.clean \
      | tee >(cut -f 1-4 | tr '\t' '\n' | gzip > ~{samplename}_R1_dehosted.fastq.gz) \
      | cut -f 5-8 | tr '\t' '\n' | gzip > ~{samplename}_R2_dehosted.fastq.gz
```

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

For each read-pair, the following command was run
```
miniwdl run --task ncbi_scrub_pe task_ncbi_scrub.wdl read1= <forward_read> read2= <reverse_read> samplename="<sample_name>"
```

| Sample | reference used | spots removed |
|---|---|---|
| flu | GCF_000865085 | 0 |
| hiv | NC_001722 | 0 |
| human | GCF_000001405 | 693504 |
| mpxv | NC_063383 | 0 |
| rsva | NC_001803 | 0 |
| sc2 | NC_045512 | 0 |
| wnv | NC_001563 | 0 |

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

- TheiaCoV Illumina PE:
  - ✅ 9 in silicon reads mixed with human for several taxa:  https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/43837945-6202-444b-ad9e-6e60dcd23477
- TheiaCoV Illumina SE:
  - ✅ 34 samples belonging to the Validation dataset: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/dfa92755-77cc-44ff-9556-a197e9dade44
- TheiaCoV ONT:
  - ✅ 9 mock ONT samples containing both viral and human reads (50% mixture) for several taxa: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/34480674-63f8-4ac8-a91d-1ffb2af565a4
- TheiaCoV ClearLabs:
  - ✅ 25 SC2 samples from Validation workspace: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/347b0b33-ad77-4cda-b008-a0481003a86f
- TheiaMeta Illumina PE:
  - ✅ 10 metagenomic samples collected from various human sources: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/4a930c75-2500-457f-aee1-3e2b4da67f23

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

#### Theiagen Version Release Testing (optional)
<!-- 
-Will changes require functional or validation testing (checking outputs etc) during the release?
-Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
-Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [ ] All code adheres to the style guide
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [ ] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
