### PR TITLE
[theiacov] Add additional vadr output files & tarball; upgrade VADR docker

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash -l {0}
     steps:
       # Checkout the repo
-      - name: Checkout theiagen/public_health_bacterial_genomics
+      - name: Checkout theiagen/public_health_bioinformatics
         uses: actions/checkout@v4
 
       # Import test data

--- a/tasks/quality_control/advanced_metrics/task_vadr.wdl
+++ b/tasks/quality_control/advanced_metrics/task_vadr.wdl
@@ -60,7 +60,7 @@ task vadr {
   output {
     File? feature_tbl_pass = "~{out_base}/~{out_base}.vadr.pass.tbl"
     File? feature_tbl_fail = "~{out_base}/~{out_base}.vadr.fail.tbl"
-    File? classification_summary_file = "~{out_base}/~{out_base}.vadr.sqc"
+    File? classification_summary_file = "~{out_base}/~{out_base}.vadr.sqc.txt"
     String num_alerts = read_string("NUM_ALERTS")
     File? alerts_list = "~{out_base}/~{out_base}.vadr.alt.list"
     File? outputs_tgz = "~{out_base}.vadr.tar.gz"

--- a/tasks/quality_control/advanced_metrics/task_vadr.wdl
+++ b/tasks/quality_control/advanced_metrics/task_vadr.wdl
@@ -9,7 +9,7 @@ task vadr {
     String vadr_opts = "--noseqnamemax --glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn --out_allfasta"
     Int assembly_length_unambiguous
     Int skip_length = 10000
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/vadr:1.6.3"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/vadr:1.6.3-hav-flu2"
     Int min_length = 50
     Int max_length = 30000
     Int cpu = 2

--- a/tasks/quality_control/advanced_metrics/task_vadr.wdl
+++ b/tasks/quality_control/advanced_metrics/task_vadr.wdl
@@ -47,7 +47,10 @@ task vadr {
 
       # prep alerts into a tsv file for parsing
       cut -f 5 "~{out_base}/~{out_base}.vadr.alt.list" | tail -n +2 > "~{out_base}.vadr.alerts.tsv"
-      cat "~{out_base}.vadr.alerts.tsv" | wc -l > NUM_ALERTS
+      wc -l "~{out_base}.vadr.alerts.tsv" > NUM_ALERTS
+
+      # rename sequence classification summary file to end in txt
+      mv -v "~{out_base}/~{out_base}.vadr.sqc" "~{out_base}/~{out_base}.vadr.sqc.txt"
 
     else
       echo "VADR skipped due to poor assembly; assembly length (unambiguous) = ~{assembly_length_unambiguous}" > NUM_ALERTS
@@ -55,7 +58,9 @@ task vadr {
 
   >>>
   output {
-    File? feature_tbl = "~{out_base}/~{out_base}.vadr.pass.tbl"
+    File? feature_tbl_pass = "~{out_base}/~{out_base}.vadr.pass.tbl"
+    File? feature_tbl_fail = "~{out_base}/~{out_base}.vadr.fail.tbl"
+    File? classification_summary_file = "~{out_base}/~{out_base}.vadr.sqc"
     String num_alerts = read_string("NUM_ALERTS")
     File? alerts_list = "~{out_base}/~{out_base}.vadr.alt.list"
     File? outputs_tgz = "~{out_base}.vadr.tar.gz"

--- a/tasks/quality_control/advanced_metrics/task_vadr.wdl
+++ b/tasks/quality_control/advanced_metrics/task_vadr.wdl
@@ -47,7 +47,7 @@ task vadr {
 
       # prep alerts into a tsv file for parsing
       cut -f 5 "~{out_base}/~{out_base}.vadr.alt.list" | tail -n +2 > "~{out_base}.vadr.alerts.tsv"
-      wc -l "~{out_base}.vadr.alerts.tsv" > NUM_ALERTS
+      cat "~{out_base}.vadr.alerts.tsv" | wc -l > NUM_ALERTS
 
       # rename sequence classification summary file to end in txt
       mv -v "~{out_base}/~{out_base}.vadr.sqc" "~{out_base}/~{out_base}.vadr.sqc.txt"

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -206,6 +206,8 @@
     - path: miniwdl_run/call-ncbi_scrub_se/task.log
       contains: ["wdl", "theiacov_clearlabs", "ncbi_scrub_se", "done"]
     - path: miniwdl_run/call-ncbi_scrub_se/work/DATE
+    - path: miniwdl_run/call-ncbi_scrub_se/work/SPOTS_REMOVED
+      md5sum: 3b3b3f3b3b3b3b3b3b3b3b3b3b3b3b3b
     - path: miniwdl_run/call-ncbi_scrub_se/work/_miniwdl_inputs/0/clearlabs.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/clearlabs_R1_dehosted.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/r1.fastq

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -207,7 +207,7 @@
       contains: ["wdl", "theiacov_clearlabs", "ncbi_scrub_se", "done"]
     - path: miniwdl_run/call-ncbi_scrub_se/work/DATE
     - path: miniwdl_run/call-ncbi_scrub_se/work/SPOTS_REMOVED
-      md5sum: 3b3b3f3b3b3b3b3b3b3b3b3b3b3b3b3b
+      md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-ncbi_scrub_se/work/_miniwdl_inputs/0/clearlabs.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/clearlabs_R1_dehosted.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/r1.fastq

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -199,15 +199,13 @@
     - path: miniwdl_run/call-ncbi_scrub_se/inputs.json
       contains: ["read1", "samplename", "clearlabs"]
     - path: miniwdl_run/call-ncbi_scrub_se/outputs.json
-      contains: ["ncbi_scrub_se", "read1_dehosted", "read1_human_spots_removed"]
+      contains: ["ncbi_scrub_se", "read1_dehosted"]
     - path: miniwdl_run/call-ncbi_scrub_se/stderr.txt
     - path: miniwdl_run/call-ncbi_scrub_se/stderr.txt.offset
     - path: miniwdl_run/call-ncbi_scrub_se/stdout.txt
     - path: miniwdl_run/call-ncbi_scrub_se/task.log
       contains: ["wdl", "theiacov_clearlabs", "ncbi_scrub_se", "done"]
     - path: miniwdl_run/call-ncbi_scrub_se/work/DATE
-    - path: miniwdl_run/call-ncbi_scrub_se/work/FWD_SPOTS_REMOVED
-      md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-ncbi_scrub_se/work/_miniwdl_inputs/0/clearlabs.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/clearlabs_R1_dehosted.fastq.gz
     - path: miniwdl_run/call-ncbi_scrub_se/work/r1.fastq
@@ -381,7 +379,7 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
       md5sum: 6ad40bcca227c92fdfec23fe9a03c344
     - path: miniwdl_run/call-vadr/command
-      md5sum: 884d636dcd4137ffe9f90eb6ce95dd5e
+      md5sum: 1f49b0fa676b3ea67201305139f2568c
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -452,7 +450,7 @@
       md5sum: 2fb190ba11ba66fc637584bb0dbbf2da
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sqa
       md5sum: 6d241df46baa9164f1cb688c80570357
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sqc
+    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sqc.txt
       md5sum: 2c726dac7c46f957e40ccd6b76da32f6
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus_trimmed.fasta
       md5sum: df3a832ffbced8719506279648c968af

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -137,7 +137,7 @@
     - path: miniwdl_run/call-pangolin4/work/fasta.pangolin_report.csv
       md5sum: b61eef3204efd24cde2b0d7257453e22
     - path: miniwdl_run/call-vadr/command
-      md5sum: 4a8931eada9fc3fcd1adc128b3b4e463
+      md5sum: 9e4318eb5b452da239723882bbcfe352
     - path: miniwdl_run/call-vadr/inputs.json
     - path: miniwdl_run/call-vadr/outputs.json
       md5sum: 2c3f4a10237310b40ceb46c6b05d1bf1

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -137,10 +137,10 @@
     - path: miniwdl_run/call-pangolin4/work/fasta.pangolin_report.csv
       md5sum: b61eef3204efd24cde2b0d7257453e22
     - path: miniwdl_run/call-vadr/command
-      md5sum: f4ad614b7ad39f28a8145cec280a93c0
+      md5sum: 4a8931eada9fc3fcd1adc128b3b4e463
     - path: miniwdl_run/call-vadr/inputs.json
     - path: miniwdl_run/call-vadr/outputs.json
-      md5sum: 0b594eb35adf56dbf6ca1ee4dd00fd06
+      md5sum: 2c3f4a10237310b40ceb46c6b05d1bf1
     - path: miniwdl_run/call-vadr/stderr.txt
     - path: miniwdl_run/call-vadr/stderr.txt.offset
     - path: miniwdl_run/call-vadr/stdout.txt

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -447,7 +447,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # vadr
     - path: miniwdl_run/call-vadr/command
-      md5sum: 196c2f03351d6f75ff279f860bb271b0
+      md5sum: dd52eaa02c16e9ce96a4c6586d320cdd
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -134,6 +134,8 @@
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/stdout.txt
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/task.log
       contains: ["wdl", "illumina_pe", "ncbi_scrub", "done"]
+    - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/work/SPOTS_REMOVED
+      md5sum: 7c5aba41f53293b712fd86d08ed5b36e
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command
       md5sum: e18830c68993b2837d1da29ce55d2de8

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -33,7 +33,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/task.log
       contains: ["wdl", "illumina_pe", "trimmomatic", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/SRR13687078.trim.stats.txt
-      md5sum: f7f3616ddeed21cbe619ca25e2e22697
+      md5sum: 454e9cd06acda96b7a13be30ef29c9d5
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR13687078_R1_dehosted.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR13687078_R2_dehosted.fastq.gz
@@ -51,9 +51,9 @@
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/task.log
       contains: ["wdl", "illumina_pe", "bbduk", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/work/SRR13687078.adapters.stats.txt
-      md5sum: 55603935123539fad25daafc00c6bcef
+      md5sum: 41e6facd9074e4cabc0eb2f756aeeff6
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/work/SRR13687078.phix.stats.txt
-      md5sum: 38cd64e412739d870e63181624b9b069
+      md5sum: 1a338999b186f6752d981ff183656bb0
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/work/_miniwdl_inputs/0/SRR13687078_1P.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/work/_miniwdl_inputs/0/SRR13687078_2P.fastq.gz
@@ -95,13 +95,13 @@
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/task.log
       contains: ["wdl", "theiacov_illumina_pe", "kraken2_theiacov_dehosted", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/work/PERCENT_HUMAN
-      md5sum: 414f4efa514540a2527a4f27124575f2
+      md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/work/PERCENT_SC2
-      md5sum: 2bf2d20f083d8fa09abf6c25f8970e2e
+      md5sum: 494a4bf9ab740c0a0fab64f670549883
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/work/PERCENT_TARGET_ORGANISM
       md5sum: 68b329da9893e34099c7d8ad5cb9c940
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_dehosted/work/SRR13687078_kraken2_report.txt
-      md5sum: 3544d9ca35d45093c03cdead46677765
+      md5sum: 2ccc036a9a93b3cf096a5c4dda49a579
     # kraken2 raw
     - path: miniwdl_run/call-read_QC_trim/call-kraken2_theiacov_raw/command
       md5sum: a16205bdb8cf133a112c4552e8f67f97
@@ -124,7 +124,7 @@
       md5sum: 3544d9ca35d45093c03cdead46677765
     # ncbi scrub
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/command
-      md5sum: 95f3a7a050579989015ea29094cedc6b
+      md5sum: 8c7ca800fa98305009cfb9116a4b60b8
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/inputs.json
       contains: ["read1", "read2", "samplename"]
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/outputs.json
@@ -134,10 +134,6 @@
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/stdout.txt
     - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/task.log
       contains: ["wdl", "illumina_pe", "ncbi_scrub", "done"]
-    - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/work/FWD_SPOTS_REMOVED
-      md5sum: 897316929176464ebc9ad085f31e7284
-    - path: miniwdl_run/call-read_QC_trim/call-ncbi_scrub_pe/work/REV_SPOTS_REMOVED
-      md5sum: 897316929176464ebc9ad085f31e7284
     # clean read screen
     - path: miniwdl_run/call-clean_check_reads/command
       md5sum: e18830c68993b2837d1da29ce55d2de8
@@ -451,7 +447,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # vadr
     - path: miniwdl_run/call-vadr/command
-      md5sum: 7d13f1374bd45a189f72e7db33172cad
+      md5sum: 196c2f03351d6f75ff279f860bb271b0
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -403,7 +403,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # vadr
     - path: miniwdl_run/call-vadr/command
-      md5sum: 3228e4022462e882f5ac4ea8bca46f71
+      md5sum: 6d439792568a3cc87cb3262553f6f7c0
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -403,7 +403,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # vadr
     - path: miniwdl_run/call-vadr/command
-      md5sum: 6d439792568a3cc87cb3262553f6f7c0
+      md5sum: 3228e4022462e882f5ac4ea8bca46f71
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -403,7 +403,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # vadr
     - path: miniwdl_run/call-vadr/command
-      md5sum: 50a8f879c19a40aa1f406379011908cf
+      md5sum: 6d439792568a3cc87cb3262553f6f7c0
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -282,7 +282,7 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.flagstat.txt
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.stats.txt
     - path: miniwdl_run/call-vadr/command
-      md5sum: a4ffb60ebb7c31951bfae1bbfd3d53cd
+      md5sum: 3228e4022462e882f5ac4ea8bca46f71
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/workflows/theiacov/updates/wf_vadr_update.wdl
+++ b/workflows/theiacov/updates/wf_vadr_update.wdl
@@ -24,6 +24,10 @@ workflow vadr_update {
     String vadr_update_analysis_date = version_capture.date
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String vadr_num_alerts = vadr.num_alerts
     String vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -235,6 +235,10 @@ workflow theiacov_clearlabs {
     # VADR Annotation QC
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
     # QC_Check Results

--- a/workflows/theiacov/wf_theiacov_fasta.wdl
+++ b/workflows/theiacov/wf_theiacov_fasta.wdl
@@ -162,6 +162,10 @@ workflow theiacov_fasta {
     String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File?  vadr_alerts_list = vadr.alerts_list
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -383,6 +383,10 @@ workflow theiacov_illumina_pe {
     String? nextclade_qc_flu_na = flu_track.nextclade_qc_flu_na
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -303,6 +303,10 @@ workflow theiacov_illumina_se {
     String? nextclade_qc = nextclade_output_parser.nextclade_qc
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -373,6 +373,10 @@ workflow theiacov_ont {
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
+    File? vadr_feature_tbl_pass = vadr.feature_tbl_pass
+    File? vadr_feature_tbl_fail = vadr.feature_tbl_fail
+    File? vadr_classification_summary_file = vadr.classification_summary_file
+    File? vadr_all_outputs_tar_gz = vadr.outputs_tgz
     String? vadr_docker = vadr.vadr_docker
     File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
     # Flu IRMA Outputs


### PR DESCRIPTION
This PR closes #464

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary

This PR updates the default VADR docker image to one that includes the most up-to-date VADR model files for Influenza `v1.6.3-2` (previous docker image included influenza models `v1.6.3-1`). Changes are described here: https://bitbucket.org/nawrockie/vadr-models-flu/src/master/00RELEASE-NOTES.txt This model version will likely be used by NCBI for screening Flu genomes submitted to GenBank in the future, when they stop using FLAN.

A more in-depth explanation of the creation of the VADR model files for Influenza can is described in this pre-print (will likely be published soon): https://www.biorxiv.org/content/10.1101/2024.03.21.585980v1

VADR docs on Flu usage: https://github.com/ncbi/vadr/wiki/Influenza-annotation#example-annotation-of-flu-sequences-1

This PR also adds additonal outputs from VADR that were not previously exposed to the user. This will help in the context of Flu and other organisms when preparing genomes for submission to NCBI. 

The feature_tbl files produced by VADR may be useful (and maybe required?) when submitting Flu genomes to FASTA as they are compatible with BankIt. https://www.ncbi.nlm.nih.gov/WebSub/html/help/feature-table.html

## :zap: Impacted Workflows/Tasks

This impacts all workflows that call the VADR task:

- theiacov_illumina_pe
- theiacov_illumina_se
- theiacov_ONT
- theiacov_clearlabs
- theiacov_FASTA
- VADR_Update

**Note: VADR is run on multiple different organisms, so this impacts all organisms**

This PR may lead to different results in pre-existing outputs: **Extremely rare & unlikely, but Flu B samples may be annotated differently due to updated VADR models for influenza**

This PR uses an element that could cause duplicate runs to have different results: **No**

## :hammer_and_wrench: Changes


### :gear: Algorithm

- default docker image has been upgraded. Still using v1.6.3 of VADR, but the difference is that Flu model files have been upgraded within the docker image. Details described above.

### ➡️ Inputs

N/A

### ⬅️ Outputs

- `File? vadr_feature_tbl_pass` - 5 column feature table output for passing sequences. This output was not previously exposed at the workflow level but is captured at the task level.
- `File? vadr_feature_tbl_fail` - 5 column feature table output for failing sequences. This file will be helpful for identifying why a specific genomic feature was rejected or given a warning by VADR.
- `File? vadr_classification_summary_file` - per-sequence tabular classification summary file
- `File? vadr_all_outputs_tar_gz` - a tar.gz file containing all of VADR's output files in case users want to investigate a sample deeply. This output was not previously exposed at the workflow level, but is captured at the task level


## :test_tube: Testing

- sars-cov-2 samples via theiacov_FASTA_PHB: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/80ccb33f-bc32-4d7f-9a80-9b19c2806667
  - ~~⚠️ need to review outputs~~ Outputs look good ✅ 
  - `.fail.tbl` files have content for samples with VADR alerts, as expected
  - `.pass.tbl` files have content for samples with 0 VADR alerts, as expected.
  - All `.sqc.txt` files have content regardless of pass or fail.
  - The tarball `vadr_all_outputs_tar_gz` has all VADR output files, as expected. Was able to extract & view files within the tarball on Windows 11 computer without issue.
- Mpox samples via theiacov_Illumina_PE_PHB: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/3da52157-776c-4716-bc24-6e5b3e239f89
  - ~~⚠️ need to review outputs~~ Outputs look good ✅ 
  - `.fail.tbl` files have content for samples with VADR alerts, as expected
  - `.pass.tbl` files have content for samples with 0 VADR alerts, as expected.
  - All `.sqc.txt` files have content regardless of pass or fail.
  - The tarball `vadr_all_outputs_tar_gz` has all VADR output files, as expected. Was able to extract & view files within the tarball on Windows 11 computer without issue.
- Flu samples via theiacov_illumina_PE_PHB: https://app.terra.bio/#workspaces/theiagen-validations/curtis-sandbox-theiagen-validations/job_history/bbfc5ae6-8741-434b-8cd3-c75f319569e1
  - ~~⚠️ need to review outputs~~ Outputs look good ✅ . Ignore the 1 failure, the original input FASTQ files are corrupted, so I expected failure.
  - each genome segment is evaluated separately, so for most samples, the `.fail.tbl` files and the `.pass.tbl` files have content depending on VADR passing or failing the segment
  - `.fail.tbl` files have content, as expected
  - `.pass.tbl` files have content, as expected.
  - The tarball `vadr_all_outputs_tar_gz` has all VADR output files, as expected. Was able to extract & view files within the tarball on Windows 11 computer without issue.
  - All `.sqc.txt` files have content regardless of pass or fail. Here's an example `.sqc.txt` file for an H1N1 sample that had passed & failed segments:

```
#seq  seq                  seq                                  sub                    seq    mdl         num                            sub   score  diff/  seq   
#idx  name                 len  p/f   ant  model1    grp1       grp1   score  sc/nt    cov    cov  bias  hits  str  model2    grp2       grp2   diff     nt  alerts
#---  ------------------  ----  ----  ---  --------  ---------  ----  ------  -----  -----  -----  ----  ----  ---  --------  ---------  ----  -----  -----  ------
1     A1_H1N1_PC_A_HA_H1  1701  PASS  yes  CY000449  fluA-seg4  H1    1094.7  0.644  0.999  0.956  39.9     1    +  DQ864721  fluA-seg4  H5    437.7  0.257  -     
2     A1_H1N1_PC_A_MP      982  PASS  yes  CY002009  fluA-seg7  -      778.8  0.793  1.000  0.956   0.5     1    +  CY103887  fluA-seg7  -     354.4  0.361  -     
3     A1_H1N1_PC_A_NA_N1  1410  PASS  yes  CY002538  fluA-seg6  N1     957.2  0.679  0.999  0.965  21.3     1    +  CY005359  fluA-seg6  N4    435.4  0.309  -     
4     A1_H1N1_PC_A_NP     1497  PASS  yes  CY006079  fluA-seg5  -     1147.8  0.767  0.999  0.955  23.4     1    +  CY125946  fluA-seg5  -     424.7  0.284  -     
5     A1_H1N1_PC_A_NS      863  PASS  yes  CY002284  fluA-seg8  -      623.2  0.722  0.999  0.969   6.8     1    +  CY103888  fluA-seg8  -     405.0  0.469  -     
6     A1_H1N1_PC_A_PA     1648  FAIL  yes  CY003645  fluA-seg3  -     1194.7  0.725  0.998  0.736  28.7     2    +  CY125944  fluA-seg3  -     417.8  0.254  -     
7     A1_H1N1_PC_A_PB1    2274  PASS  yes  CY003646  fluA-seg2  -     2153.0  0.947  1.000  0.971  60.1     1    +  CY125943  fluA-seg2  -     975.7  0.429  -     
8     A1_H1N1_PC_A_PB2    2024  FAIL  yes  CY002079  fluA-seg1  -     1467.1  0.725  0.999  0.868  29.6     3    +  CY103881  fluA-seg1  -     718.7  0.355  -     
```

### Suggested Scenarios for Reviewer to Test

Would be good to test a variety of organisms that are applicable to VADR across a variety of impacted workflows

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (Theiagen developers only)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
