### PR TITLE
[Freyja] - Update to version v1.5.1 and make it compatible with ILMN PE, ILMN SE and ONT

### DIFF
--- a/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
+++ b/tasks/quality_control/read_filtering/task_ncbi_scrub.wdl
@@ -27,6 +27,9 @@ task ncbi_scrub_pe {
     read1_count=$($cat_command ~{read1} | wc -l | awk '{print $1/4}')
     read2_count=$($cat_command ~{read2} | wc -l | awk '{print $1/4}')
 
+    echo "DEBUG: Number of files in read1: $read1_count"
+    echo "DEBUG: Number of files in read2: $read2_count"
+
     if [[ $read1_count -ne $read2_count ]]
     then
       echo "ERROR: The number of reads in the two input files do not match."
@@ -38,9 +41,8 @@ task ncbi_scrub_pe {
     # paste command takes 4 lines at a time and merges them into a single line with tabs
     # tr substitutes the tab separators from paste into new lines, effectively interleaving the reads and keeping the FASTQ format
     # Important: To ensure that the reads are interleaved correctly, the reads must be in the same order in both files
-    # Additionally, only print read pairs that have 8 fields (4 lines) to avoid interleaving unpaired reads
     echo "DEGUB: Interleaving reads with paste..."
-    paste <($cat_command ~{read1} | paste - - - -) <($cat_command ~{read2} | paste - - - -) | awk '{if (NF == 8) print $1"\n"$2"\n"$3"\n"$4"\n"$5"\n"$6"\n"$7"\n"$8}' | tr '\t' '\n' > interleaved.fastq
+    paste <($cat_command ~{read1} | paste - - - -) <($cat_command ~{read2} | paste - - - -) | tr '\t' '\n' > interleaved.fastq
 
     # dehost reads
     # -x Remove spots instead of default 'N' replacement.

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -14,7 +14,7 @@ task freyja_one_sample {
     Boolean bootstrap = false
     Int? number_bootstraps
     Int? depth_cutoff
-    Int memory = 4
+    Int memory = 8
     Int cpu = 2
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-07-22"
     Int disk_size = 100

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -8,6 +8,7 @@ task freyja_one_sample {
     File? freyja_usher_barcodes
     File? freyja_lineage_metadata
     Float? eps
+    Float? adapt
     Boolean update_db = false
     Boolean confirmed_only = false
     Boolean bootstrap = false
@@ -93,6 +94,7 @@ task freyja_one_sample {
     ~{'--barcodes ' + freyja_usher_barcodes} \
     ~{'--depthcutoff ' + depth_cutoff} \
     ~{true='--confirmedonly' false='' confirmed_only} \
+    ~{'--adapt ' + adapt} \
     ~{samplename}_freyja_variants.tsv \
     ~{samplename}_freyja_depths.tsv \
     --output ~{samplename}_freyja_demixed.tmp

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -45,7 +45,7 @@ task freyja_one_sample {
   else
     # configure barcode    
     if [[ ! -z "~{freyja_usher_barcodes}" ]]; then
-      echo "User freyja usher barcodes identified; ~{freyja_usher_barcodes} will be utilized fre freyja demixing"
+      echo "User freyja usher barcodes identified; ~{freyja_usher_barcodes} will be utilized for freyja demixing"
       freyja_usher_barcode_version=$(basename -- "~{freyja_usher_barcodes}")
     else
       freyja_usher_barcode_version="unmodified from freyja container: ~{docker}"  

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -103,8 +103,8 @@ task freyja_one_sample {
   echo -e "\t/~{samplename}" > ~{samplename}_freyja_demixed.tsv
   tail -n+2 ~{samplename}_freyja_demixed.tmp >> ~{samplename}_freyja_demixed.tsv
 
-  if [ -f opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.csv ]; then
-    mv opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.csv usher_barcodes.csv
+  if [ -f /opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.feather ]; then
+    mv /opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.feather usher_barcodes.feather
   fi
 
   if [ -f /opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/curated_lineages.json ]; then
@@ -144,8 +144,8 @@ task freyja_one_sample {
     File? freyja_bootstrap_summary = "~{samplename}_summarized.csv"
     File? freyja_bootstrap_summary_pdf = "~{samplename}_summarized.pdf"
     # capture barcode file - first is user supplied, second appears if the user did not supply a barcode file
-    File freyja_usher_barcode_file = select_first([freyja_usher_barcodes, "usher_barcodes.csv"])
-    File freyja_lineage_metadata_file = select_first([freyja_lineage_metadata, "lineage_metadata.json"])
+    File freyja_usher_barcode_file = select_first([freyja_usher_barcodes, "usher_barcodes.feather"])
+    File freyja_lineage_metadata_file = select_first([freyja_lineage_metadata, "curated_lineages.json"])
     String freyja_barcode_version = read_string("FREYJA_BARCODES")
     String freyja_metadata_version = read_string("FREYJA_METADATA")
     String freyja_version = read_string("FREYJA_VERSION")

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -103,8 +103,12 @@ task freyja_one_sample {
   echo -e "\t/~{samplename}" > ~{samplename}_freyja_demixed.tsv
   tail -n+2 ~{samplename}_freyja_demixed.tmp >> ~{samplename}_freyja_demixed.tsv
 
-  if [ -f /opt/conda/envs/freyja-env/lib/python3.10/site-packages/freyja/data/usher_barcodes.csv ]; then
-    mv /opt/conda/envs/freyja-env/lib/python3.10/site-packages/freyja/data/usher_barcodes.csv usher_barcodes.csv
+  if [ -f opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.csv ]; then
+    mv opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/usher_barcodes.csv usher_barcodes.csv
+  fi
+
+  if [ -f /opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/curated_lineages.json ]; then
+    mv /opt/conda/envs/freyja-env/lib/python3.12/site-packages/freyja/data/curated_lineages.json curated_lineages.json
   fi
   
   #Output QC values to the Terra data table
@@ -140,7 +144,8 @@ task freyja_one_sample {
     File? freyja_bootstrap_summary = "~{samplename}_summarized.csv"
     File? freyja_bootstrap_summary_pdf = "~{samplename}_summarized.pdf"
     # capture barcode file - first is user supplied, second appears if the user did not supply a barcode file
-    File freyja_barcode_file = select_first([freyja_usher_barcodes, "usher_barcodes.csv"])
+    File freyja_usher_barcode_file = select_first([freyja_usher_barcodes, "usher_barcodes.csv"])
+    File freyja_lineage_metadata_file = select_first([freyja_lineage_metadata, "lineage_metadata.json"])
     String freyja_barcode_version = read_string("FREYJA_BARCODES")
     String freyja_metadata_version = read_string("FREYJA_METADATA")
     String freyja_version = read_string("FREYJA_VERSION")

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -15,7 +15,7 @@ task freyja_one_sample {
     Int? depth_cutoff
     Int memory = 4
     Int cpu = 2
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.4.8"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-07-22"
     Int disk_size = 100
   }
   command <<<

--- a/tasks/taxon_id/freyja/task_freyja_dashboard.wdl
+++ b/tasks/taxon_id/freyja/task_freyja_dashboard.wdl
@@ -13,7 +13,7 @@ task freyja_dashboard_task {
     Boolean scale_by_viral_load = false
     String freyja_dashboard_title
     File? dashboard_intro_text
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.4.8"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-07-22"
     Int disk_size = 100
     Int memory = 4
     Int cpu = 2

--- a/tasks/taxon_id/freyja/task_freyja_plot.wdl
+++ b/tasks/taxon_id/freyja/task_freyja_plot.wdl
@@ -10,7 +10,7 @@ task freyja_plot_task {
     String plot_time_interval="MS"
     Int plot_day_window=14
     String freyja_plot_name
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.4.8"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-07-22"
     Int disk_size = 100
     Int mincov = 60
     Int memory = 4

--- a/tasks/taxon_id/freyja/task_freyja_update.wdl
+++ b/tasks/taxon_id/freyja/task_freyja_update.wdl
@@ -26,7 +26,7 @@ task freyja_update_refs {
     disk: disk_size + " GB" # TES
   }
   output {
-    File updated_barcodes = "freyja_update_refs/usher_barcodes.csv"
+    File updated_barcodes = "freyja_update_refs/usher_barcodes.feather"
     File updated_lineages = "freyja_update_refs/curated_lineages.json"
     File update_log = "freyja_update_refs/update_log.txt"
   }

--- a/tasks/taxon_id/freyja/task_freyja_update.wdl
+++ b/tasks/taxon_id/freyja/task_freyja_update.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 task freyja_update_refs {
   input {
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.4.8"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-07-22"
     Int disk_size = 100
     Int memory = 16
     Int cpu = 4

--- a/tasks/utilities/data_handling/task_fasta_utilities.wdl
+++ b/tasks/utilities/data_handling/task_fasta_utilities.wdl
@@ -1,0 +1,46 @@
+version 1.0
+
+task get_fasta_genome_size {
+  meta {
+    description: "Parse FASTA file to know the length of the genome"
+  }
+  input {
+    File fasta
+    String docker = "us-docker.pkg.dev/general-theiagen/biocontainers/seqkit:2.4.0--h9ee0642_0"
+    Int disk_size = 10
+    Int cpu = 1
+    Int memory = 2
+  }
+  command <<<
+    # from a fasta file, get the length of the genome
+    seqkit stats --tabular ~{fasta} > SEQKIT_STDOUT
+
+    if [ ! -s SEQKIT_STDOUT ]; then
+      echo "ERROR: seqkit stats failed to generate output!"
+      exit 1
+    fi
+
+    # verify that STDOUT file only has two lines
+    if [ $(cat SEQKIT_STDOUT | wc -l) -ne 2 ]; then
+      echo "ERROR: seqkit stats output is not as expected!"
+      exit 1
+    fi
+
+    # extract the length of the genome - assumes the value is in the fifth column in the last line
+    # header: file    format  type    num_seqs        sum_len min_len avg_len max_len
+    cat SEQKIT_STDOUT | tail -1 | cut -f 5  | tee GENOME_LENGTH
+    
+  >>>
+  output {
+    String fasta_length = read_string("GENOME_LENGTH")
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: memory + " GB"
+    cpu: cpu
+    disks: "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    maxRetries: 0
+    preemptible: 0
+  }
+}

--- a/tasks/utilities/data_handling/task_fasta_utilities.wdl
+++ b/tasks/utilities/data_handling/task_fasta_utilities.wdl
@@ -32,7 +32,7 @@ task get_fasta_genome_size {
     
   >>>
   output {
-    String fasta_length = read_string("GENOME_LENGTH")
+    Int fasta_length = read_int("GENOME_LENGTH")
   }
   runtime {
     docker: "~{docker}"

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -73,25 +73,25 @@
       md5sum: 87f1a9ed69127009aa0c173cd74c9d31
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/VERSION
     # kraken2
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/command
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/command
       md5sum: 0efd43fc9f7079a38e5b094245c97f59
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/inputs.json
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/inputs.json
       contains: ["read1", "samplename"]
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/outputs.json
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/outputs.json
       contains: ["kraken2", "percent_human", "percent_sc2"]
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stderr.txt
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stderr.txt.offset
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stdout.txt
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/task.log
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/stderr.txt
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/stderr.txt.offset
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/stdout.txt
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/task.log
       contains: ["wdl", "theiacov_illumina_se", "kraken2_raw", "done"]
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_HUMAN
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/PERCENT_HUMAN
       md5sum: 4fd4dcef994592f9865e9bc8807f32f4
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_SC2
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/PERCENT_SC2
       md5sum: 73f7f6bf2257905cb4bee12d23247db3
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_TARGET_ORGANISM
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/PERCENT_TARGET_ORGANISM
       md5sum: 68b329da9893e34099c7d8ad5cb9c940
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
-    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/ERR6319327_kraken2_report.txt
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
+    - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/ERR6319327_kraken2_report.txt
       md5sum: 3d1bab1c5040916642df5baf20a2d6bd
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -83,7 +83,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/stderr.txt.offset
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/stdout.txt
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/task.log
-      contains: ["wdl", "theiacov_illumina_se", "kraken2_raw", "done"]
+      contains: ["wdl", "theiacov_illumina_se", "kraken2_theiacov_raw", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/PERCENT_HUMAN
       md5sum: 4fd4dcef994592f9865e9bc8807f32f4
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/work/PERCENT_SC2

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -73,25 +73,25 @@
       md5sum: 87f1a9ed69127009aa0c173cd74c9d31
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/VERSION
     # kraken2
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/command
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/command
       md5sum: 0efd43fc9f7079a38e5b094245c97f59
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/inputs.json
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/inputs.json
       contains: ["read1", "samplename"]
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/outputs.json
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/outputs.json
       contains: ["kraken2", "percent_human", "percent_sc2"]
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/stderr.txt
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/stderr.txt.offset
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/stdout.txt
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/task.log
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stderr.txt
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stderr.txt.offset
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/stdout.txt
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/task.log
       contains: ["wdl", "theiacov_illumina_se", "kraken2_raw", "done"]
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_HUMAN
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_HUMAN
       md5sum: 4fd4dcef994592f9865e9bc8807f32f4
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_SC2
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_SC2
       md5sum: 73f7f6bf2257905cb4bee12d23247db3
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/PERCENT_TARGET_ORGANISM
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/PERCENT_TARGET_ORGANISM
       md5sum: 68b329da9893e34099c7d8ad5cb9c940
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
-    - path: miniwdl_run/call-read_QC_trim/call-kraken2_raw/work/ERR6319327_kraken2_report.txt
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/_miniwdl_inputs/0/ERR6319327_1.clean.fastq.gz
+    - path: miniwdl_run/call-read_QC_trim/kraken2_theiacov_raw/work/ERR6319327_kraken2_report.txt
       md5sum: 3d1bab1c5040916642df5baf20a2d6bd
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -600,6 +600,6 @@
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
       md5sum: fb891a62a0629bcbc1158276b2622b95
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
-      md5sum: a28fda3c3d806eb005e8a4e6cdf7b71b
+      md5sum: 51c696b5d122eb1bc7e03d31ccc82cc6
     - path: miniwdl_run/workflow.log
       contains: ["wdl", "theiaprok_illumina_se", "NOTICE", "done"]

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -56,7 +56,8 @@ workflow freyja_fastq {
     call read_qc_ont.read_QC_trim_ont {
       input:
         samplename = samplename,
-        read1 = read1
+        read1 = read1,
+        workflow_series = "theiacov"
     }
     call nanoplot_task.nanoplot as nanoplot_clean {
       input:

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "../../tasks/alignment/task_bwa.wdl" as align
-import "../../tasks/alignment/task_minimap2.wdl" as minimap2
+import "../../tasks/alignment/task_minimap2.wdl" as minimap2_task
 import "../../tasks/quality_control/read_filtering/task_ivar_primer_trim.wdl" as trim_primers
 import "../../tasks/task_versioning.wdl" as versioning
 import "../../tasks/taxon_id/freyja/task_freyja.wdl" as freyja_task
@@ -40,12 +40,13 @@ workflow freyja_fastq {
     }
   }
   if (ont){
-    call minimap2.minimap2 {
+    call minimap2_task.minimap2 {
       input:
         samplename = samplename,
         reference = reference_genome,
         query1 = select_first([read_QC_trim_pe.read1_clean, read_QC_trim_se.read1_clean]), # this select_first might not be needed -> ont will always follow se path
-        output_sam = true
+        output_sam = true,
+        mode = "map-ont"
     }
     call task_parse_mapping.sam_to_sorted_bam {
       input:

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -195,7 +195,8 @@ workflow freyja_fastq {
     File freyja_depths = freyja.freyja_depths
     File freyja_demixed = freyja.freyja_demixed
     Float freyja_coverage = freyja.freyja_coverage
-    File freyja_barcode_file = freyja.freyja_barcode_file
+    File freyja_usher_barcode_file = freyja.freyja_usher_barcode_file
+    File freyja_lineage_metadata_file = freyja.freyja_lineage_metadata_file
     String freyja_barcode_version = freyja.freyja_barcode_version
     String freyja_metadata_version = freyja.freyja_metadata_version
     File? freyja_bootstrap_lineages = freyja.freyja_bootstrap_lineages

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -92,7 +92,7 @@ workflow freyja_fastq {
     input:
       samplename = samplename,
       primer_bed = primer_bed,
-      bamfile = select_first([sam_to_sorted_bam.bam,bwa.sorted_bam])
+      bamfile = select_first([sam_to_sorted_bam.bam, bwa.sorted_bam])
   }
   call freyja_task.freyja_one_sample as freyja {
     input:

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -159,7 +159,7 @@ workflow freyja_fastq {
     # Read QC - nanoq - ONT
     String? nanoq_version = read_QC_trim_ont.nanoq_version
     # Read QC - bbduk outputs - Illumina PE and SE
-    String bbduk_docker = select_first([read_QC_trim_pe.bbduk_docker,read_QC_trim_se.bbduk_docker])
+    String bbduk_docker = select_first([read_QC_trim_pe.bbduk_docker, read_QC_trim_se.bbduk_docker, ""])
     # Read QC - clean reads - all
     File read1_clean = select_first([read_QC_trim_pe.read1_clean, read_QC_trim_se.read1_clean, read_QC_trim_ont.read1_clean])
     File? read2_clean = read_QC_trim_pe.read2_clean

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -104,6 +104,10 @@ workflow freyja_fastq {
   call versioning.version_capture {
     input:
   }
+  
+  # capture correct alignment method
+  String alignment_method_technology = if ont then "minimap2 ~{minimap2.minimap2_version}; ~{primer_trim.ivar_version}" else "~{bwa.bwa_version}; ~{primer_trim.ivar_version}"
+
   output {
     # Version Capture
     String freyja_fastq_wf_version = version_capture.phb_version
@@ -176,7 +180,7 @@ workflow freyja_fastq {
     File kraken_report_dehosted = select_first([read_QC_trim_pe.kraken_report_dehosted, read_QC_trim_se.kraken_report_dehosted, read_QC_trim_ont.kraken_report_dehosted])
     # Read Alignment - bwa outputs
     String? bwa_version = bwa.bwa_version
-    String? alignment_method = "~{bwa.bwa_version}; ~{primer_trim.ivar_version}"
+    String? alignment_method = alignment_method_technology
     # Read Alignment - minimap2 outputs
     String? minimap2_version = minimap2.minimap2_version
     String? minimap2_docker = minimap2.minimap2_docker

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -143,8 +143,8 @@ workflow freyja_fastq {
     # Read Alignment - samtools
     String samtools_version = select_first([sam_to_sorted_bam.samtools_version, bwa.sam_version])
     # Read Alignment - bam and bai files
-    File? aligned_bam = select_first([sam_to_sorted_bam.bam, primer_trim.trim_sorted_bam])
-    File? aligned_bai = select_first([sam_to_sorted_bam.bai, primer_trim.trim_sorted_bai])
+    File aligned_bam = select_first([sam_to_sorted_bam.bam, primer_trim.trim_sorted_bam])
+    File aligned_bai = select_first([sam_to_sorted_bam.bai, primer_trim.trim_sorted_bai])
     # Read Alignment - primer trimming outputs
     Float primer_trimmed_read_percent = primer_trim.primer_trimmed_read_percent
     String ivar_version_primtrim = primer_trim.ivar_version

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -96,10 +96,16 @@ workflow read_QC_trim_se {
     }
   }
   if ("~{workflow_series}" == "theiacov") {
-    call kraken.kraken2_theiacov as kraken2_raw {
+    call kraken.kraken2_theiacov as kraken2_theiacov_raw {
       input:
         samplename = samplename,
         read1 = bbduk_se.read1_clean,
+        target_organism = target_organism
+    }
+    call kraken.kraken2_theiacov as kraken2_theiacov_dehosted {
+      input:
+        samplename = samplename,
+        read1 = select_first([ncbi_scrub_se.read1_dehosted]),
         target_organism = target_organism
     }
   }
@@ -153,14 +159,18 @@ workflow read_QC_trim_se {
     File? fastqc_clean1_html = fastqc_clean.read1_fastqc_html
     
     # kraken2
-    String kraken_version = select_first([kraken2_raw.version, kraken2_standalone.kraken2_version, ""])
-    String kraken_docker = select_first([kraken2_raw.docker, kraken2_standalone.kraken2_docker, ""])
-    Float? kraken_human = kraken2_raw.percent_human
-    Float? kraken_sc2 = kraken2_raw.percent_sc2
-    String? kraken_target_organism = kraken2_raw.percent_target_organism
-    String kraken_report = select_first([kraken2_raw.kraken_report, kraken2_standalone.kraken2_report, ""])
+    String kraken_version = select_first([kraken2_theiacov_raw.version, kraken2_standalone.kraken2_version, ""])
+    Float? kraken_human = kraken2_theiacov_raw.percent_human
+    Float? kraken_sc2 = kraken2_theiacov_raw.percent_sc2
+    String? kraken_target_organism = kraken2_theiacov_raw.percent_target_organism
+    String kraken_report = select_first([kraken2_theiacov_raw.kraken_report, kraken2_standalone.kraken2_report, ""])
+    Float? kraken_human_dehosted = kraken2_theiacov_dehosted.percent_human
+    Float? kraken_sc2_dehosted = kraken2_theiacov_dehosted.percent_sc2
+    String? kraken_target_organism_dehosted = kraken2_theiacov_dehosted.percent_target_organism
     String? kraken_target_organism_name = target_organism
-    String kraken_database = select_first([kraken2_raw.database, kraken2_standalone.kraken2_database, kraken_db_warning, ""])
+    File? kraken_report_dehosted = kraken2_theiacov_dehosted.kraken_report
+    String kraken_docker = select_first([kraken2_theiacov_raw.docker, kraken2_standalone.kraken2_docker, ""])
+    String kraken_database = select_first([kraken2_theiacov_raw.database, kraken2_standalone.kraken2_database, kraken_db_warning, ""])
    
     # trimming versioning
     String? trimmomatic_version = trimmomatic_se.version


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted in line with or style guide found here: https://github.com/theiagen/public_health_bioinformatics#contributing-to-the-phb-workflows and follow the instructions with <>  to complete this PR.

As you create the PR, please provide all information required to validate the workflow.
-->

This PR closes #546

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Aim, Context and Functionality
<!--Please describe the aim of this PR, why the changes were made, and how the workflow should now function -->

This PR reworks the `Freyja_FASTQ` workflow to be technology-agnostic, allowing analysis with sequencing data from Illumina (paired-end and single-end) and ONT instruments (the first of it's kind!!!). 

Additionally, Freyja was updated to the latest version, `v1.5.1`:
- The barcodes file now is expected to be in the `.feather` format (see [here](https://github.com/andersen-lab/Freyja/releases/tag/v1.5.1))
- Additional optional inputs have been exposed for `freyja demix`

## :hammer_and_wrench:  Impacted Workflows/Tasks & Changes Being Made
- This will affect the behavior of the workflow(s) even if users don’t change any workflow inputs relative to the last version <!--  Delete as appropriate -->: No if update if turned off and the same type of data is used.

- Running this workflow on different occasions could result in different results, e.g. due to use of a live database, "latest" docker image, or stochastic data processing <!--  Delete as appropriate. If yes, please describe. -->: Yes only if update is true 
<!--
-Please use bullet points or headings to describe what is being added or modified to each impacted workflow or task, and the reasoning for those choices. 
-Consider inserting before and after tables or pictures to demonstrate the consequences of the changes on files etc.
-->

For **Illumina**, the following logic is implemented:
- If a `read2` is provided, the data is QCed with the `workflows/utilities/wf_read_QC_trim_pe.wdl` sub-workflow otherwise, it uses the `workflows/utilities/wf_read_QC_trim_se.wdl` sub-workflow
- The clean read (or reads) are aligned to the provided reference genome with the `bwa` task (already compatible to optionally receive the `read2` file)

For **ONT**, activated by passing the `ont` boolean, the following logic is implemented:
- If `ont`, the length of the provided reference is calculated with `seqkit` via the `get_fasta_genome_size` task
- The calculated reference length and raw read is passed to the `nanoplot_task.nanoplot` task for quality assessment
- The data is QCed with the `workflows/utilities/wf_read_QC_trim_ont.wdl` sub-workflow
- The calculated reference length and clean read is passed to the `nanoplot_task.nanoplot` task for quality assessment
- The clean read is aligned to the provided reference genome with the `minimap2` task
- The resulting sam file is converted to bam and sorted with the `task_parse_mapping.sam_to_sorted_bam` task

The rest of the steps are followed regardless of the type of input data (unchanged from how it was functioning before this PR):
- primers are trimmed from the bam file with the `trim_primers.primer_trim` task
- all the Freyja magic happens in the `freyja_task.freyja_one_sample` task

## :clipboard: Workflow/Task Step Changes

#### 🔄 Data Processing 
<!-- How are data processed differently through the steps of the task/workflow? 
Please describe in the sections below. 
If nothing has changed, please explicitly say so.-->

Docker/software or software versions changed: `freyja:1.4.8` -> `freyja:1.5.1-07_02_2024-01-27-2024-07-22`

Databases or database versions changed: None

Data processing/commands changed: None

File processing changed: See above for the new tracks added for Illumina SE and ONT data

Compute resources changed: None

#### ➡️ Inputs 
<!--Which inputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g input name, type, default parameters, acceptable input ranges etc? 
If nothing has changed, please explicitly say so.-->

New input:
- `ont` (default false)
- `freyja.adapt` (optional)

Downgraded to optional:
- `read2`

#### ⬅️ Outputs 
<!--Which outputs of the workflow/task have been added/removed/modified? 
How have these been modified, e.g. output variable name, output content, output type, file changes? 
If nothing has changed, please explicitly say so.-->

- `fastp_html_report`
- `fastp_version`
- `fastq_scan_num_reads_clean1`
- `fastq_scan_num_reads_clean2`
- `fastq_scan_num_reads_clean_pairs`
- `fastq_scan_num_reads_raw1`
- `fastq_scan_num_reads_raw2`
- `fastq_scan_num_reads_raw_pairs`
- `fastqc_docker`
- `freyja_lineage_metadata_file` <- New and improved!
- `freyja_usher_barcode_file` <- New and improved!
- `minimap2_docker`
- `minimap2_version`
- `nanoplot_html_clean`
- `nanoplot_html_raw`
- `nanoplot_num_reads_clean1`
- `nanoplot_num_reads_raw1`
- `nanoplot_r1_est_coverage_clean`
- `nanoplot_r1_est_coverage_raw`
- `nanoplot_r1_mean_q_clean`
- `nanoplot_r1_mean_q_raw`
- `nanoplot_r1_mean_readlength_clean`
- `nanoplot_r1_mean_readlength_raw`
- `nanoplot_r1_median_q_clean`
- `nanoplot_r1_median_q_raw`
- `nanoplot_r1_median_readlength_clean`
- `nanoplot_r1_median_readlength_raw`
- `nanoplot_r1_n50_clean`
- `nanoplot_r1_n50_raw`
- `nanoplot_r1_stdev_readlength_clean`
- `nanoplot_r1_stdev_readlength_raw`
- `nanoplot_tsv_clean`
- `nanoplot_tsv_raw`
- `nanoq_version`
- `trimmomatic_docker`

## :test_tube: Testing 
#### Test Dataset
<!--Briefly describe what samples were used for testing, e.g. what organism/s, pathogen diversity, etc. -->

#### Commandline Testing with MiniWDL or Cromwell (optional)
<!--
Please show, with screenshots if possible, that your changes pass the local execution of the workflow.
If the whole test dataset was not used, please specify which samples were tested and verify the results were as anticipated. 
If local testing was not undertaken/possible, please explicitly state this.-->

- **freyja_update_refs task**
![image](https://github.com/user-attachments/assets/5a433d72-b63c-4b77-9833-52b59ad150c1)

- **freyja_fastq workflow**
  - Illumina PE
![image](https://github.com/user-attachments/assets/2739f529-15eb-4893-8eb2-be0cf2219c16)
![image](https://github.com/user-attachments/assets/2bea96d6-b196-42c3-bb30-5033f6490ec1)
  - ONT
![image](https://github.com/user-attachments/assets/daf09b55-7955-4826-ab23-0d7329915a14)
![image](https://github.com/user-attachments/assets/0149e555-61e2-451a-987a-3e75bda618cb)

#### Terra Testing
<!--Please show, with screenshots if possible and/or a URL to the job execution, that your changes pass the execution of the workflow on Terra and that all results were as anticipated (including outputs you didn't expect to change!)-->

- **Freyja_FASTQ** Illumina Paired-End with update DB set to `true`: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/04efacc2-6a99-49dd-828e-75b4f25b3a8c

- **Freyja_FASTQ** ONT with update DB set to `true` and ont set to `true`: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/8b243c25-d9fe-4689-8b71-8ea815092e90 (many samples failed due to bad data (no reads left after QC)

- **Freyja_Update**: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/e1eecc93-29b1-4ae5-867e-88315b593754

- **Freyja_Plot**: https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/bf7968b2-54be-4c3b-a15d-4c2a24f51761

- **Freyja_Dashboard**: Didn't test due to missing data. 😢 

#### Suggested Scenarios for Reviewer to Test
<!--Please list any potential scenarios that the reviewer should test, including edge cases or data types-->

#### Theiagen Version Release Testing (optional)
<!-- 
- Will changes require functional or validation testing (checking outputs etc) during the release?
- Do new samples need to be added to validation datasets? If so, upload these to the appropriate validation workspace Google bucket (). Please describe the new samples here and why these have been chosen.
- Are there any output files that should be checked after running the version release testing?
-->

## :microscope: Final Developer Checklist
<!--Please mark boxes [X] -->
- [x] The workflow/task has been tested locally and results, including file contents, are as anticipated
- [x] The workflow/task has been tested on Terra and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (to be completed by Theiagen developer)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-bb456f34322d4f4db699d4029050481c)


## 🎯 Reviewer Checklist 
<!--  Indicate NA when not applicable  -->
- [ ] All impacted workflows/tasks have been tested on Terra with a different dataset than used for development
- [ ] All reviewer-suggested scenarios have been tested and any additional
- [ ] All changed results have been confirmed to be accurate
- [ ] All workflows/tasks impacted by change/s have been tested using a standard validation dataset to ensure no unintended change of functionality
- [x] All code adheres to the style guide
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments

## 🗂️ Associated Documentation (to be completed by Theiagen developer)
<!--  Indicate NA when not applicable -->
- [x] Relevant documentation on the Public Health Resources "PHB Main" has been updated
- [ ] Workflow diagrams have been updated to reflect changes
