### PR TITLE
[TheiaCoV] iVar Consensus Pipefail fix

### DIFF
--- a/docs/workflows/genomic_characterization/theiacov.md
+++ b/docs/workflows/genomic_characterization/theiacov.md
@@ -191,8 +191,6 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | gene_coverage | **min_depth** | Int | The minimum depth to determine if a position was covered. | 10 | Optional | ONT, PE, SE | MPXV, sars-cov-2 |
 | gene_coverage | **sc2_s_gene_start** | Int | start nucleotide position of the SARS-CoV-2 Spike gene | 21563 | Optional | CL, ONT, PE, SE | MPXV, sars-cov-2 |
 | gene_coverage | **sc2_s_gene_stop** | Int | End/Last nucleotide position of the SARS-CoV-2 Spike gene | 25384 | Optional | CL, ONT, PE, SE | MPXV, sars-cov-2 |
-| ivar_consensus | **read2** | File | Internal component, do not modify | | Do not modify, Optional | SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
-| ivar_consensus | **skip_N** | Boolean | True/False variable that determines if regions with depth less than minimum depth should not be added to the consensus sequence | FALSE | Optional | PE, SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **ivar_bwa_cpu** | Int | Number of CPUs to allocate to the task | 6 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **ivar_bwa_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **ivar_bwa_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
@@ -209,6 +207,8 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | ivar_consensus | **ivar_variant_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **ivar_variant_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **ivar_variant_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional  | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **read2** | File | Internal component, do not modify | | Do not modify, Optional | SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **skip_N** | Boolean | True/False variable that determines if regions with depth less than minimum depth should not be added to the consensus sequence | FALSE | Optional | PE, SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **stats_n_coverage_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **stats_n_coverage_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **stats_n_coverage_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/samtools:1.15 | | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |

--- a/docs/workflows/genomic_characterization/theiacov.md
+++ b/docs/workflows/genomic_characterization/theiacov.md
@@ -193,6 +193,30 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | gene_coverage | **sc2_s_gene_stop** | Int | End/Last nucleotide position of the SARS-CoV-2 Spike gene | 25384 | Optional | CL, ONT, PE, SE | MPXV, sars-cov-2 |
 | ivar_consensus | **read2** | File | Internal component, do not modify | | Do not modify, Optional | SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | ivar_consensus | **skip_N** | Boolean | True/False variable that determines if regions with depth less than minimum depth should not be added to the consensus sequence | FALSE | Optional | PE, SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_bwa_cpu** | Int | Number of CPUs to allocate to the task | 6 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_bwa_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_bwa_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_bwa_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 16 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_consensus_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_consensus_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_consensus_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_consensus_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_trim_primers_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_trim_primers_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_trim_primers_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_trim_primers_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_variant_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional  | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_variant_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_variant_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan | | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **ivar_variant_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional  | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/samtools:1.15 | | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_primtrim_cpu** | Int | Number of CPUs to allocate to the task | 2 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_primtrim_disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_primtrim_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/samtools:1.15 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
+| ivar_consensus | **stats_n_coverage_primtrim_memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 8 | Optional | SE,PE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | kraken2_dehosted | **cpu** | Int | Number of CPUs to allocate to the task | 4 | Optional | CL | sars-cov-2 |
 | kraken2_dehosted | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | CL | sars-cov-2 |
 | kraken2_dehosted | **docker_image** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/kraken2:2.0.8-beta_hv | Optional | CL | sars-cov-2 |

--- a/tasks/assembly/task_ivar_consensus.wdl
+++ b/tasks/assembly/task_ivar_consensus.wdl
@@ -20,6 +20,8 @@ task consensus {
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan"
   }
   command <<<
+    #set -euo pipefail to avoid silent failure
+    set -euo pipefail
     # date and version control
     date | tee DATE
     ivar version | head -n1 | tee IVAR_VERSION

--- a/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
+++ b/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
@@ -19,7 +19,7 @@ task variant_call {
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan"
   }
   command <<<
-    set -eou pipefail
+    set -euo pipefail
     # version control
     ivar version | head -n1 | tee IVAR_VERSION
     samtools --version | head -n1 | tee SAMTOOLS_VERSION

--- a/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
+++ b/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
@@ -19,6 +19,7 @@ task variant_call {
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/ivar:1.3.1-titan"
   }
   command <<<
+    set -eou pipefail
     # version control
     ivar version | head -n1 | tee IVAR_VERSION
     samtools --version | head -n1 | tee SAMTOOLS_VERSION

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -236,7 +236,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: bc40f95c8c990dbf25a8d8408a7e0195
+      md5sum: 871e716bb580f4157f34d4356f681482
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json
@@ -267,7 +267,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # consensus
     - path: miniwdl_run/call-ivar_consensus/call-consensus/command
-      md5sum: ccdea44d43b85395ac64135a9fbe3e08
+      md5sum: 89e10c8cf1368912456d477a3cb30dbf
     - path: miniwdl_run/call-ivar_consensus/call-consensus/inputs.json
       contains: ["bamfile", "samplename", "min_depth"]
     - path: miniwdl_run/call-ivar_consensus/call-consensus/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -188,7 +188,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: b19b644c97a1e267664bc334622471a4
+      md5sum: 0e927e531c7c66c130fbb69e4fece330
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json
@@ -219,7 +219,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # consensus
     - path: miniwdl_run/call-ivar_consensus/call-consensus/command
-      md5sum: 043ae7ecbd31d90be3e92cdc9fd55c10
+      md5sum: d74095745fef2e76e82e1f195da8b32e
     - path: miniwdl_run/call-ivar_consensus/call-consensus/inputs.json
       contains: ["bamfile", "samplename", "min_depth"]
     - path: miniwdl_run/call-ivar_consensus/call-consensus/outputs.json

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -75,7 +75,7 @@ workflow ivar_consensus {
       bamfile = primer_trim.trim_sorted_bam,
       cpu = stats_n_coverage_primtrim_cpu,
       memory = stats_n_coverage_primtrim_memory,
-      disk_size = stats_n_coverage_primtrim_size,
+      disk_size = stats_n_coverage_primtrim_disk_size,
       docker = stats_n_coverage_primtrim_docker
     }
   }

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -22,30 +22,30 @@ workflow ivar_consensus {
     Float consensus_min_freq 
     File? primer_bed
     Boolean? skip_N
-    Int?        ivar_bwa_cpu
-    Int?        ivar_bwa_memory
-    Int?        ivar_bwa_disk_size
-    String?     ivar_bwa_docker
-    Int?        ivar_trim_primers_cpu
-    Int?        ivar_trim_primers_memory
-    Int?        ivar_trim_primers_disk_size
-    String?     ivar_trim_primers_docker
-    Int?        stats_n_coverage_primtrim_cpu
-    Int?        stats_n_coverage_primtrim_memory
-    Int?        stats_n_coverage_primtrim_disk_size
-    String?     stats_n_coverage_primtrim_docker
-    Int?        ivar_variant_cpu
-    Int?        ivar_variant_memory
-    Int?        ivar_variant_disk_size
-    String?     ivar_variant_docker
-    Int?        ivar_consensus_cpu
-    Int?        ivar_consensus_memory
-    Int?        ivar_consensus_disk_size
-    String?     ivar_consensus_docker
-    Int?        stats_n_coverage_cpu
-    Int?        stats_n_coverage_memory
-    Int?        stats_n_coverage_disk_size
-    String?     stats_n_coverage_docker
+    Int? ivar_bwa_cpu
+    Int? ivar_bwa_memory
+    Int? ivar_bwa_disk_size
+    String? ivar_bwa_docker
+    Int? ivar_trim_primers_cpu
+    Int? ivar_trim_primers_memory
+    Int? ivar_trim_primers_disk_size
+    String? ivar_trim_primers_docker
+    Int? stats_n_coverage_primtrim_cpu
+    Int? stats_n_coverage_primtrim_memory
+    Int? stats_n_coverage_primtrim_disk_size
+    String? stats_n_coverage_primtrim_docker
+    Int? ivar_variant_cpu
+    Int? ivar_variant_memory
+    Int? ivar_variant_disk_size
+    String? ivar_variant_docker
+    Int? ivar_consensus_cpu
+    Int? ivar_consensus_memory
+    Int? ivar_consensus_disk_size
+    String? ivar_consensus_docker
+    Int? stats_n_coverage_cpu
+    Int? stats_n_coverage_memory
+    Int? stats_n_coverage_disk_size
+    String? stats_n_coverage_docker
   }
   call bwa_task.bwa {
     input:

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -30,6 +30,10 @@ workflow ivar_consensus {
     Int?        ivar_trim_primers_memory
     Int?        ivar_trim_primers_disk_size
     String?     ivar_trim_primers_docker
+    Int?        stats_n_coverage_primtrim_cpu
+    Int?        stats_n_coverage_primtrim_memory
+    Int?        stats_n_coverage_primtrim_disk_size
+    String?     stats_n_coverage_primtrim_docker
     Int?        ivar_variant_cpu
     Int?        ivar_variant_memory
     Int?        ivar_variant_disk_size
@@ -68,7 +72,11 @@ workflow ivar_consensus {
     call assembly_metrics.stats_n_coverage as stats_n_coverage_primtrim {
     input:
       samplename = samplename,
-      bamfile = primer_trim.trim_sorted_bam
+      bamfile = primer_trim.trim_sorted_bam,
+      cpu = stats_n_coverage_primtrim_cpu,
+      memory = stats_n_coverage_primtrim_memory,
+      disk_size = stats_n_coverage_primtrim_size,
+      docker = stats_n_coverage_primtrim_docker
     }
   }
   call variant_call_task.variant_call {

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -22,25 +22,53 @@ workflow ivar_consensus {
     Float consensus_min_freq 
     File? primer_bed
     Boolean? skip_N
+    Int?        ivar_bwa_cpu
+    Int?        ivar_bwa_memory
+    Int?        ivar_bwa_disk_size
+    String?     ivar_bwa_docker
+    Int?        ivar_trim_primers_cpu
+    Int?        ivar_trim_primers_memory
+    Int?        ivar_trim_primers_disk_size
+    String?     ivar_trim_primers_docker
+    Int?        ivar_variant_cpu
+    Int?        ivar_variant_memory
+    Int?        ivar_variant_disk_size
+    String?     ivar_variant_docker
+    Int?        ivar_consensus_cpu
+    Int?        ivar_consensus_memory
+    Int?        ivar_consensus_disk_size
+    String?     ivar_consensus_docker
+    Int?        stats_n_coverage_cpu
+    Int?        stats_n_coverage_memory
+    Int?        stats_n_coverage_disk_size
+    String?     stats_n_coverage_docker
   }
   call bwa_task.bwa {
     input:
       samplename = samplename,
       read1 = read1,
       read2 = read2,
-      reference_genome = reference_genome
+      reference_genome = reference_genome,
+      cpu = ivar_bwa_cpu,
+      memory = ivar_bwa_memory,
+      disk_size = ivar_bwa_disk_size,
+      docker = ivar_bwa_docker
   }
   if (trim_primers) {
     call primer_trim_task.primer_trim {
       input:
         samplename = samplename,
         primer_bed = select_first([primer_bed]),
-        bamfile = bwa.sorted_bam
+        bamfile = bwa.sorted_bam,
+        cpu = ivar_trim_primers_cpu,
+        memory = ivar_trim_primers_memory,
+        disk_size = ivar_trim_primers_disk_size,
+        docker = ivar_trim_primers_docker
     }
     call assembly_metrics.stats_n_coverage as stats_n_coverage_primtrim {
     input:
       samplename = samplename,
-      bamfile = primer_trim.trim_sorted_bam,
+      bamfile = primer_trim.trim_sorted_bam
     }
   }
   call variant_call_task.variant_call {
@@ -50,8 +78,11 @@ workflow ivar_consensus {
       reference_gff = reference_gff,
       reference_genome = reference_genome,
       variant_min_depth = min_depth,
-      variant_min_freq = variant_min_freq
-
+      variant_min_freq = variant_min_freq,
+      cpu = ivar_variant_cpu,
+      memory = ivar_variant_memory,
+      disk_size = ivar_variant_disk_size,
+      docker = ivar_variant_docker
   }
   call consensus_task.consensus {
     input:
@@ -60,12 +91,20 @@ workflow ivar_consensus {
       reference_genome = reference_genome,
       consensus_min_depth = min_depth,
       consensus_min_freq = consensus_min_freq,
-      skip_N = skip_N
+      skip_N = skip_N,
+      cpu = ivar_consensus_cpu,
+      memory = ivar_consensus_memory,
+      disk_size = ivar_consensus_disk_size,
+      docker = ivar_consensus_docker
   }
   call assembly_metrics.stats_n_coverage {
     input:
       samplename = samplename,
-      bamfile = bwa.sorted_bam
+      bamfile = bwa.sorted_bam,
+      cpu = stats_n_coverage_cpu,
+      memory = stats_n_coverage_memory,
+      disk_size = stats_n_coverage_disk_size,
+      docker = stats_n_coverage_docker
   }
   output {
     # bwa outputs


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #598 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
The Ivar Consensus workflow was facing a silent error due to a pipefail on input files that were very large. 

The changes in this PR do the following:
1. Add pipefail parameters `set -euo pipefail` to both the ivar consensus task and the ivar variant calling task.
2. Expose `cpu`, `memory`, `disk_size`, and `docker` parameters for the following tasks in the ivar consensus wf:
- bwa alignment 
- primer trimming
- stats and coverage for primer trimming 
- variant calling
- consensus 
- stats and coverage for the consensus wf

3.Improve error handling so that tasks will now fail correctly instead of producing silent errors.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
This PR may lead to different results in pre-existing outputs: No

This PR uses an element that could cause duplicate runs to have different results: No
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
`set -euo pipefail` has been added to the [task_ivar_consensus.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/mb-ivar-pipe-fail-dev/tasks/assembly/task_ivar_consensus.wdl) and to [task_ivar_variant_call.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/mb-ivar-pipe-fail-dev/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl)

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
The following optional inputs have been added to the ivar consensus workflow:
```
Int?        ivar_bwa_cpu
Int?        ivar_bwa_memory
Int?        ivar_bwa_disk_size
String?     ivar_bwa_docker
Int?        ivar_trim_primers_cpu
Int?        ivar_trim_primers_memory
Int?        ivar_trim_primers_disk_size
String?     ivar_trim_primers_docker
Int?        ivar_variant_cpu
Int?        ivar_variant_memory
Int?        ivar_variant_disk_size
String?     ivar_variant_docker
Int?        ivar_consensus_cpu
Int?        ivar_consensus_memory
Int?        ivar_consensus_disk_size
String?     ivar_consensus_docker
Int?        stats_n_coverage_cpu
Int?        stats_n_coverage_memory
Int?        stats_n_coverage_disk_size
String?     stats_n_coverage_docker
```
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
This PR was tested on the input data that originally brought up this bug by Marc Perry from UCSC. The following set of rsv fastq inputs: RSV00100_A & RSV00122_A, these inputs can be exported from the ucsc-rsv data table found [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/data).

This data was first tested with the workflow defaults, which lead to the correct failures being flagged on terra. 

Then the data was tested with the following parameters adjusted for the ivar consensus task on the TheiaCov Illumina PE wf:
`ivar_consensus_memory: 16`
`ivar_variant_memory: 16`

To further confirm the updates did not cause any breaking changes, the workflow was tested with defaults against WNV and MPXV validation data from the theiagen validation illumina pe data set. 
### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->
Please test with simple inputs with defualt and one with large files >=1.5GB per fastq with the following adjustments:
`ivar_consensus_memory: 16`
`ivar_variant_memory: 16`

I can provide the source to the large datasets. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (Theiagen developers only)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
