### PR TITLE
[TheiaProk] Merlin_magic subwf bugfix: run virulencefinder on Shigella sonnei

### DIFF
--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -635,7 +635,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: 646e726beb68fc61f84a428bf2fb7244
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 43367523b9140ca0d2ac15869046343c
+      md5sum: fb891a62a0629bcbc1158276b2622b95
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 347c054f9850e885e6a130d1655765d7
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 43367523b9140ca0d2ac15869046343c
+      md5sum: fb891a62a0629bcbc1158276b2622b95
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 963090bb29184f61c7025e2bc487de4b
     - path: miniwdl_run/workflow.log

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -119,7 +119,10 @@ workflow merlin_magic {
     }
   }
   if (merlin_tag == "Escherichia" || merlin_tag == "Shigella sonnei" ) {
-    # tools specific to all Escherichia and Shigella species
+    # tools specific to ALL Escherichia and Shigella species
+    #
+    # FYI see the GAMBIT task for all merlin_tag designations but all Escherichia and Shigella species are given "Escherichia" merlin_tag designation, except for Shigella sonnei which is given "Shigella sonnei" merlin_tag.
+    # The reason being is that S. sonnei does have a species-specific tool (sonneityping) where the other Shigella species do not (flexneri, dysenteriae, boydii, etc.)
     call serotypefinder_task.serotypefinder {
       input:
         assembly = assembly,
@@ -156,9 +159,6 @@ workflow merlin_magic {
           paired_end = paired_end
       }
     }
-  }
-  if (merlin_tag == "Escherichia" ) {
-    # E coli specific tasks
     call virulencefinder_task.virulencefinder {
       input:
       #  read1 = read1,


### PR DESCRIPTION
This PR closes #273 

🗑️ This dev branch should  be deleted after merging to main.

## :brain: Aim, Context and Functionality

This PR resolves a minor bug described in https://github.com/theiagen/public_health_bioinformatics/issues/273

The code change allows for Shigella sonnei samples to also be run through the virulencefinder task. Previously they were excluded due to the conditionals in the merlin_magic subworkflow.

With this change, all Shigella sonnei samples will be run through virulencefinder (along with all E. coli and other non-sonnei Shigella species like flexneri, dysenteriae, boydii)

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: **Yes, slightly for S sonnei samples**

Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing: **No** 

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 

No changes to way data is processed.

Docker/software or software versions changed: **N/A**

Databases or database versions changed: **N/A**

Data processing/commands changed: **N/A**

File processing changed: **N/A**

Compute resources changed: **N/A**

#### ➡️ Inputs 

**N/A**

#### ⬅️ Outputs 

**N/A**

## :test_tube: Testing 
#### Test Dataset

I tested with Shigella sonnei, Shigella flexneri, E. coli, and Salmonella samples (all have correct/expected `gambit_predicted_taxon` results)

#### Commandline Testing with MiniWDL or Cromwell (optional)

Ran one S. sonnei samples successfully via theiaprok_illumina_pe workflow using miniwdl, but not showing output here.

#### Terra Testing

- A few Salmonella through theiaprok_illumina_PE: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/9bfdda2a-b4be-4f98-aa90-e879bdfc903a
  - ✅ samples were unimpacted, merlin_magic tasks ran as expected
- A few E. coli, S. flexneri, and S. sonnei samples through theiaprok_Illumina_PE: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/ea701260-8f78-4e56-b929-5fcbfb09f1f0
  - ✅ S. sonnei samples are now run through virulencefinder, as expected with the feature add
  - ✅ E. coli & S. flexneri samples were also run through virulencefinder as expected (it ran previously but was not cached, likely due to merlin_magic subwf code changing slightly)


#### Suggested Scenarios for Reviewer to Test

Test at least one Shigella sonnei sample

#### Theiagen Version Release Testing (optional)

- Will changes require functional or validation testing (checking outputs etc) during the release? **No**
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen. **No**
- Are there any output files that should be checked after running the version release testing? **No**


## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [x] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated. **No docs or workflow diagram update required**
- [x] Workflow diagrams have been updated to reflect changes
