### PR TITLE
[TheiaCoV] Update nextclade dataset tags and pangolin docker version

### DIFF
--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -234,7 +234,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
       md5sum: 4dff84d2d6ada820e0e3a8bc6798d402
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: a51a91e0b5e16590c1afd0c7897ad071
+      md5sum: 32f20640f926d5b59fed6b954541792d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
@@ -308,13 +308,13 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 59478efddde2191ead1b46b1f121bbc9
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 0803245359027bd3017d2bd9a9c9c8e3
+      md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: b5dbf2ba7480effea8c656099df0e78e
+      md5sum: dfd90750c8776f46bad1de214c1d1a57
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/clearlabs.pangolin_report.csv
-      md5sum: 151390c419b00ca44eb83e2bbfb96996
+      md5sum: 0370f24c270c44f6023dd98af79501e7
     - path: miniwdl_run/call-stats_n_coverage/command
       md5sum: ac020678f99ac145b11d3dbc7b9fe9ba
     - path: miniwdl_run/call-stats_n_coverage/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_fasta.yml
@@ -37,7 +37,7 @@
       md5sum: 6808ca805661622ad65ae014a4b2a094
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: 59868097729a0dac73f93a62d57ecd4c
+      md5sum: 5f142285394dd5432eeda69c8db06444
     - path: miniwdl_run/call-nextclade_v3/inputs.json
     - path: miniwdl_run/call-nextclade_v3/outputs.json
     - path: miniwdl_run/call-nextclade_v3/stderr.txt
@@ -50,22 +50,22 @@
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.auspice.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.fasta.gz.nextclade.tsv
-      md5sum: 3aeae954ba64b8ad7db55e08f9c7131c
+      md5sum: 6f73969f56007a50f230d9768d95daf1
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
       md5sum: bf487271d506418ea23fe30fc033e44d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
-      md5sum: 50ca5404982b62cbdf077c5d16543e6f
+      md5sum: d03e4ca908ab966f2a5c4e6a2a346c74
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
       md5sum: 4dff84d2d6ada820e0e3a8bc6798d402
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: a51a91e0b5e16590c1afd0c7897ad071
+      md5sum: 32f20640f926d5b59fed6b954541792d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
       md5sum: c2a4d6cbb837dce22d81f9c36dd0629e
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
-      md5sum: f5a645741d65a60de34373e9e912b8a1
+      md5sum: 82d588f58ef37c713bdc1eb8d2c5c22d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.E.fasta
       md5sum: dc43b1e98245a25c142aec52b29a07df
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.M.fasta
@@ -111,7 +111,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.fasta.gz.nextclade.tsv
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
-      md5sum: 3aeae954ba64b8ad7db55e08f9c7131c
+      md5sum: 6f73969f56007a50f230d9768d95daf1
     - path: miniwdl_run/call-pangolin4/command
       md5sum: b9c36681b77c5e007bf7e890265d70eb
     - path: miniwdl_run/call-pangolin4/inputs.json
@@ -130,12 +130,12 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 71eba5c871bca955ab2a69dbd2c3c62e
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: e01f9468a9a5490f5743cc0ca76286a7
+      md5sum: e5d1adcf421ec6306f35626a6f7c9961
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: b5dbf2ba7480effea8c656099df0e78e
+      md5sum: dfd90750c8776f46bad1de214c1d1a57
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.fasta.gz
     - path: miniwdl_run/call-pangolin4/work/fasta.pangolin_report.csv
-      md5sum: 163d8390eb18b50c7d871edf815d029f
+      md5sum: 87c7b2dbd5d507949ff6cfddfee22766
     - path: miniwdl_run/call-vadr/command
       md5sum: 9e4318eb5b452da239723882bbcfe352
     - path: miniwdl_run/call-vadr/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -364,14 +364,14 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: e98d2fc28664c0622f6b490433286e32
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 0803245359027bd3017d2bd9a9c9c8e3
+      md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: b5dbf2ba7480effea8c656099df0e78e
+      md5sum: dfd90750c8776f46bad1de214c1d1a57
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/SRR13687078.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: 75c10b0cc6a7c826b84f6b3fa8be5a26
+      md5sum: 113378e9114fde0abcf359fda49de568
     - path: miniwdl_run/call-nextclade_v3/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_v3/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -316,9 +316,9 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 0b1f8fb5b938fe71631f61234cbf7ab3
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 0803245359027bd3017d2bd9a9c9c8e3
+      md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: b5dbf2ba7480effea8c656099df0e78e
+      md5sum: dfd90750c8776f46bad1de214c1d1a57
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade
@@ -372,7 +372,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
-      md5sum: a51a91e0b5e16590c1afd0c7897ad071
+      md5sum: 32f20640f926d5b59fed6b954541792d
     - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade output parsing

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -323,7 +323,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     # nextclade
     - path: miniwdl_run/call-nextclade_v3/command
-      md5sum: a98129345713c75ac2e51ffa465c1703
+      md5sum: c5d644127d8eae3f8fb3e3eaecb7fd2e
     - path: miniwdl_run/call-nextclade_v3/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_v3/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -205,9 +205,9 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 35aa27af5fb90d54561ee9d45a3163d5
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 0803245359027bd3017d2bd9a9c9c8e3
+      md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: b5dbf2ba7480effea8c656099df0e78e
+      md5sum: dfd90750c8776f46bad1de214c1d1a57
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/ont.pangolin_report.csv

--- a/workflows/utilities/wf_organism_parameters.wdl
+++ b/workflows/utilities/wf_organism_parameters.wdl
@@ -52,9 +52,9 @@ workflow organism_parameters {
     String sc2_org_name = "sars-cov-2"
     String sc2_reference_genome = "gs://theiagen-public-files-rp/terra/augur-sars-cov-2-references/MN908947.fasta"
     String sc2_gene_locations_bed = "gs://theiagen-public-files-rp/terra/sars-cov-2-files/sc2_gene_locations.bed"
-    String sc2_nextclade_ds_tag = "2024-07-17--12-57-03Z"
+    String sc2_nextclade_ds_tag = "2024-11-19--14-18-53Z"
     String sc2_nextclade_ds_name = "nextstrain/sars-cov-2/wuhan-hu-1/orfs"
-    String sc2_pangolin_docker = "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.29"
+    String sc2_pangolin_docker = "us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.31"
     Int sc2_genome_len = 29903
     Int sc2_vadr_max_length = 30000
     Int sc2_vadr_skip_length = 10000
@@ -65,7 +65,7 @@ workflow organism_parameters {
     String mpox_org_name = "MPXV"
     String mpox_reference_genome = "gs://theiagen-public-files/terra/mpxv-files/MPXV.MT903345.reference.fasta"
     String mpox_gene_locations_bed = "gs://theiagen-public-files/terra/mpxv-files/mpox_gene_locations.bed"
-    String mpox_nextclade_ds_tag = "2024-04-19--07-50-39Z"
+    String mpox_nextclade_ds_tag = "2024-11-19--14-18-53Z"
     String mpox_nextclade_ds_name = "nextstrain/mpox/lineage-b.1"
     String mpox_kraken_target_organism = "Monkeypox virus"
     String mpox_primer_bed_file = "gs://theiagen-public-files/terra/mpxv-files/MPXV.primer.bed"
@@ -124,7 +124,7 @@ workflow organism_parameters {
       if (flu_subtype == "H1N1") {
         String h1n1_ha_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_h1n1pdm_ha.fasta"
         String h1n1_ha_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_h1n1pdm_ha.gb"
-        String h1n1_ha_nextclade_ds_tag = "2024-07-03--08-29-55Z"
+        String h1n1_ha_nextclade_ds_tag = "2024-11-27--02-51-00Z"
         String h1n1_ha_nextclade_ds_name = "nextstrain/flu/h1n1pdm/ha/MW626062"
         String h1n1_ha_clades_tsv = "gs://theiagen-public-files-rp/terra/flu-references/clades_h1n1pdm_ha.tsv"
         String h1n1_ha_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_h1n1pdm.json"
@@ -132,7 +132,7 @@ workflow organism_parameters {
       if (flu_subtype == "H3N2") {
         String h3n2_ha_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_h3n2_ha.fasta"
         String h3n2_ha_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_h3n2_ha.gb"
-        String h3n2_ha_nextclade_ds_tag = "2024-08-08--05-08-21Z"
+        String h3n2_ha_nextclade_ds_tag = "2024-11-27--02-51-00Z"
         String h3n2_ha_nextclade_ds_name = "nextstrain/flu/h3n2/ha/EPI1857216"
         String h3n2_ha_clades_tsv = "gs://theiagen-public-files-rp/terra/flu-references/clades_h3n2_ha.tsv"
         String h3n2_ha_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_h3n2.json"
@@ -140,7 +140,7 @@ workflow organism_parameters {
       if (flu_subtype == "Victoria") {
         String vic_ha_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_vic_ha.fasta"
         String vic_ha_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_vic_ha.gb"
-        String vic_ha_nextclade_ds_tag = "2024-07-03--08-29-55Z"
+        String vic_ha_nextclade_ds_tag = "2024-11-05--09-19-52Z"
         String vic_ha_nextclade_ds_name = "nextstrain/flu/vic/ha/KX058884"
         String vic_ha_clades_tsv = "gs://theiagen-public-files-rp/terra/flu-references/clades_vic_ha.tsv"
         String vic_ha_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_vic.json"
@@ -167,21 +167,21 @@ workflow organism_parameters {
       if (flu_subtype == "H1N1") {
         String h1n1_na_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_h1n1pdm_na.fasta"
         String h1n1_na_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_h1n1pdm_na.gb"
-        String h1n1_na_nextclade_ds_tag = "2024-07-03--08-29-55Z"
+        String h1n1_na_nextclade_ds_tag = "2024-11-05--09-19-52Z"
         String h1n1_na_nextclade_ds_name = "nextstrain/flu/h1n1pdm/na/MW626056"
         String h1n1_na_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_h1n1pdm.json"
       }
       if (flu_subtype == "H3N2") {
         String h3n2_na_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_h3n2_na.fasta"
         String h3n2_na_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_h3n2_na.gb"
-        String h3n2_na_nextclade_ds_tag = "2024-04-19--07-50-39Z"
+        String h3n2_na_nextclade_ds_tag = "2024-11-05--09-19-52Z"
         String h3n2_na_nextclade_ds_name = "nextstrain/flu/h3n2/na/EPI1857215"
         String h3n2_na_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_h3n2.json"
       }
       if (flu_subtype == "Victoria") {
         String vic_na_reference = "gs://theiagen-public-files-rp/terra/flu-references/reference_vic_na.fasta"
         String vic_na_reference_gbk = "gs://theiagen-public-files-rp/terra/flu-references/reference_yam_na.gb"
-        String vic_na_nextclade_ds_tag = "2024-04-19--07-50-39Z"
+        String vic_na_nextclade_ds_tag = "2024-11-05--09-19-52Z"
         String vic_na_nextclade_ds_name = "nextstrain/flu/vic/na/CY073894"
         String vic_na_auspice_config = "gs://theiagen-public-files-rp/terra/flu-references/auspice_config_vic.json"
       }
@@ -197,7 +197,7 @@ workflow organism_parameters {
   if (organism == "rsv_a" || organism == "rsv-a" || organism == "RSV-A" || organism == "RSV_A") {
     String rsv_a_org_name = "rsv_a"
     String rsv_a_reference_genome = "gs://theiagen-public-files-rp/terra/rsv_references/reference_rsv_a.fasta"
-    String rsv_a_nextclade_ds_tag = "2024-08-01--22-31-31Z"
+    String rsv_a_nextclade_ds_tag = "2024-11-27--02-51-00Z"
     String rsv_a_nextclade_ds_name = "nextstrain/rsv/a/EPI_ISL_412866"
     Int rsv_a_genome_len = 15500
     String rsv_a_kraken_target_organism = "Respiratory syncytial virus"
@@ -221,7 +221,7 @@ workflow organism_parameters {
   if (organism == "rsv_b" || organism == "rsv-b" || organism == "RSV-B" || organism == "RSV_B") {
     String rsv_b_org_name = "rsv_b"
     String rsv_b_reference_genome = "gs://theiagen-public-files-rp/terra/rsv_references/reference_rsv_b.fasta"
-    String rsv_b_nextclade_ds_tag = "2024-08-01--22-31-31Z"
+    String rsv_b_nextclade_ds_tag = "2024-11-27--02-51-00Z"
     String rsv_b_nextclade_ds_name = "nextstrain/rsv/b/EPI_ISL_1653999"
     Int rsv_b_genome_len = 15500
     String rsv_b_kraken_target_organism = "Human orthopneumovirus"  


### PR DESCRIPTION
… parameters

<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #669 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR updates nextclade dataset tags to the latest versions as of 12/3/2024, as well as bumping the pangolin docker from 1.29 -> 1.31. 

Aside, but along with this I made a utility to automatically check nextclade versions that need to be udpated. 
https://github.com/theiagen/utilities/blob/mb-nextclade-utility/scripts/nextclade-version-check.sh
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

The `wf_organism_parameters` has been updated. 

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

The following changes have been made for latest updates:

| Variable Name | Dataset Name | Latest Tag | Current Tag |
|--------------|--------------|------------|-------------|
| sc2_nextclade_ds_name | nextstrain/sars-cov-2/wuhan-hu-1/orfs | 2024-11-19--14-18-53Z | 2024-07-17--12-57-03Z | 
| mpox_nextclade_ds_name | nextstrain/mpox/lineage-b.1 | 2024-11-19--14-18-53Z | 2024-04-19--07-50-39Z | 
| h1n1_ha_nextclade_ds_name | nextstrain/flu/h1n1pdm/ha/MW626062 | 2024-11-27--02-51-00Z | 2024-07-03--08-29-55Z | 
| h3n2_ha_nextclade_ds_name | nextstrain/flu/h3n2/ha/EPI1857216 | 2024-11-27--02-51-00Z | 2024-08-08--05-08-21Z | 
| vic_ha_nextclade_ds_name | nextstrain/flu/vic/ha/KX058884 | 2024-11-05--09-19-52Z | 2024-07-03--08-29-55Z | 
| h1n1_na_nextclade_ds_name | nextstrain/flu/h1n1pdm/na/MW626056 | 2024-11-05--09-19-52Z | 2024-07-03--08-29-55Z | 
| h3n2_na_nextclade_ds_name | nextstrain/flu/h3n2/na/EPI1857215 | 2024-11-05--09-19-52Z | 2024-04-19--07-50-39Z | 
| vic_na_nextclade_ds_name | nextstrain/flu/vic/na/CY073894 | 2024-11-05--09-19-52Z | 2024-04-19--07-50-39Z |
| rsv_a_nextclade_ds_name | nextstrain/rsv/a/EPI_ISL_412866 | 2024-11-27--02-51-00Z | 2024-08-01--22-31-31Z | 
| rsv_b_nextclade_ds_name | nextstrain/rsv/b/EPI_ISL_1653999 | 2024-11-27--02-51-00Z | 2024-08-01--22-31-31Z | 

As well as bumping the pangolin docker:

`us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.29` - -> `us-docker.pkg.dev/general-theiagen/staphb/pangolin:4.3.1-pdata-1.31`

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

Pangolin docker has been bumped from 1.29 -> 1.31.
Database versions for nextclade have been bumped for the latest versions available, as per the table above. 

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
No inputs have been changed. 
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
No outputs have been changed. 

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
TheiaCoV illumina PE has been tested [here](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/7f9c7395-1c8e-45ed-a850-56a57b5b28b7), Sars-cov-2, MPX, WNV, HIV, FLU + variants, rsv-a & rsv-b has been tested. All updated versions can be found in the nextclade_ds_tag. 

Tested the following to ensure no issues with nextclade updates:
[TheiaCoV_Fasta_PHB](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/378029ce-25be-4dd8-b4f7-8f23e7b2b73f)
[TheiaCoV_Illumina_SE_PHB](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/0c21919d-684d-46e2-b2ad-68650d45afd4)
[TheiaCoV_Clearlabs_PHB](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/87aa69bd-3c18-45dc-ac91-d5569a44a5a2)
[TheiaCoV_ONT_PHB](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/a1a3a362-ba67-482e-bb85-b91c0f7f2a8c)

Please bring up any other scenarios you would like me to test. 
### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->
Please repeat the TheiaCoV_Illumina_PE test and check that all the organisms selected have the corrected update or NA. Feel free to test any of the other TheiaCoV variations. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (Theiagen developers only)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
