### PR TITLE
[TheiaCoV] Reorder flu segments from largest to smallest in irma task

### DIFF
--- a/docs/workflows/genomic_characterization/theiacov.md
+++ b/docs/workflows/genomic_characterization/theiacov.md
@@ -785,7 +785,7 @@ All input reads are processed through "core tasks" in the TheiaCoV Illumina, ONT
 
 ??? toggle "`irma`: Assembly and Characterization ==_for flu in TheiaCoV_Illumina_PE & TheiaCoV_ONT_=="
 
-    Cleaned reads are assembled using `irma` which does not use a reference due to the rapid evolution and high variability of influenza. `irma` also performs typing and subtyping as part of the assembly process.
+    Cleaned reads are assembled using `irma` which does not use a reference due to the rapid evolution and high variability of influenza. Assemblies produced by `irma` will be orderd from largest to smallest assembled flu segment. `irma` also performs typing and subtyping as part of the assembly process.
 
     General statistics about the assembly are generated with the `consensus_qc` task ([task_assembly_metrics.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/main/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl)).
 
@@ -932,7 +932,7 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | aligned_bam | File | Primer-trimmed BAM file; generated during consensus assembly process | CL, ONT, PE, SE |
 | artic_docker | String | Docker image utilized for read trimming and consensus genome assembly | CL, ONT |
 | artic_version | String | Version of the Artic software utilized for read trimming and conesnsus genome assembly | CL, ONT |
-| assembly_fasta | File | Consensus genome assembly; for lower quality flu samples, the output may state "Assembly could not be generated" when there is too little and/or too low quality data for IRMA to produce an assembly | CL, ONT, PE, SE |
+| assembly_fasta | File | Consensus genome assembly; for lower quality flu samples, the output may state "Assembly could not be generated" when there is too little and/or too low quality data for IRMA to produce an assembly. Contigs will be ordered from smallest to largest when IRMA is used. | CL, ONT, PE, SE |
 | assembly_length_unambiguous | Int | Number of unambiguous basecalls within the consensus assembly | CL, FASTA, ONT, PE, SE |
 | assembly_mean_coverage | Float | Mean sequencing depth throughout the consensus assembly. Generated after performing primer trimming and calculated using the SAMtools coverage command | CL, ONT, PE, SE |
 | assembly_method | String | Method employed to generate consensus assembly | CL, FASTA, ONT, PE, SE |


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #630 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
PR updates TheiaCoV workflow for when "flu" organism is chosen, and reorders flue segments from largest to smallest in the irma task. 
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
wf: TheiaCov
task: task_irma

This PR may lead to different results in pre-existing outputs: **Yes**

This PR uses an element that could cause duplicate runs to have different results: **Yes/No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Changes take expected flu segment lengths (large to small) and concatenates them in the irma task to the irma consensus fasta in descending order

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
In task_irma.wdl for the flu track of TheiaCoV, the process for creating the consensus fasta was updated to order the flu segments from largest to smallest `segments=("PB2" "PB1" "PA" "HA" "NP" "NA" "MP" "NS")` as per request, updating the assembly_fasta output. 

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
- assembly_fasta (when flu track is triggered)
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
This PR was tested against flu data found in the flu_testing table [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/data). The workspace for testing this data can be found [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/42b14b65-0b37-4e4c-8127-154d256140a4).

Further testing was done on the theiacov validation set against [WNV](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/52959af0-4c09-4631-b6d9-4a90890ee2d5) and [MPXV](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/d9d5241b-addf-4de2-a89c-c64988ab57f1)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->
Test with flu set from flu_testing table [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/data). For flu ensure output fasta are in the following order of segments: `segments=("PB2" "PB1" "PA" "HA" "NP" "NA" "MP" "NS")`. Test with validation sets of your choosing. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (Theiagen developers only)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
