### PR TITLE
[TheiaMeta] Midas call in read_QC_trim_pe.wdl workflow and outputs

### DIFF
--- a/docs/workflows/genomic_characterization/theiameta.md
+++ b/docs/workflows/genomic_characterization/theiameta.md
@@ -184,9 +184,8 @@ The TheiaMeta_Illumina_PE workflow processes Illumina paired-end (PE) reads ge
 
     The `MIDAS` task is for the identification of reads to detect contamination with non-target taxa. This task is optional and turned off by default. It can be used by setting the `call_midas` input variable to `true`.
 
-    The MIDAS tool was originally designed for metagenomic sequencing data but has been co-opted for use with bacterial isolate WGS methods. It can be used to detect contamination present in raw sequencing data by estimating bacterial species abundance in bacterial isolate WGS data. If a secondary genus is detected above a relative frequency of 0.01 (1%), then the sample should fail QC and be investigated further for potential contamination.
+    The MIDAS reference database, located at **`gs://theiagen-large-public-files-rp/terra/theiaprok-files/midas/midas_db_v1.2.tar.gz`**, is provided as the default. It is possible to provide a custom database. More information is available [here](https://github.com/snayfach/MIDAS/blob/master/docs/ref_db.md).
 
-    This task is similar to those used in commercial software, BioNumerics, for estimating secondary species abundance.
 
     ??? toggle "How are the MIDAS output columns determined?"
         
@@ -206,8 +205,6 @@ The TheiaMeta_Illumina_PE workflow processes Illumina paired-end (PE) reads ge
         - count_reads: number of reads mapped to marker genes
         - coverage: estimated genome-coverage (i.e. read-depth) of species in metagenome
         - relative_abundance: estimated relative abundance of species in metagenome
-        
-        The value in the `midas_primary_genus` column is derived by ordering the rows in order of "relative_abundance" and identifying the genus of top species in the "species_id" column (Salmonella). The value in the `midas_secondary_genus` column is derived from the genus of the second-most prevalent genus in the "species_id" column (Citrobacter). The `midas_secondary_genus_abundance` column is the "relative_abundance" of the second-most prevalent genus (0.009477003). The `midas_secondary_genus_coverage` is the "coverage" of the second-most prevalent genus (0.995216227).
         
     !!! techdetails "read_QC_trim Technical Details"
                 

--- a/docs/workflows/genomic_characterization/theiameta.md
+++ b/docs/workflows/genomic_characterization/theiameta.md
@@ -325,10 +325,7 @@ The TheiaMeta_Illumina_PE workflow processes Illumina paired-end (PE) reads ge
 | metaspades_docker | String | Docker image of metaspades |
 | metaspades_version | String | Version of metaspades |
 | midas_primary_genus | String | Primary genus detected by MIDAS |
-| midas_report | File | MIDAS report file |
-| midas_secondary_genus | String | Secondary genus detected by MIDAS |
-| midas_secondary_genus_abundance | Float | Abundance of the secondary genus |
-| midas_secondary_genus_coverage | Float | Coverage of the secondary genus |
+| midas_report | File | MIDAS report file tsv file|
 | minimap2_docker | String | Docker image of minimap2 |
 | minimap2_version | String | Version of minimap2 |
 | ncbi_scrub_docker | String | Docker image for NCBI's HRRT |

--- a/docs/workflows/genomic_characterization/theiameta.md
+++ b/docs/workflows/genomic_characterization/theiameta.md
@@ -324,6 +324,11 @@ The TheiaMeta_Illumina_PE workflow processes Illumina paired-end (PE) reads ge
 | largest_contig | Int | Largest contig size |
 | metaspades_docker | String | Docker image of metaspades |
 | metaspades_version | String | Version of metaspades |
+| midas_primary_genus | String | Primary genus detected by MIDAS |
+| midas_report | File | MIDAS report file |
+| midas_secondary_genus | String | Secondary genus detected by MIDAS |
+| midas_secondary_genus_abundance | Float | Abundance of the secondary genus |
+| midas_secondary_genus_coverage | Float | Coverage of the secondary genus |
 | minimap2_docker | String | Docker image of minimap2 |
 | minimap2_version | String | Version of minimap2 |
 | ncbi_scrub_docker | String | Docker image for NCBI's HRRT |

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -561,7 +561,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_resfinder.wdl
       md5sum: 27528633723303b462d095b642649453
     - path: miniwdl_run/wdl/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
-      md5sum: 284ce680b52e7e1c1753537b344fa161
+      md5sum: 3b9e04569d7e856dcc649b7726b306b7
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_bbduk.wdl
       md5sum: aec6ef024d6dff31723f44290f6b9cf5
     - path: miniwdl_run/wdl/tasks/quality_control/advanced_metrics/task_busco.wdl

--- a/workflows/theiameta/wf_theiameta_illumina_pe.wdl
+++ b/workflows/theiameta/wf_theiameta_illumina_pe.wdl
@@ -232,6 +232,12 @@ workflow theiameta_illumina_pe {
     String bbduk_docker = read_QC_trim.bbduk_docker
     # Read QC - Read stats
     Float? average_read_length = read_QC_trim.average_read_length
+    # MIDAS outputs
+    String? midas_primary_genus = read_QC_trim.midas_primary_genus
+    String? midas_secondary_genus = read_QC_trim.midas_secondary_genus
+    Float? midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance
+    File? midas_report = read_QC_trim.midas_report
+    Float? midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage
     # Assembly - metaspades 
     File assembly_fasta = select_first([retrieve_aligned_contig_paf.final_assembly, pilon.assembly_fasta])
     String metaspades_version = metaspades_pe.metaspades_version

--- a/workflows/theiameta/wf_theiameta_illumina_pe.wdl
+++ b/workflows/theiameta/wf_theiameta_illumina_pe.wdl
@@ -234,10 +234,7 @@ workflow theiameta_illumina_pe {
     Float? average_read_length = read_QC_trim.average_read_length
     # MIDAS outputs
     String? midas_primary_genus = read_QC_trim.midas_primary_genus
-    String? midas_secondary_genus = read_QC_trim.midas_secondary_genus
-    Float? midas_secondary_genus_abundance = read_QC_trim.midas_secondary_genus_abundance
     File? midas_report = read_QC_trim.midas_report
-    Float? midas_secondary_genus_coverage = read_QC_trim.midas_secondary_genus_coverage
     # Assembly - metaspades 
     File assembly_fasta = select_first([retrieve_aligned_contig_paf.final_assembly, pilon.assembly_fasta])
     String metaspades_version = metaspades_pe.metaspades_version

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -119,7 +119,7 @@ workflow read_QC_trim_pe {
         read2 = bbduk.read2_clean
     }
   }
-  if ("~{workflow_series}" == "theiaprok") {
+  if ("~{workflow_series}" == "theiaprok") || ("~{workflow_series}" == "theiameta")) {
     if (call_midas) {
       call midas_task.midas {
         input:

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -213,6 +213,9 @@ workflow read_QC_trim_pe {
     String? midas_docker = midas.midas_docker
     File? midas_report = midas.midas_report
     String? midas_primary_genus = midas.midas_primary_genus
+    String? midas_secondary_genus = midas.midas_secondary_genus
+    Float? midas_secondary_genus_abundance = midas.midas_secondary_genus_abundance
+    Float? midas_secondary_genus_coverage = midas.midas_secondary_genus_coverage
 
     # readlength
     Float? average_read_length = readlength.average_read_length

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -119,7 +119,7 @@ workflow read_QC_trim_pe {
         read2 = bbduk.read2_clean
     }
   }
-  if ("~{workflow_series}" == "theiaprok") || ("~{workflow_series}" == "theiameta")) {
+  if ("~{workflow_series}" == "theiaprok" || "~{workflow_series}" == "theiameta") {
     if (call_midas) {
       call midas_task.midas {
         input:

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -213,9 +213,6 @@ workflow read_QC_trim_pe {
     String? midas_docker = midas.midas_docker
     File? midas_report = midas.midas_report
     String? midas_primary_genus = midas.midas_primary_genus
-    String? midas_secondary_genus = midas.midas_secondary_genus
-    Float? midas_secondary_genus_abundance = midas.midas_secondary_genus_abundance
-    Float? midas_secondary_genus_coverage = midas.midas_secondary_genus_coverage
 
     # readlength
     Float? average_read_length = readlength.average_read_length


### PR DESCRIPTION
This PR closes #308

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
This PR introduces conditional logic for MIDAS to run within the TheiaMeta workflow, adding additional QC through the integration of MIDAS for metagenomic data processing. Additionally, the workflow has been updated to allow for flexibility in handling theiaprok and theiameta as workflow series inputs.

## :zap: Impacted Workflows/Tasks
- TheiaMeta Illumina PE workflow: The integration of MIDAS as a conditional QC step.
- wf_read_QC_trim_pe workflow: Updated logic for handling theiaprok and theiameta and adding MIDAS as a task.

This PR may lead to different results in pre-existing outputs: Yes
MIDAS-related outputs will now be available in runs where call_midas = true, which adds new outputs related to taxonomic identification and abundance metrics.
This PR uses an element that could cause duplicate runs to have different results: No


## :hammer_and_wrench: Changes
MIDAS integration: Added conditional logic for MIDAS to run in both theiaprok and theiameta workflows. MIDAS is now available to run QC steps for taxonomic profiling of metagenomic data.
Task linking: Added midas_task.midas as a task to be triggered based on the workflow series and the call_midas flag.

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
call_midas (Boolean): Determines whether to run MIDAS as part of the workflow. Default is false.
midas_db (File?): Path to the MIDAS database required for the MIDAS task. Default provided

### ⬅️ Outputs
MIDAS Outputs:
midas_primary_genus: Primary genus detected by MIDAS.
midas_secondary_genus: Secondary genus detected by MIDAS.
midas_secondary_genus_abundance: Abundance of the secondary genus.
midas_secondary_genus_coverage: Coverage of the secondary genus.
midas_report: The MIDAS output report file.

## :test_tube: Testing
Tested the updated workflow locally and verified that MIDAS is triggered when call_midas = true.
https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Combe_Sandbox/job_history/f55e9b17-e2df-42a6-ae71-2ff31f366719
Ensured that outputs from MIDAS (genus-level identification, abundance, and report files) are properly generated.
![image](https://github.com/user-attachments/assets/1188090c-d85e-48a6-a85f-32e3e09babf3)

Confirmed that the theiameta and theiaprok workflow series run without issues, and MIDAS only runs for call_midas = true.
Tested setting to false, https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Combe_Sandbox/job_history/2fff2b41-2968-409e-8b41-49db24e99e7b

### Suggested Scenarios for Reviewer to Test
Run TheiaMeta with call_midas = true and check for MIDAS outputs.
Run TheiaMeta with call_midas = false and verify that the workflow completes without MIDAS tasks.
Test with different workflow series inputs (theiameta, theiaprok) and ensure the correct behavior.

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [X ] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [X] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (Theiagen developers only)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
