### PR TITLE
[theiaprok] amrfinderplus: add support for Vibrio parahaemolyticus, Vibrio vulnificus, Enterobacter asburiae. Fix C diff bug

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -67,9 +67,9 @@ If local testing was not undertaken/possible, please explicitly state this.-->
 
 #### Theiagen Version Release Testing (optional)
 <!-- 
--Will changes require functional or validation testing (checking outputs etc) during the release?
--Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
--Are there any output files that should be checked after running the version release testing?
+- Will changes require functional or validation testing (checking outputs etc) during the release?
+- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
+- Are there any output files that should be checked after running the version release testing?
 -->
 
 ## :microscope: Final Developer Checklist

--- a/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
@@ -29,7 +29,7 @@ task amrfinderplus_nuc {
     ## create associative array
     declare -A organisms=( ["Acinetobacter baumannii"]="Acinetobacter_baumannii" ["Burkholderia cepacia"]="Burkholderia_cepacia" \
       ["Burkholderia pseudomallei"]="Burkholderia_pseudomallei" ["Campylobacter coli"]="Campylobacter" ["Campylobacter jejuni"]="Campylobacter" \
-      ["Citrobacter freundii"]="Citrobacter_freundii" ["Clostridioides _difficile"]="Clostridioides_difficile" ["Enterobacter cloacae"]="Enterobacter_cloacae" \
+      ["Citrobacter freundii"]="Citrobacter_freundii" ["Clostridioides difficile"]="Clostridioides_difficile" ["Enterobacter asburiae"]="Enterobacter_asburiae" ["Enterobacter cloacae"]="Enterobacter_cloacae" \
       ["Enterococcus faecalis"]="Enterococcus_faecalis" ["Enterococcus hirae"]="Enterococcus_faecium" ["Enterococcusfaecium"]="Enterococcus_faecium" \
       [*"Escherichia"*]="Escherichia" [*"Shigella"*]="Escherichia" ["Klebsiella aerogenes"]="Klebsiella_pneumoniae" ["Klebsiella pneumoniae"]="Klebsiella_pneumoniae" \
       ["Klebsiella variicola"]="Klebsiella_pneumoniae" ["Klebsiella oxytoca"]="Klebsiella_oxytoca" ["Neisseria gonorrhea"]="Neisseria_gonorrhoeae" \
@@ -37,7 +37,7 @@ task amrfinderplus_nuc {
       [*"Salmonella"*]="Salmonella" ["Serratia marcescens"]="Serratia_marcescens" ["Staphylococcus aureus"]="Staphylococcus_aureus" \
       ["Staphylococcus pseudintermedius"]="Staphylococcus_pseudintermedius" ["Streptococcus agalactiae"]="Streptococcus_agalactiae" \
       ["Streptococcus pneumoniae"]="Streptococcus_pneumoniae" ["Streptococcus mitis"]="Streptococcus_pneumoniae" \
-      ["Streptococcus pyogenes"]="Streptococcus_pyogenes" ["Vibrio cholerae"]="Vibrio_cholerae"
+      ["Streptococcus pyogenes"]="Streptococcus_pyogenes" ["Vibrio cholerae"]="Vibrio_cholerae" ["Vibrio parahaemolyticus"]="Vibrio_parahaemolyticus" ["Vibrio vulnificus"]="Vibrio_vulnificus"
       )
 
     for key in "${!organisms[@]}"; do
@@ -49,7 +49,7 @@ task amrfinderplus_nuc {
     done
 
     # checking bash variable
-    echo "amrfinder_organism is set to: " ${amrfinder_organism}
+    echo "amrfinder_organism is set to: ${amrfinder_organism}"
     
     # if amrfinder_organism variable is set, use --organism flag, otherwise do not use --organism flag
     if [[ -v amrfinder_organism ]] ; then

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -17,7 +17,7 @@
     - wf_theiaprok_illumina_pe_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: 6c2c570754a616e7ac032109d8ffe71c
+      md5sum: 949298123cab12a6921a378abfc90cd6
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json
@@ -551,7 +551,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_abricate.wdl
       md5sum: 0a8e80d9c835a712936eac2cc6e3a05d
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
-      md5sum: 654c31055b807b3cd2aee9d5ceeea766
+      md5sum: 02e5699f8d4fa6e6c3591a829e8441e5
     - path: miniwdl_run/wdl/tasks/gene_typing/annotation/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/plasmid_detection/task_plasmidfinder.wdl

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -17,7 +17,7 @@
     - wf_theiaprok_illumina_se_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: 6c2c570754a616e7ac032109d8ffe71c
+      md5sum: 949298123cab12a6921a378abfc90cd6
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json
@@ -516,7 +516,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_abricate.wdl
       md5sum: 0a8e80d9c835a712936eac2cc6e3a05d
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
-      md5sum: 654c31055b807b3cd2aee9d5ceeea766
+      md5sum: 02e5699f8d4fa6e6c3591a829e8441e5
     - path: miniwdl_run/wdl/tasks/gene_typing/annotation/task_bakta.wdl
       md5sum: 0bed8fb60786095843a67b1ad03051dc
     - path: miniwdl_run/wdl/tasks/gene_typing/plasmid_detection/task_plasmidfinder.wdl


### PR DESCRIPTION
This PR closes #129 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Aim, Context and Functionality

This PR adds support for using the `amrfinder --organism <organism_name>` option for 3 new organisms (Vv, Vp, and Enterobacter asburiae) and corrects a typo for C. diff.

These are organisms that were recently added to NCBI AMRFinderPlus' list of supported organisms that have taxon-specific point mutations or other organism-specific handling of annotation: https://github.com/ncbi/amr/wiki/Running-AMRFinderPlus#--organism-option

When users analyze these samples via the TheiaProk workflows (or the standalone amrfinderplus workflow), AMRFinderPlus will now use the `--organism` flag and be able to detect organism-specific point mutations.

The usage of the `amrfinder --organism` option depends on GAMBIT accurately predicting the genus and species correctly, but the user also has the ability to override GAMBIT's results for `gambit_predicted_taxon` by manually entering an optional String input `expected_taxon` for the various theiaprok workflows.

⚠️ This manual override is currently required for C. diff as GAMBIT with the 1.3.0 database does not have the ability to predict `Clostridioides difficile` as it is not included in the database (AFAIK)

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made

This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: **No** 

### Workflows impacted:

- theiaprok_illumina_pe
- theiaprok_illumina_se
- theiaprok_ONT
- theiaprok_FASTA
- NCBI-AMRFinderPlus standalone wf

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

Docker/software or software versions changed: **N/A**

Databases or database versions changed: **N/A**

Data processing/commands changed: added use of `--organism` flag for 3 organism, fixed for 1 (C. diff)

File processing changed: **N/A**

Compute resources changed: **N/A**

#### ➡️ Inputs 

**N/A**

#### ⬅️ Outputs 

Outputs **may** now include organism-specific point mutations if detected by amrfinderplus.

## :test_tube: Testing 
#### Test Dataset

I tested with either assemblies or Illumina PE datasets for samples that are known to have organism-specific point mutations as reported by NCBI pathogen detection browser.

I also tested with my full amrfinderplus testing dataset that includes diverse taxa, most of which have organism-specific point mutations/acquired genes, to ensure functionality is not lost for these datasets.

#### Commandline Testing with MiniWDL or Cromwell (optional)

Tested the amrfinderplus task successfully on the command line, but not including output here.

#### Terra Testing

Will add tests once they are complete

- ILMN PE - 2 C. diff; manually set `expected_taxon` to `"Clostridioides difficile"`: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/93ab7fc4-a36f-4e45-9116-4ae329c9851b
  - ✅ "Clostridioides difficile" correctly utilized and point mutations identified
- FASTA - Vv, Vp, and E. asburiae, relying upon GAMBIT: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/e3bf8d7f-d8ff-4af5-b570-5d4b8a8d0fb6
  - ✅ E. asburiae correctly utilized and point mutation identified
  - ✅ V parahaemolyticus correctly utilitized and point mutations identified
  - ✅ V vulnificus correctly utilized and point mutations identified
- ILMN PE - test on diverse set of organisms (non-Vv, Vp, E. asburiae, and C. diff), again relying upon GAMBIT task output `gambit_predicted_taxon`: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/2047b9eb-301e-4ece-b9b3-2395c38305ef
  - ~~⚠️ Need to review outputs~~
  - ✅ other organisms are unaffected, the workflow still uses their gambit_predicted_taxon outputs as input into amrfinderplus task, and the `--organism` flag is used correctly

#### Suggested Scenarios for Reviewer to Test

Test any of the TheiaProk workflows with data from these organisms, or others, to ensure new functionality is working as intended and other organisms are unimpacted by this change

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **No**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **We could add the datasets that I've tested with to the validation datasets, though it's not critically important to do.**
- Are there any output files that should be checked after running the version release testing? **No**


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [x] Workflow diagrams have been updated to reflect changes
