### PR TITLE
[Artic] Large overhaul for newer versions supporting clair3

### DIFF
--- a/docs/workflows/genomic_characterization/theiacov.md
+++ b/docs/workflows/genomic_characterization/theiacov.md
@@ -128,8 +128,8 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | clean_check_reads | **memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 2 | Optional | ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | consensus | **cpu** | Int | Number of CPUs to allocate to the task | 8 | Optional | CL, ONT | sars-cov-2 |
 | consensus | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | CL, ONT | sars-cov-2 |
-| consensus | **docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019-epi2me | Optional | ONT | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
-| consensus | **medaka_model** | String | In order to obtain the best results, the appropriate model must be set to match the sequencer's basecaller model; this string takes the format of {pore}_{device}_{caller variant}_{caller_version}. See also https://github.com/nanoporetech/medaka?tab=readme-ov-file#models. | r941_min_high_g360 | Optional | CL, ONT | sars-cov-2 |
+| consensus | **docker** | String | The Docker container to use for the task |  us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0_rerio | Optional | ONT | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
+| consensus | **clair3_model** | String | In order to obtain the best results, the appropriate model must be set to match the sequencer's basecaller model, Clair includes these: https://github.com/HKU-BAL/Clair3?tab=readme-ov-file#pre-trained-models . More models also found here: https://github.com/nanoporetech/rerio?tab=readme-ov-file#clair3-models. | r1041_e82_400bps_hac_v420 | Optional | CL, ONT | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | consensus | **memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 16 | Optional | CL, ONT | sars-cov-2 |
 | consensus_qc | **cpu** | Int | Number of CPUs to allocate to the task | 1 | Optional | CL, FASTA, ONT, PE, SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
 | consensus_qc | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional | CL, FASTA, ONT, PE, SE | HIV, MPXV, WNV, rsv_a, rsv_b, sars-cov-2 |
@@ -377,7 +377,7 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | workflow name | **genome_length** | Int | Use to specify the expected genome length | | Optional | FASTA, ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | workflow name | **max_genome_length** | Int | Maximum genome length able to pass read screening | 2673870 | Optional | ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | workflow name | **max_length** | Int | Maximum length for a read based on the SARS-CoV-2 primer scheme | 700 | Optional | ONT | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
-| workflow name | **medaka_docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019:1.3.0-medaka-1.4.3 | Optional | CL | |
+| workflow name | **artic_docker_image** | String | The Docker container to use for the task | | Optional | CL | |
 | workflow name | **min_basepairs** | Int | Minimum base pairs to pass read screening | 34000 | Optional | ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | workflow name | **min_coverage** | Int | Minimum coverage to pass read screening | 10 | Optional | ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
 | workflow name | **min_depth** | Int | Minimum depth of reads required to call variants and generate a consensus genome. This value is passed to the iVar software. | 100 | Optional | ONT, PE, SE | HIV, MPXV, WNV, flu, rsv_a, rsv_b, sars-cov-2 |
@@ -828,7 +828,7 @@ All input reads are processed through "core tasks" in the TheiaCoV Illumina, ONT
 
 ??? toggle "`artic_consensus`: Alignment, Primer Trimming, Variant Detection, and Consensus ==_for non-flu organisms in ONT & ClearLabs workflows_=="
 
-    Briefly, input reads are aligned to the appropriate reference with [minimap2](https://github.com/lh3/minimap2) to generate a Binary Alignment Mapping ([BAM](https://en.wikipedia.org/wiki/Binary_Alignment_Map)) file. Primer sequences are then removed from the BAM file and a consensus assembly file is generated using the [Artic minion](https://artic.readthedocs.io/en/latest/commands/#basecaller) Medaka argument.
+    Briefly, input reads are aligned to the appropriate reference with [minimap2](https://github.com/lh3/minimap2) to generate a Binary Alignment Mapping ([BAM](https://en.wikipedia.org/wiki/Binary_Alignment_Map)) file. Primer sequences are then removed from the BAM file and a consensus assembly file is generated using the [Artic minion](https://artic.readthedocs.io/en/latest/commands/#basecaller) argument. Variant calling is done using [Clair3](https://github.com/HKU-BAL/Clair3).
 
     !!! info ""
         Read-trimming is performed on raw read data generated on the ClearLabs instrument and thus not a required step in the TheiaCoV_ClearLabs workflow.
@@ -994,6 +994,7 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | aligned_bai | File | Index companion file to the bam file generated during the consensus assembly process | CL, ONT, PE, SE |
 | aligned_bam | File | Primer-trimmed BAM file; generated during consensus assembly process | CL, ONT, PE, SE |
 | artic_docker | String | Docker image utilized for read trimming and consensus genome assembly | CL, ONT |
+| artic_reference | String | Reference file used in artic pipeline | CL, ONT |
 | artic_version | String | Version of the Artic software utilized for read trimming and conesnsus genome assembly | CL, ONT |
 | assembly_fasta | File | Consensus genome assembly; for lower quality flu samples, the output may state "Assembly could not be generated" when there is too little and/or too low quality data for IRMA to produce an assembly. Contigs will be ordered from largest to smallest when IRMA is used. | CL, ONT, PE, SE |
 | assembly_length_unambiguous | Int | Number of unambiguous basecalls within the consensus assembly | CL, FASTA, ONT, PE, SE |
@@ -1005,6 +1006,7 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | bbduk_docker | String | Docker image used to run BBDuk | PE, SE |
 | bwa_version | String | Version of BWA used to map read data to the reference genome | PE, SE |
 | consensus_flagstat | File | Output from the SAMtools flagstat command to assess quality of the alignment file (BAM) | CL, ONT, PE, SE |
+|clair3_vcf| File | Clair3 VCF output by artic containing all passing variants | ONT |
 | consensus_n_variant_min_depth | Int | Minimum read depth to call variants for iVar consensus and iVar variants | PE, SE |
 | consensus_stats | File | Output from the SAMtools stats command to assess quality of the alignment file (BAM) | CL, ONT, PE, SE |
 | est_coverage_clean | Float | Estimated coverage of the clean reads | ONT |
@@ -1087,8 +1089,6 @@ All TheiaCoV Workflows (not TheiaCoV_FASTA_Batch)
 | kraken_version | String | Version of Kraken software used | CL, ONT, PE, SE |
 | meanbaseq_trim | Float | Mean quality of the nucleotide basecalls aligned to the reference genome after primer trimming | CL, ONT, PE, SE |
 | meanmapq_trim | Float | Mean quality of the mapped reads to the reference genome after primer trimming | CL, ONT, PE, SE |
-| medaka_reference | String | Reference sequence used in medaka task | CL, ONT |
-| medaka_vcf | File | A VCF file containing the identified variants | ONT |
 | nanoplot_docker | String | Docker image used to run Nanoplot | ONT |
 | nanoplot_html_clean | File | An HTML report describing the clean reads | ONT |
 | nanoplot_html_raw | File | An HTML report describing the raw reads | ONT |

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -19,19 +19,26 @@ task consensus {
 
     # Determine if we're using provided or local schemes - most of the time will be provided
     # But with newer versions of ARTIC, we can use remote schemes from https://github.com/quick-lab/primerschemes
-    if [[ -z "~{primer_bed}" && -z "~{reference_genome}" ]]; then
+    # Check if primer_bed is empty OR its file is empty/nonexistent AND reference_genome is empty/nonexistent
+    if [[ -z "~{primer_bed}" || ! -s "~{primer_bed}" ]] && [[ -z "~{reference_genome}" || ! -s "~{reference_genome}" ]]; then
       echo "Using remote scheme..."
       
       # Set scheme parameters based on organism
       if [[ "~{organism}" == "sars-cov-2" ]]; then
         scheme_name="sars-cov-2"
         scheme_version="v4.0.0"
+        scheme_length="400"
+      elif [[ "~{organism}" == "MPXV" ]]; then
+        scheme_name="artic-inrb-mpox"
+        scheme_version="v1.0.0"
+        scheme_length="400"
       else
         echo "Error: Unsupported organism for remote schemes: ~{organism}" >&2
         echo "Please provide primer bed and reference genome for custom organisms" >&2
         exit 1
       fi
-
+      
+      echo "Using scheme: ${scheme_name} ${scheme_version} ${scheme_length}"
       # Run ARTIC with remote scheme per newer versions of ARTIC
       artic minion --model ~{clair3_model} \
         --normalise ~{normalise} \
@@ -39,6 +46,7 @@ task consensus {
         --scheme-directory /data/primer-schemes \
         --scheme-name ${scheme_name} \
         --scheme-version ${scheme_version} \
+        --scheme-length ${scheme_length} \
         --read-file ~{read1} \
         ~{samplename}
 

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -11,8 +11,8 @@ task consensus {
     Int cpu = 8
     Int memory = 16
     Int disk_size = 100
-    String clair3_model = "r941_prom_hac_g360+g422"
-    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0"
+    String clair3_model = "r1041_e82_400bps_hac_v420"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0_rerio"
   }
   command <<<
     set -euo pipefail
@@ -26,9 +26,6 @@ task consensus {
       if [[ "~{organism}" == "sars-cov-2" ]]; then
         scheme_name="sars-cov-2"
         scheme_version="v4.0.0"
-      elif [[ "~{organism}" == "MPXV" ]]; then
-        scheme_name="mpox"
-        scheme_version="v1.0.0"
       else
         echo "Error: Unsupported organism for remote schemes: ~{organism}" >&2
         echo "Please provide primer bed and reference genome for custom organisms" >&2
@@ -79,7 +76,8 @@ task consensus {
     echo "Artic Pipeline Version $(artic -v)" > VERSION
 
     # Grab reads from alignment - cdph wants this
-    samtools fastq -F4 ~{samplename}.primertrimmed.rg.sorted.bam | gzip > ~{samplename}.fastq.gz  
+    # 0x904 means we are now filtering out unaligned, secondary, and supplemental alignments - thanks Curtis
+    samtools fastq -F0x904 ~{samplename}.primertrimmed.rg.sorted.bam | gzip > ~{samplename}.fastq.gz  
   >>>
   output {
     File consensus_seq = "~{samplename}.consensus.fasta"

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -5,84 +5,93 @@ task consensus {
     String samplename
     String? organism
     File read1
-    File primer_bed
+    File? primer_bed
     File? reference_genome
     Int normalise = 20000
     Int cpu = 8
     Int memory = 16
     Int disk_size = 100
-    String medaka_model = "r941_min_high_g360"
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019-epi2me"
+    String clair3_model = "r941_prom_hac_g360+g422"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.5.8_dev2"
   }
-  String primer_name = basename(primer_bed)
   command <<<
-    # HIV
-    if [[ ~{organism} == "HIV" ]]; then
-      # setup custom primer scheme (/V is required by Artic)
-      mkdir -p ./primer-schemes/HIV/Vuser
+    set -euo pipefail
 
-      ## set reference genome
-      ref_genome="~{reference_genome}"
-
-      head -n1 "${ref_genome}" | sed 's/>//' | tee REFERENCE_GENOME
-      cp "${ref_genome}" ./primer-schemes/HIV/Vuser/HIV.reference.fasta
-
-      ## set primers
-      #cp ~{primer_bed} ./primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
-      #p_bed="~{primer_bed}"
-      cp "~{primer_bed}" ./primer-schemes/HIV/Vuser/HIV.scheme.bed
-      scheme_name="HIV/Vuser"
-    # Add other viruses here
-    # Default is SARS-CoV-2
-    else
-      # setup custom primer scheme (/V is required by Artic)
-      mkdir -p ./primer-schemes/SARS-CoV-2/Vuser
-
-      ## set reference genome
-      if [[ ! -z "~{reference_genome}" ]]; then
-        ref_genome="~{reference_genome}"
+    # Determine if we're using provided or local schemes - most of the time will be provided
+    # But with newer versions of ARTIC, we can use remote schemes from https://github.com/quick-lab/primerschemes
+    if [[ -z "~{primer_bed}" && -z "~{reference_genome}" ]]; then
+      echo "Using remote scheme..."
+      
+      # Set scheme parameters based on organism
+      if [[ "~{organism}" == "sars-cov-2" ]]; then
+        scheme_name="sars-cov-2"
+        scheme_version="v4.0.0"
+      elif [[ "~{organism}" == "MPXV" ]]; then
+        scheme_name="mpox"
+        scheme_version="v1.0.0"
       else
-        # use reference file in docker--different paths depending on image specified 
-        if [[ -d "/fieldbioinformatics" ]]; then
-          ref_genome=$(find /fieldbioinformatics/*/primer*schemes/nCoV-2019/V3/ -name "nCoV-2019.reference.fasta")
-        else
-          ref_genome=$(find /wf-artic*/data/primer_schemes/SARS-CoV-2/V4/ -name "SARS-CoV-2.reference.fasta")
-        fi
-        echo "No user-defined reference genome; setting reference to ${ref_genome}"
+        echo "Error: Unsupported organism for remote schemes: ~{organism}" >&2
+        echo "Please provide primer bed and reference genome for custom organisms" >&2
+        exit 1
       fi
-      head -n1 "${ref_genome}" | sed 's/>//' | tee REFERENCE_GENOME
-      cp "${ref_genome}" ./primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.reference.fasta
 
-      ## set primers
-      cp ~{primer_bed} ./primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
-      scheme_name="SARS-CoV-2/Vuser"
+      # Run ARTIC with remote scheme per newer versions of ARTIC
+      artic minion --model ~{clair3_model} \
+        --normalise ~{normalise} \
+        --threads ~{cpu} \
+        --scheme-directory /data/primer-schemes \
+        --scheme-name ${scheme_name} \
+        --scheme-version ${scheme_version} \
+        --read-file ~{read1} \
+        ~{samplename}
+
+      # Set output file contents for remote scheme
+      echo "${scheme_name}" > REFERENCE_GENOME
+      echo "${scheme_name}_${scheme_version}" > PRIMER_NAME
+
+    else
+      # Newer version of Artic use a different command to launch the pipeline
+      # when using user provided files for bed and reference genome are provided, 
+      # we can now provide the bed and reference genome files to the pipeline directly 
+      # instead of using the --scheme-directory and --scheme-name flags
+      echo "Using user provided files..."
+      
+      if [[ -z "~{primer_bed}" || -z "~{reference_genome}" ]]; then
+        echo "Error: Both primer bed and reference genome must be provided for local scheme" >&2
+        exit 1
+      fi
+
+      # Run ARTIC with user provided files
+      artic minion --model ~{clair3_model} \
+        --normalise ~{normalise} \
+        --threads ~{cpu} \
+        --bed ~{primer_bed} \
+        --ref ~{reference_genome} \
+        --read-file ~{read1} \
+        ~{samplename}
+
+      # Set output file contents for local scheme
+      head -n1 "~{reference_genome}" | sed 's/>//' > REFERENCE_GENOME
+      basename "~{primer_bed}" > PRIMER_NAME
     fi
 
-    # version control
-    echo "Medaka via $(artic -v)" | tee VERSION
-    echo "~{primer_name}" | tee PRIMER_NAME
-    artic minion --medaka --medaka-model ~{medaka_model} --normalise ~{normalise} --threads ~{cpu} --scheme-directory ./primer-schemes --read-file ~{read1} ${scheme_name} ~{samplename}
-    gunzip -f ~{samplename}.pass.vcf.gz
+    # Capture ARTIC version
+    echo "Artic Pipeline Version $(artic -v)" > VERSION
 
-    # clean up fasta header
-    echo ">~{samplename}" > ~{samplename}.medaka.consensus.fasta
-    grep -v ">" ~{samplename}.consensus.fasta >> ~{samplename}.medaka.consensus.fasta
-
-    # grab reads from alignment
+    # Grab reads from alignment - cdph wants this
     samtools fastq -F4 ~{samplename}.primertrimmed.rg.sorted.bam | gzip > ~{samplename}.fastq.gz  
   >>>
   output {
-    File consensus_seq = "~{samplename}.medaka.consensus.fasta"
+    File artic_consensus_fasta = "~{samplename}.consensus.fasta"
+    File artic_clair3_pass_vcf = "~{samplename}.pass.vcf"
+    String artic_pipeline_reference = read_string("REFERENCE_GENOME")
+    String artic_pipeline_version = read_string("VERSION")
+    String artic_pipeline_docker = docker
     File sorted_bam = "~{samplename}.trimmed.rg.sorted.bam"
     File trim_sorted_bam = "~{samplename}.primertrimmed.rg.sorted.bam"
     File trim_sorted_bai = "~{samplename}.primertrimmed.rg.sorted.bam.bai"
-    File medaka_pass_vcf = "~{samplename}.pass.vcf"
     File? reads_aligned = "~{samplename}.fastq.gz"
-    String medaka_reference = read_string("REFERENCE_GENOME")
-    String artic_pipeline_version = read_string("VERSION")
-    String artic_pipeline_docker = docker
     String primer_bed_name = read_string("PRIMER_NAME")
-    File? trim_fastq = "~{samplename}.primertrimmed.rg.fastq"
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -58,12 +58,14 @@ task consensus {
         exit 1
       fi
 
+      # Copy reference files to working directory
+      cp "~{reference_genome}" reference.fasta
       # Run ARTIC with user provided files
       artic minion --model ~{clair3_model} \
         --normalise ~{normalise} \
         --threads ~{cpu} \
         --bed ~{primer_bed} \
-        --ref ~{reference_genome} \
+        --ref reference.fasta \
         --read-file ~{read1} \
         ~{samplename}
 

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -58,7 +58,8 @@ task consensus {
         exit 1
       fi
 
-      # Copy reference files to working directory
+      # Copy reference files to working directory, this is neccessary for fiadx to work
+      # which is a requirement of clair3, we run into similar issues in the clair3_variants task
       cp "~{reference_genome}" reference.fasta
       # Run ARTIC with user provided files
       artic minion --model ~{clair3_model} \

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -82,8 +82,9 @@ task consensus {
     samtools fastq -F4 ~{samplename}.primertrimmed.rg.sorted.bam | gzip > ~{samplename}.fastq.gz  
   >>>
   output {
-    File artic_consensus_fasta = "~{samplename}.consensus.fasta"
+    File consensus_seq = "~{samplename}.consensus.fasta"
     File artic_clair3_pass_vcf = "~{samplename}.pass.vcf"
+    String artic_clair3_model = clair3_model
     String artic_pipeline_reference = read_string("REFERENCE_GENOME")
     String artic_pipeline_version = read_string("VERSION")
     String artic_pipeline_docker = docker

--- a/tasks/assembly/task_artic_consensus.wdl
+++ b/tasks/assembly/task_artic_consensus.wdl
@@ -12,7 +12,7 @@ task consensus {
     Int memory = 16
     Int disk_size = 100
     String clair3_model = "r941_prom_hac_g360+g422"
-    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.5.8_dev2"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0"
   }
   command <<<
     set -euo pipefail

--- a/tasks/quality_control/read_filtering/task_artic_guppyplex.wdl
+++ b/tasks/quality_control/read_filtering/task_artic_guppyplex.wdl
@@ -5,7 +5,7 @@ task read_filtering {
     File read1
     String samplename
     String run_prefix = "artic_ncov2019"
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0_rerio"
     Int min_length = 400
     Int max_length = 700
     Int cpu = 8

--- a/tasks/quality_control/read_filtering/task_artic_guppyplex.wdl
+++ b/tasks/quality_control/read_filtering/task_artic_guppyplex.wdl
@@ -16,7 +16,7 @@ task read_filtering {
     # date and version control
     mkdir ~{samplename}
     cp ~{read1} ~{samplename}/
-    echo "DIRNAME: $(dirname)"
+    echo "DIRNAME: ~{samplename}"
 
     # run artic guppyplex 
     artic guppyplex --min-length ~{min_length} --max-length ~{max_length} --directory ~{samplename} --prefix ~{run_prefix}

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -41,7 +41,7 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.csv
       md5sum: 3cbc074cd5baefbf594c73ddfd633c8a
     - path: miniwdl_run/call-consensus/work/clearlabs.consensus.fasta
-      md5sum: a4dcfa721272ae95a5e950f3e2d25986
+      md5sum: 536f7643ef165dc7d72ca39e46cd3538
     - path: miniwdl_run/call-consensus/work/clearlabs.coverage_mask.txt
       md5sum: f3d76027b8506a5b1d0f5b1c7e7c8cff
     - path: miniwdl_run/call-consensus/work/clearlabs.fail.vcf
@@ -52,7 +52,6 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta
-      md5sum: 6401ca1acb69843b55b792754a54e444
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta.fai
     - path: miniwdl_run/call-consensus/work/clearlabs.primers.vcf
       md5sum: 8f60b25110cdf39ce27dd48719566416
@@ -77,15 +76,15 @@
       contains: ["wdl", "theiacov_clearlabs", "consensus_qc", "done"]
     - path: miniwdl_run/call-consensus_qc/work/DATE
     - path: miniwdl_run/call-consensus_qc/work/NUM_ACTG
-      md5sum: 8d7e91afbf4b25d066e0e4ee3f757af1
+      md5sum: b042297eaf71f467789516212e2ca5ac
     - path: miniwdl_run/call-consensus_qc/work/NUM_DEGENERATE
       md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-consensus_qc/work/NUM_N
-      md5sum: fd7c21d6426a67e58606f4f5af3bcb0c
+      md5sum: 8ad46215ff3252d17d9e062e6f84d472
     - path: miniwdl_run/call-consensus_qc/work/NUM_TOTAL
       md5sum: 64887188f1a0c0176ed5ad2e108d1046
     - path: miniwdl_run/call-consensus_qc/work/PERCENT_REF_COVERAGE
-      md5sum: 3f5b244cd6683efff0dec4915a795267
+      md5sum: 7f9226df824c26eaa79412a2ba1390ab
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-fastq_scan_clean_reads/command
@@ -206,7 +205,6 @@
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
-      md5sum: fd2c9f76bda2f2df78cdbae2e82d7430
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
@@ -375,13 +373,9 @@
       md5sum: 2562e7c1fd77507231c7059bb7f09a93
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus.vadr.tar.gz
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: d7167d1728389a9a48fbdbdb1f0f1675
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: 37ae1c39a53eef5d26944228b531a478
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: 5fe92e7fb7cf3fa33f74974e04faef48
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.2.fa
-      md5sum: 293fb93b99a93927ffac6411a057799d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
       md5sum: a763652b87cea3fe5b361f6327419b07
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.mat_peptide.2.fa
@@ -419,19 +413,12 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.pass.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.rpn
-      md5sum: ba4815d0793abb64566d6d303f20831d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sda
-      md5sum: 7a6d49ee8d1354238dfefeeab63ae25f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.seqstat
-      md5sum: 68ab4eef53100545cf3ec5dcfd3bf156
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sgm
-      md5sum: b97bad7e110cf7cac19cae374b80e1bb
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqa
-      md5sum: 1efac9aeee74d0cdfc7467799905fd6d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqc.txt
-      md5sum: 633508465581359ba1aba2f43ea1faf9
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus_trimmed.fasta
-      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus_vadr-fasta-files.zip
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.2.fa

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -21,7 +21,7 @@
     - path: miniwdl_run/call-consensus/inputs.json
       contains: ["read1", "samplename", "fastq"]
     - path: miniwdl_run/call-consensus/outputs.json
-      contains: ["consensus", "medaka_pass_vcf", "trim_sorted_bam"]
+      contains: ["consensus", "artic_clair3_pass_vcf", "trim_sorted_bam"]
     - path: miniwdl_run/call-consensus/stderr.txt
     - path: miniwdl_run/call-consensus/stderr.txt.offset
     - path: miniwdl_run/call-consensus/stdout.txt
@@ -32,44 +32,30 @@
     - path: miniwdl_run/call-consensus/work/REFERENCE_GENOME
       md5sum: 0e6efd549c8773f9a2f7a3e82619ee61
     - path: miniwdl_run/call-consensus/work/VERSION
-      md5sum: f3528ff85409c70100063c55ad75612b
+      md5sum: b50a846b8b57f344bcedad5c6962b2c7
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/artic-v3.primers.bed
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/clearlabs_R1_dehosted.fastq.gz
-    - path: miniwdl_run/call-consensus/work/clearlabs.1.hdf
     - path: miniwdl_run/call-consensus/work/clearlabs.1.vcf
-    - path: miniwdl_run/call-consensus/work/clearlabs.2.hdf
     - path: miniwdl_run/call-consensus/work/clearlabs.2.vcf
-    - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.er
-      md5sum: a5cdc705c76b0ed04da5aba852b457fa
-    - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.txt
-      md5sum: 866acd50ae51abddd4471d8d4148189b
-    - path: miniwdl_run/call-consensus/work/clearlabs.amplicon_plot_data_mqc.json
-      md5sum: 0569d0088a0042c473aa761df08bc4c6
-    - path: miniwdl_run/call-consensus/work/clearlabs.amplicon_stats_data_mqc.json
-      md5sum: 84cde1c25041ec4592ff46641353bb4a
+    - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.csv
+      md5sum: 3cbc074cd5baefbf594c73ddfd633c8a
     - path: miniwdl_run/call-consensus/work/clearlabs.consensus.fasta
-      md5sum: adb04dc7e733a9018981243df7df3666
+      md5sum: 536f7643ef165dc7d72ca39e46cd3538
     - path: miniwdl_run/call-consensus/work/clearlabs.coverage_mask.txt
       md5sum: f3d76027b8506a5b1d0f5b1c7e7c8cff
     - path: miniwdl_run/call-consensus/work/clearlabs.fail.vcf
     - path: miniwdl_run/call-consensus/work/clearlabs.fastq.gz
-    - path: miniwdl_run/call-consensus/work/clearlabs.medaka.consensus.fasta
-      md5sum: 0cfde305a06ac76d858bc38e03b8e43e
     - path: miniwdl_run/call-consensus/work/clearlabs.merged.vcf.gz
     - path: miniwdl_run/call-consensus/work/clearlabs.merged.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/clearlabs.minion.log.txt
-    - path: miniwdl_run/call-consensus/work/clearlabs.muscle.in.fasta
-      md5sum: ba7fb9dfbad227cf71eca71960684da3
-    - path: miniwdl_run/call-consensus/work/clearlabs.muscle.out.fasta
-      md5sum: 4e82a0f38a81e73994d2c18e9aa828e8
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta
-      md5sum: f1976dc2b5e9e604c2c3588c19503709
+      md5sum: 3279c5ce27628f7a34b3d11232e4de65
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta.fai
     - path: miniwdl_run/call-consensus/work/clearlabs.primers.vcf
-      md5sum: 173f73f55d32f99544af48f3544467cf
+      md5sum: 8f60b25110cdf39ce27dd48719566416
     - path: miniwdl_run/call-consensus/work/clearlabs.primersitereport.txt
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/clearlabs.primertrimmed.rg.sorted.bam
@@ -78,18 +64,10 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.sorted.bam.bai
     - path: miniwdl_run/call-consensus/work/clearlabs.trimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/clearlabs.trimmed.rg.sorted.bam.bai
-    - path: miniwdl_run/call-consensus/work/clearlabs.vcfcheck.log
-    - path: miniwdl_run/call-consensus/work/clearlabs.vcfreport.txt
-      md5sum: e08ab2cbd80de1e9c31e128e8e449652
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.reference.fasta
-      md5sum: b9b67235a2d9d0b0d7f531166ffefd41
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.reference.fasta.fai
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
-      md5sum: d5ad850f8c610dc45162957ab84530d6
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: f3962bd094641b408205378dc683e87e
+      md5sum: 48e7df2ae11e2aed2f5900efe9868921
     - path: miniwdl_run/call-consensus_qc/inputs.json
-      contains: ["assembly_fasta", "medaka"]
+      contains: ["assembly_fasta"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
       contains: ["consensus_qc", "number_N", "percent_reference_coverage"]
     - path: miniwdl_run/call-consensus_qc/stderr.txt
@@ -99,16 +77,16 @@
       contains: ["wdl", "theiacov_clearlabs", "consensus_qc", "done"]
     - path: miniwdl_run/call-consensus_qc/work/DATE
     - path: miniwdl_run/call-consensus_qc/work/NUM_ACTG
-      md5sum: c51cafa417f1fc0caa49cb98b1ea8a65
+      md5sum: b042297eaf71f467789516212e2ca5ac
     - path: miniwdl_run/call-consensus_qc/work/NUM_DEGENERATE
       md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-consensus_qc/work/NUM_N
-      md5sum: 274b28c15b0a21efb78323a00cf4e8f2
+      md5sum: 8ad46215ff3252d17d9e062e6f84d472
     - path: miniwdl_run/call-consensus_qc/work/NUM_TOTAL
       md5sum: 64887188f1a0c0176ed5ad2e108d1046
     - path: miniwdl_run/call-consensus_qc/work/PERCENT_REF_COVERAGE
-      md5sum: 31d0a19a3d1a6b809db3bb3b393f0d95
-    - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
+      md5sum: 7f9226df824c26eaa79412a2ba1390ab
+    - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-fastq_scan_clean_reads/command
       contains: ["read", "fastq", "zcat"]
@@ -222,13 +200,13 @@
       contains: ["wdl", "theiacov_clearlabs", "nextclade", "done"]
     - path: miniwdl_run/call-nextclade_v3/work/NEXTCLADE_VERSION
       md5sum: 70aa6879bf9f0e8ba2b9953b0d4a2216
-    - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
+    - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.medaka.consensus.nextclade.auspice.json
-    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.medaka.consensus.nextclade.json
-    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.medaka.consensus.nextclade.tsv
+    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.auspice.json
+    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.json
+    - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
-      md5sum: eb18c508f26125851279f2c03d4a336c
+      md5sum: 1ba0d3575483bc24b6cf4565f0ef797f
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
@@ -284,7 +262,7 @@
       md5sum: 717da6cd0df2d2f1d00461f3498aaca9
     - path: miniwdl_run/call-nextclade_output_parser/work/TAMIFLU_AASUBS
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.nextclade.tsv
+    - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/clearlabs.consensus.nextclade.tsv
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
     - path: miniwdl_run/call-pangolin4/command
@@ -311,7 +289,7 @@
       md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
       md5sum: dfd90750c8776f46bad1de214c1d1a57
-    - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
+    - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/clearlabs.pangolin_report.csv
       md5sum: 0370f24c270c44f6023dd98af79501e7
@@ -391,89 +369,89 @@
       contains: ["wdl", "theiacov_clearlabs", "vadr", "done"]
     - path: miniwdl_run/call-vadr/work/NUM_ALERTS
       md5sum: 1dcca23355272056f04fe8bf20edfce0
-    - path: miniwdl_run/call-vadr/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
+    - path: miniwdl_run/call-vadr/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus.vadr.alerts.tsv
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus.vadr.alerts.tsv
       md5sum: 2562e7c1fd77507231c7059bb7f09a93
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus.vadr.tar.gz
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: ef14be0f59dc55c666797ef3a3b40e62
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: ab2261fb93f30902350cca9f4b47d39f
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: cda43f921f578dce1fde4bc08cf17934
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.gene.2.fa
-      md5sum: b1f6d78381a5b97da1be035512c357c8
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.mat_peptide.1.fa
-      md5sum: 83c9e63df3f7029fb2003391867de0fe
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.mat_peptide.2.fa
-      md5sum: 3fad94cf6baa4c18bb6efe5bd0e6f0a8
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.stem_loop.1.fa
-      md5sum: d9b9c6fb8be9278cd55270af26f8012f
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.NC_045512.stem_loop.2.fa
-      md5sum: b927b16fb069f0b506f037ef48178dd9
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.alc
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus.vadr.tar.gz
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
+      md5sum: 01f8699ad0440b85c6f3459cc8807bed
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
+      md5sum: 78b1d8284142225dd6431754153a73b7
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.1.fa
+      md5sum: 9acee3886131673087ff77f0a6dc488a
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.2.fa
+      md5sum: 293fb93b99a93927ffac6411a057799d
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
+      md5sum: a763652b87cea3fe5b361f6327419b07
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.mat_peptide.2.fa
+      md5sum: 2bf9f5aeef164c8bc9125fb7306cf20e
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.stem_loop.1.fa
+      md5sum: f55f1e6287a8d5a41ead5209059c1d2b
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.stem_loop.2.fa
+      md5sum: 4acfd69ec183f3a9374fbb4c3cce491f
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.alc
       md5sum: 462c3764417b6650584adf6925f8483b
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.alt
-      md5sum: 8e475411b9a0a94338e7fd6d50d09dc3
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.alt.list
-      md5sum: e5131b7a38776bffed73e87e0802addc
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.cmd
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.dcr
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.alt
+      md5sum: edc2687c2e82b2426921e0e537edc075
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.alt.list
+      md5sum: 6a252b77d6c37949f00f8c3629350be7
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.cmd
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.dcr
       md5sum: d9b5295b718f16cf523fa42c69c67f7f
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.fail.fa
-      md5sum: df3a832ffbced8719506279648c968af
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.fail.list
-      md5sum: 56f45c5bc5bb8cd5af69419e0a18486f
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.fail.tbl
-      md5sum: 3138cb2f9d51a7f33e25d60567f90154
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.filelist
-      md5sum: e927a45c88281953bcae932bbe412d72
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.ftr
-      md5sum: 09cbb3709dddad2ae7e1895be2f2c0d6
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.log
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.mdl
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.fa
+      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.list
+      md5sum: 7b7182529739b37ce90f7eb74301fe1f
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.tbl
+      md5sum: ceee7788ffea5737bfc99a51905cc8fc
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.filelist
+      md5sum: 8736d943b1e4b18906cf0cad4be881f9
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.ftr
+      md5sum: b2f5f7bdeec14292a089bb0d968c6f3b
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.log
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.mdl
       md5sum: 43735aaecb85b313c6b6c9789b324337
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.pass.fa
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.pass.fa
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.pass.list
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.pass.list
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.pass.tbl
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.pass.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.rpn
-      md5sum: a5adc1532dabada4737a0be6664187e3
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sda
-      md5sum: 474051475b970e16c0355aa4a864f947
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.seqstat
-      md5sum: e7f072c85a7348a8b562db1a5c61cf76
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sgm
-      md5sum: 2fb190ba11ba66fc637584bb0dbbf2da
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sqa
-      md5sum: 6d241df46baa9164f1cb688c80570357
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.sqc.txt
-      md5sum: 2c726dac7c46f957e40ccd6b76da32f6
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus_trimmed.fasta
-      md5sum: df3a832ffbced8719506279648c968af
-    - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus_vadr-fasta-files.zip
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: ef14be0f59dc55c666797ef3a3b40e62
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: ab2261fb93f30902350cca9f4b47d39f
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: cda43f921f578dce1fde4bc08cf17934
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.gene.2.fa
-      md5sum: b1f6d78381a5b97da1be035512c357c8
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.mat_peptide.1.fa
-      md5sum: 83c9e63df3f7029fb2003391867de0fe
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.mat_peptide.2.fa
-      md5sum: 3fad94cf6baa4c18bb6efe5bd0e6f0a8
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.stem_loop.1.fa
-      md5sum: d9b9c6fb8be9278cd55270af26f8012f
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.NC_045512.stem_loop.2.fa
-      md5sum: b927b16fb069f0b506f037ef48178dd9
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.fail.fa
-      md5sum: df3a832ffbced8719506279648c968af
-    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.medaka.consensus.vadr.pass.fa
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.rpn
+      md5sum: 5e323f8edc70f5fd4d2636ed650c96ea
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sda
+      md5sum: 7a6d49ee8d1354238dfefeeab63ae25f
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.seqstat
+      md5sum: 68ab4eef53100545cf3ec5dcfd3bf156
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sgm
+      md5sum: b97bad7e110cf7cac19cae374b80e1bb
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqa
+      md5sum: 1efac9aeee74d0cdfc7467799905fd6d
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqc.txt
+      md5sum: 77e5d6c111753ac47a6168f48b04be18
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus_trimmed.fasta
+      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+    - path: miniwdl_run/call-vadr/work/clearlabs.consensus_vadr-fasta-files.zip
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
+      md5sum: 01f8699ad0440b85c6f3459cc8807bed
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
+      md5sum: 78b1d8284142225dd6431754153a73b7
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.1.fa
+      md5sum: 9acee3886131673087ff77f0a6dc488a
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.2.fa
+      md5sum: 293fb93b99a93927ffac6411a057799d
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
+      md5sum: a763652b87cea3fe5b361f6327419b07
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.mat_peptide.2.fa
+      md5sum: 2bf9f5aeef164c8bc9125fb7306cf20e
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.stem_loop.1.fa
+      md5sum: f55f1e6287a8d5a41ead5209059c1d2b
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.stem_loop.2.fa
+      md5sum: 4acfd69ec183f3a9374fbb4c3cce491f
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.fail.fa
+      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+    - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.pass.fa
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-version_capture/inputs.json
     - path: miniwdl_run/call-version_capture/task.log

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -217,7 +217,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.N.fasta
       md5sum: 22756e66f3b0fe8a00d685fc145edaf5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1a.fasta
-      md5sum: 397e034fe525d393a8b5b500df0c75c0
+      md5sum: 8d49bc37ee2d3506cd7bf67cc98d9070
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1b.fasta
       md5sum: 9827745ec4fe4976ad6c063b0f097cb3
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF3a.fasta
@@ -348,7 +348,7 @@
       md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
     - path: miniwdl_run/call-vadr/command
-      md5sum: f7dbfd3d59316546682133d7aae17fad
+      md5sum: 7423ff35f0c469bb4390496eafc2320e
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -387,7 +387,6 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.dcr
       md5sum: d9b5295b718f16cf523fa42c69c67f7f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.fa
-      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.list
       md5sum: 7b7182529739b37ce90f7eb74301fe1f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.tbl
@@ -395,7 +394,6 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.filelist
       md5sum: 8736d943b1e4b18906cf0cad4be881f9
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.ftr
-      md5sum: d4809c38b77c7ba477ef58090fb32f86
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.log
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.mdl
       md5sum: 43735aaecb85b313c6b6c9789b324337

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -41,7 +41,6 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.csv
       md5sum: 3cbc074cd5baefbf594c73ddfd633c8a
     - path: miniwdl_run/call-consensus/work/clearlabs.consensus.fasta
-      md5sum: 536f7643ef165dc7d72ca39e46cd3538
     - path: miniwdl_run/call-consensus/work/clearlabs.coverage_mask.txt
       md5sum: f3d76027b8506a5b1d0f5b1c7e7c8cff
     - path: miniwdl_run/call-consensus/work/clearlabs.fail.vcf
@@ -54,7 +53,6 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta.fai
     - path: miniwdl_run/call-consensus/work/clearlabs.primers.vcf
-      md5sum: 8f60b25110cdf39ce27dd48719566416
     - path: miniwdl_run/call-consensus/work/clearlabs.primersitereport.txt
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/clearlabs.primertrimmed.rg.sorted.bam
@@ -76,15 +74,12 @@
       contains: ["wdl", "theiacov_clearlabs", "consensus_qc", "done"]
     - path: miniwdl_run/call-consensus_qc/work/DATE
     - path: miniwdl_run/call-consensus_qc/work/NUM_ACTG
-      md5sum: b042297eaf71f467789516212e2ca5ac
     - path: miniwdl_run/call-consensus_qc/work/NUM_DEGENERATE
       md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-consensus_qc/work/NUM_N
-      md5sum: 8ad46215ff3252d17d9e062e6f84d472
     - path: miniwdl_run/call-consensus_qc/work/NUM_TOTAL
       md5sum: 64887188f1a0c0176ed5ad2e108d1046
     - path: miniwdl_run/call-consensus_qc/work/PERCENT_REF_COVERAGE
-      md5sum: 7f9226df824c26eaa79412a2ba1390ab
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-fastq_scan_clean_reads/command
@@ -322,7 +317,6 @@
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.flagstat.txt
       md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.stats.txt
-      md5sum: 091d3db26cbfd2c804dd7348f4b09087
     - path: miniwdl_run/call-stats_n_coverage_primtrim/command
       md5sum: 2974f886e1959cd5eaae5e495c91f7cc
     - path: miniwdl_run/call-stats_n_coverage_primtrim/inputs.json
@@ -353,7 +347,6 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.flagstat.txt
       md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
-      md5sum: 60a3f910312be4cf39bcd3116b2a161a
     - path: miniwdl_run/call-vadr/command
       md5sum: f7dbfd3d59316546682133d7aae17fad
     - path: miniwdl_run/call-vadr/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -41,7 +41,7 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.alignreport.csv
       md5sum: 3cbc074cd5baefbf594c73ddfd633c8a
     - path: miniwdl_run/call-consensus/work/clearlabs.consensus.fasta
-      md5sum: 536f7643ef165dc7d72ca39e46cd3538
+      md5sum: a4dcfa721272ae95a5e950f3e2d25986
     - path: miniwdl_run/call-consensus/work/clearlabs.coverage_mask.txt
       md5sum: f3d76027b8506a5b1d0f5b1c7e7c8cff
     - path: miniwdl_run/call-consensus/work/clearlabs.fail.vcf
@@ -52,10 +52,10 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf
     - path: miniwdl_run/call-consensus/work/clearlabs.pass.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta
-      md5sum: 3279c5ce27628f7a34b3d11232e4de65
+      md5sum: 6401ca1acb69843b55b792754a54e444
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta.fai
     - path: miniwdl_run/call-consensus/work/clearlabs.primers.vcf
-      md5sum: 2121a7dd91771d89b3283da5ff897e04
+      md5sum: 8f60b25110cdf39ce27dd48719566416
     - path: miniwdl_run/call-consensus/work/clearlabs.primersitereport.txt
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/clearlabs.primertrimmed.rg.sorted.bam
@@ -77,15 +77,15 @@
       contains: ["wdl", "theiacov_clearlabs", "consensus_qc", "done"]
     - path: miniwdl_run/call-consensus_qc/work/DATE
     - path: miniwdl_run/call-consensus_qc/work/NUM_ACTG
-      md5sum: b042297eaf71f467789516212e2ca5ac
+      md5sum: 8d7e91afbf4b25d066e0e4ee3f757af1
     - path: miniwdl_run/call-consensus_qc/work/NUM_DEGENERATE
       md5sum: 897316929176464ebc9ad085f31e7284
     - path: miniwdl_run/call-consensus_qc/work/NUM_N
-      md5sum: 8ad46215ff3252d17d9e062e6f84d472
+      md5sum: fd7c21d6426a67e58606f4f5af3bcb0c
     - path: miniwdl_run/call-consensus_qc/work/NUM_TOTAL
       md5sum: 64887188f1a0c0176ed5ad2e108d1046
     - path: miniwdl_run/call-consensus_qc/work/PERCENT_REF_COVERAGE
-      md5sum: 7f9226df824c26eaa79412a2ba1390ab
+      md5sum: 3f5b244cd6683efff0dec4915a795267
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-fastq_scan_clean_reads/command
@@ -206,7 +206,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade_v3/work/clearlabs.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
-      md5sum: 1ba0d3575483bc24b6cf4565f0ef797f
+      md5sum: fd2c9f76bda2f2df78cdbae2e82d7430
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
@@ -224,7 +224,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.N.fasta
       md5sum: 22756e66f3b0fe8a00d685fc145edaf5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1a.fasta
-      md5sum: 8d49bc37ee2d3506cd7bf67cc98d9070
+      md5sum: 397e034fe525d393a8b5b500df0c75c0
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1b.fasta
       md5sum: 9827745ec4fe4976ad6c063b0f097cb3
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF3a.fasta
@@ -324,7 +324,7 @@
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.flagstat.txt
       md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.stats.txt
-      md5sum: 2ec4deb812d1cb840d67666114726070
+      md5sum: 091d3db26cbfd2c804dd7348f4b09087
     - path: miniwdl_run/call-stats_n_coverage_primtrim/command
       md5sum: 2974f886e1959cd5eaae5e495c91f7cc
     - path: miniwdl_run/call-stats_n_coverage_primtrim/inputs.json
@@ -355,9 +355,9 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.flagstat.txt
       md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
-      md5sum: c91dddf8c6282849df368c0a27535da0
+      md5sum: 60a3f910312be4cf39bcd3116b2a161a
     - path: miniwdl_run/call-vadr/command
-      md5sum: 7423ff35f0c469bb4390496eafc2320e
+      md5sum: f7dbfd3d59316546682133d7aae17fad
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -375,11 +375,11 @@
       md5sum: 2562e7c1fd77507231c7059bb7f09a93
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus.vadr.tar.gz
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: 01f8699ad0440b85c6f3459cc8807bed
+      md5sum: d7167d1728389a9a48fbdbdb1f0f1675
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: 78b1d8284142225dd6431754153a73b7
+      md5sum: 37ae1c39a53eef5d26944228b531a478
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: 9acee3886131673087ff77f0a6dc488a
+      md5sum: 5fe92e7fb7cf3fa33f74974e04faef48
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.gene.2.fa
       md5sum: 293fb93b99a93927ffac6411a057799d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
@@ -400,7 +400,7 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.dcr
       md5sum: d9b5295b718f16cf523fa42c69c67f7f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.fa
-      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.list
       md5sum: 7b7182529739b37ce90f7eb74301fe1f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.fail.tbl
@@ -408,7 +408,7 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.filelist
       md5sum: 8736d943b1e4b18906cf0cad4be881f9
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.ftr
-      md5sum: b2f5f7bdeec14292a089bb0d968c6f3b
+      md5sum: d4809c38b77c7ba477ef58090fb32f86
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.log
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.mdl
       md5sum: 43735aaecb85b313c6b6c9789b324337
@@ -419,7 +419,7 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.pass.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.rpn
-      md5sum: 5e323f8edc70f5fd4d2636ed650c96ea
+      md5sum: ba4815d0793abb64566d6d303f20831d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sda
       md5sum: 7a6d49ee8d1354238dfefeeab63ae25f
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.seqstat
@@ -429,16 +429,16 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqa
       md5sum: 1efac9aeee74d0cdfc7467799905fd6d
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus/clearlabs.consensus.vadr.sqc.txt
-      md5sum: 77e5d6c111753ac47a6168f48b04be18
+      md5sum: 633508465581359ba1aba2f43ea1faf9
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus_trimmed.fasta
-      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus_vadr-fasta-files.zip
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: 01f8699ad0440b85c6f3459cc8807bed
+      md5sum: d7167d1728389a9a48fbdbdb1f0f1675
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: 78b1d8284142225dd6431754153a73b7
+      md5sum: 37ae1c39a53eef5d26944228b531a478
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: 9acee3886131673087ff77f0a6dc488a
+      md5sum: 5fe92e7fb7cf3fa33f74974e04faef48
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.2.fa
       md5sum: 293fb93b99a93927ffac6411a057799d
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
@@ -450,7 +450,7 @@
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.stem_loop.2.fa
       md5sum: 4acfd69ec183f3a9374fbb4c3cce491f
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.fail.fa
-      md5sum: 5b11a0cec698d10a5c44ff0048ee63b4
+      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.pass.fa
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-version_capture/inputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -434,25 +434,15 @@
       md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/clearlabs.consensus_vadr-fasta-files.zip
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.1.fa
-      md5sum: d7167d1728389a9a48fbdbdb1f0f1675
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.CDS.2.fa
-      md5sum: 37ae1c39a53eef5d26944228b531a478
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.1.fa
-      md5sum: 5fe92e7fb7cf3fa33f74974e04faef48
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.gene.2.fa
-      md5sum: 293fb93b99a93927ffac6411a057799d
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.mat_peptide.1.fa
-      md5sum: a763652b87cea3fe5b361f6327419b07
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.mat_peptide.2.fa
-      md5sum: 2bf9f5aeef164c8bc9125fb7306cf20e
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.stem_loop.1.fa
-      md5sum: f55f1e6287a8d5a41ead5209059c1d2b
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.NC_045512.stem_loop.2.fa
-      md5sum: 4acfd69ec183f3a9374fbb4c3cce491f
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.fail.fa
-      md5sum: 2ad8aee5a998d9f4cef4bbe9a60f6f44
     - path: miniwdl_run/call-vadr/work/vadr_fasta_files/clearlabs.consensus.vadr.pass.fa
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-version_capture/inputs.json
     - path: miniwdl_run/call-version_capture/task.log
       contains: ["wdl", "theiacov_clearlabs", "version_capture", "done"]

--- a/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_clearlabs.yml
@@ -17,7 +17,7 @@
     - wf_theiacov_clearlabs_miniwdl
   files:
     - path: miniwdl_run/call-consensus/command
-      md5sum: a8e200703dedf732b45dd92b0af15f1c
+      md5sum: 788e48441f357bdd0fc9eac5a13b77b5
     - path: miniwdl_run/call-consensus/inputs.json
       contains: ["read1", "samplename", "fastq"]
     - path: miniwdl_run/call-consensus/outputs.json
@@ -55,7 +55,7 @@
       md5sum: 3279c5ce27628f7a34b3d11232e4de65
     - path: miniwdl_run/call-consensus/work/clearlabs.preconsensus.fasta.fai
     - path: miniwdl_run/call-consensus/work/clearlabs.primers.vcf
-      md5sum: 8f60b25110cdf39ce27dd48719566416
+      md5sum: 2121a7dd91771d89b3283da5ff897e04
     - path: miniwdl_run/call-consensus/work/clearlabs.primersitereport.txt
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/clearlabs.primertrimmed.rg.sorted.bam
@@ -65,7 +65,7 @@
     - path: miniwdl_run/call-consensus/work/clearlabs.trimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/clearlabs.trimmed.rg.sorted.bam.bai
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 48e7df2ae11e2aed2f5900efe9868921
+      md5sum: c0322c2bf5843b932d3d1236728d1fb8
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -218,31 +218,31 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/sequences.fasta
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.E.fasta
-      md5sum: 14808ad8b34c8bac7de500707400250e
+      md5sum: a5f39d648125d093265909fec5d8c796
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.M.fasta
-      md5sum: 4799e5af880d2005da56342d6a9d64ab
+      md5sum: 3d1e1d721639861a261f37e7777bead5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.N.fasta
-      md5sum: bbc46cedb153b3213a9cf8f425dd906c
+      md5sum: 22756e66f3b0fe8a00d685fc145edaf5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1a.fasta
-      md5sum: 0c1b1bbcbcfe86d10c466bf63fca5c11
+      md5sum: 8d49bc37ee2d3506cd7bf67cc98d9070
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1b.fasta
-      md5sum: bea75a83074a11fa74c316e4df6a3d9f
+      md5sum: 9827745ec4fe4976ad6c063b0f097cb3
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF3a.fasta
-      md5sum: 692b2c314c4ff6584a40273dc239cb78
+      md5sum: 20973e57a94f101e505aa5b32e8a6318
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF6.fasta
-      md5sum: c1d610f9e45acd3915e40f0d643f0188
+      md5sum: a634b9f1f79b1ee1fd647a4ddaadd25d
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF7a.fasta
-      md5sum: a655a6c325b0bc9ad69842fcf2e927a7
+      md5sum: fa51f9e1f5963888f4a03e1689fea283
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF7b.fasta
-      md5sum: 27fd219bb6d18731898a9ddfdee27f67
+      md5sum: d489f9864522a1d4fef7050d83c3daaf
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF8.fasta
-      md5sum: 398798980c482562e7c5b21b205e0445
+      md5sum: 900c8d5cd319c58a8c83a069dca56d28
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF9b.fasta
-      md5sum: 3d6a949bdcecaf70e9d123651a7a7c5e
+      md5sum: 1de0599c935243b9eb42afba07374645
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.S.fasta
-      md5sum: 0ce44a0a8e2784ca4b3e8d8f03211813
+      md5sum: 80652d7864028a48bf20917851ba9d92
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: f377fb9fc901d440fa35b1b05317a0e1
+      md5sum: e642f66a6a1447868c2d98a2d0044762
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json
@@ -255,7 +255,7 @@
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_AADELS
       md5sum: 9d4c759e1c177be4e5942816848c3cb1
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_AASUBS
-      md5sum: 62ff3d35d7bb1bc431b8201c616a55c0
+      md5sum: bff3612e4142d3cd0b6bd7fb70a0f910
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_CLADE
       md5sum: 96d3cf337be2f7948d6f6df5c1ab69a4
     - path: miniwdl_run/call-nextclade_output_parser/work/NEXTCLADE_LINEAGE
@@ -266,7 +266,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
     - path: miniwdl_run/call-pangolin4/command
-      md5sum: 822d5c5276870d28971ca5d134193114
+      md5sum: 466ab567c6dad8a7411a84b6ea7ba197
     - path: miniwdl_run/call-pangolin4/inputs.json
       contains: ["fasta", "samplename", "clearlabs"]
     - path: miniwdl_run/call-pangolin4/outputs.json
@@ -292,7 +292,7 @@
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/clearlabs.pangolin_report.csv
-      md5sum: 0370f24c270c44f6023dd98af79501e7
+      md5sum: 81aa24ad56cd7e0f45cb317ccfcdbb62
     - path: miniwdl_run/call-stats_n_coverage/command
       md5sum: ac020678f99ac145b11d3dbc7b9fe9ba
     - path: miniwdl_run/call-stats_n_coverage/inputs.json
@@ -308,23 +308,23 @@
       md5sum: 74f46f4a356cce9074878a617f07a91b
     - path: miniwdl_run/call-stats_n_coverage/work/DATE
     - path: miniwdl_run/call-stats_n_coverage/work/DEPTH
-      md5sum: 259558c0ddfe059337bda4ad62967a5d
+      md5sum: 4fc8230861db115aa3ec767a9e61a10c
     - path: miniwdl_run/call-stats_n_coverage/work/MEANBASEQ
-      md5sum: 2ebbb627df13f6457dca15e655093eb6
+      md5sum: 96d5add61fe1362be0a14eca5dc18a5c
     - path: miniwdl_run/call-stats_n_coverage/work/MEANMAPQ
-      md5sum: 43ab305877efbc03639d3a97adacff8c
+      md5sum: 682f8d1495a65f5049f9c2b5feef0ba5
     - path: miniwdl_run/call-stats_n_coverage/work/VERSION
       md5sum: 53be85d2ed9fa57ab45424fe071a6672
     - path: miniwdl_run/call-stats_n_coverage/work/_miniwdl_inputs/0/clearlabs.trimmed.rg.sorted.bam
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.cov.hist
-      md5sum: 244232adb475973961575c9428961e34
+      md5sum: a5e82bf6a8eb701be88343b33b1b3ab8
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.cov.txt
-      md5sum: 72596e3153e78a00e46533db3c1ed863
+      md5sum: a3b9fb3593c7ef13aed261867f308e59
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.flagstat.txt
-      md5sum: e0b5f095ba646f1a697acd6d8ec5a54c
+      md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage/work/clearlabs.stats.txt
-      md5sum: bfed5344c91ce6f4db1f688cac0a3ab9
+      md5sum: 2ec4deb812d1cb840d67666114726070
     - path: miniwdl_run/call-stats_n_coverage_primtrim/command
       md5sum: 2974f886e1959cd5eaae5e495c91f7cc
     - path: miniwdl_run/call-stats_n_coverage_primtrim/inputs.json
@@ -340,24 +340,24 @@
       md5sum: b8f1c75b54620ff2391bc8b2273e6f12
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/DATE
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/DEPTH
-      md5sum: 271fea9642e2e43a5b89a9b84cc39c17
+      md5sum: b74588802b7c2771353045deada86ad9
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/MEANBASEQ
-      md5sum: 2ebbb627df13f6457dca15e655093eb6
+      md5sum: 96d5add61fe1362be0a14eca5dc18a5c
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/MEANMAPQ
-      md5sum: 43ab305877efbc03639d3a97adacff8c
+      md5sum: 682f8d1495a65f5049f9c2b5feef0ba5
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/VERSION
       md5sum: 53be85d2ed9fa57ab45424fe071a6672
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/clearlabs.primertrimmed.rg.sorted.bam
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.cov.hist
-      md5sum: 9857b51b88673b8b17722f7673c08a24
+      md5sum: 1a117a41e848387eadb48e5dcf1523b8
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.cov.txt
-      md5sum: 7939c5298ffba56c5898eec17e72b2a1
+      md5sum: 49131b634e04d4f6cd81f7969802c8ec
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.flagstat.txt
-      md5sum: e0b5f095ba646f1a697acd6d8ec5a54c
+      md5sum: f5d6f96c87d96ebe60358948d310f223
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
-      md5sum: 6ad40bcca227c92fdfec23fe9a03c344
+      md5sum: c91dddf8c6282849df368c0a27535da0
     - path: miniwdl_run/call-vadr/command
-      md5sum: 1f49b0fa676b3ea67201305139f2568c
+      md5sum: 7423ff35f0c469bb4390496eafc2320e
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -31,7 +31,7 @@
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/artic_ncov2019_ont.fastq
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/command
-      md5sum: 056563d18294928fef5238bac7213791
+      md5sum: 0f2dae4a90b19d6b1e39e435894629a6
     - path: miniwdl_run/call-consensus/inputs.json
       contains: ["read1_clean", "samplename", "fastq"]
     - path: miniwdl_run/call-consensus/outputs.json
@@ -77,7 +77,7 @@
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam.bai
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 31dfee1552f68e5c6f72431458a33535
+      md5sum: 11ad9f5b0130528f5f2f77a7ea048333
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -175,7 +175,7 @@
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
     - path: miniwdl_run/call-pangolin4/command
-      md5sum: c1c714d97c9c01cd446da625f63e0391
+      md5sum: fd82f5a05984e29e490404c7b58b5d90
     - path: miniwdl_run/call-pangolin4/inputs.json
       contains: ["fasta", "samplename", "ont"]
     - path: miniwdl_run/call-pangolin4/outputs.json
@@ -228,7 +228,7 @@
     - path: miniwdl_run/call-stats_n_coverage/work/DATE
     - path: miniwdl_run/call-stats_n_coverage/work/DEPTH
     - path: miniwdl_run/call-stats_n_coverage/work/MEANBASEQ
-      md5sum: 68f06358611afb96787e55c81f8544e9
+      md5sum: 18ace91e015d5572acb4eaa7c0963713
     - path: miniwdl_run/call-stats_n_coverage/work/MEANMAPQ
       md5sum: ecf27a776cdfc771defab1c5d19de9ab
     - path: miniwdl_run/call-stats_n_coverage/work/VERSION
@@ -264,7 +264,7 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.flagstat.txt
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.stats.txt
     - path: miniwdl_run/call-vadr/command
-      md5sum: 3228e4022462e882f5ac4ea8bca46f71
+      md5sum: 8d56010af0d8d91596f8d4eebc6158d3
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -45,27 +45,19 @@
     - path: miniwdl_run/call-consensus/work/REFERENCE_GENOME
       md5sum: 0e6efd549c8773f9a2f7a3e82619ee61
     - path: miniwdl_run/call-consensus/work/VERSION
-      md5sum: f3528ff85409c70100063c55ad75612b
+      md5sum: b50a846b8b57f344bcedad5c6962b2c7
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/artic-v3.primers.bed
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/artic_ncov2019_ont.fastq
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-consensus/work/ont.1.hdf
     - path: miniwdl_run/call-consensus/work/ont.1.vcf
-    - path: miniwdl_run/call-consensus/work/ont.2.hdf
     - path: miniwdl_run/call-consensus/work/ont.2.vcf
-    - path: miniwdl_run/call-consensus/work/ont.alignreport.er
-    - path: miniwdl_run/call-consensus/work/ont.alignreport.txt
     - path: miniwdl_run/call-consensus/work/ont.consensus.fasta
-      md5sum: cdde2d8b7efeb498806c5c2cfc522675
+      md5sum: 3950a30ee2fe99e53f2565723480867a
     - path: miniwdl_run/call-consensus/work/ont.coverage_mask.txt
       md5sum: afe03fabc8dd227e790deddd6402e9a5
     - path: miniwdl_run/call-consensus/work/ont.fail.vcf
     - path: miniwdl_run/call-consensus/work/ont.fastq.gz
-    - path: miniwdl_run/call-consensus/work/ont.medaka.consensus.fasta
-      md5sum: d36b7c665aa4127f0a6e8dbc562eea3e
-    - path: miniwdl_run/call-consensus/work/ont.merged.gvcf.vcf.gz
-    - path: miniwdl_run/call-consensus/work/ont.merged.gvcf.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/ont.merged.vcf.gz
     - path: miniwdl_run/call-consensus/work/ont.merged.vcf.gz.tbi
     - path: miniwdl_run/call-consensus/work/ont.minion.log.txt
@@ -77,25 +69,17 @@
       md5sum: 4ca7d9fd06b9cdf379c2cf02b9fd6d0e
     - path: miniwdl_run/call-consensus/work/ont.primers.vcf
     - path: miniwdl_run/call-consensus/work/ont.primersitereport.txt
-      md5sum: cffee67632a262eeb947cea9cee0b4c1
+      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-consensus/work/ont.primertrimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/ont.primertrimmed.rg.sorted.bam.bai
     - path: miniwdl_run/call-consensus/work/ont.sorted.bam
     - path: miniwdl_run/call-consensus/work/ont.sorted.bam.bai
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam.bai
-    - path: miniwdl_run/call-consensus/work/ont.vcfcheck.log
-    - path: miniwdl_run/call-consensus/work/ont.vcfreport.txt
-      md5sum: 69131186223267b3ae6621cb8ef4eecd
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.reference.fasta
-      md5sum: b9b67235a2d9d0b0d7f531166ffefd41
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.reference.fasta.fai
-    - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
-      md5sum: d5ad850f8c610dc45162957ab84530d6
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 3f21640edd4e1691fec5f5e2cc061d97
+      md5sum: 31dfee1552f68e5c6f72431458a33535
     - path: miniwdl_run/call-consensus_qc/inputs.json
-      contains: ["assembly_fasta", "medaka"]
+      contains: ["assembly_fasta"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
       contains: ["consensus_qc", "number_N", "percent_reference_coverage"]
     - path: miniwdl_run/call-consensus_qc/stderr.txt
@@ -114,7 +98,7 @@
       md5sum: cd5d3fde6b7f2417ec8ed3e7d5e85b28
     - path: miniwdl_run/call-consensus_qc/work/PERCENT_REF_COVERAGE
       md5sum: 1684062540bab8897921ed5e40c747cf
-    - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
+    - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/ont.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_v3/command
     - path: miniwdl_run/call-nextclade_v3/inputs.json
@@ -128,10 +112,9 @@
       contains: ["wdl", "theiacov_ont", "done"]
     - path: miniwdl_run/call-nextclade_v3/work/NEXTCLADE_VERSION
       md5sum: 70aa6879bf9f0e8ba2b9953b0d4a2216
-    - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+    - path: miniwdl_run/call-nextclade_v3/work/_miniwdl_inputs/0/ont.consensus.fasta
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.aligned.fasta
-      md5sum: 9af2828c3169f789cd1266960c8595da
+      md5sum: e89d162b1de311166f574fdd72bb889b
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.csv
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.ndjson
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/genome_annotation.gff3
@@ -141,32 +124,32 @@
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/tree.json
     - path: miniwdl_run/call-nextclade_v3/work/nextclade_dataset_dir/pathogen.json
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.E.fasta
-      md5sum: b84502318ddddc339eae05c5eb2a1ff8
+      md5sum: ed16c9347bfc40c036bfd6696357f276
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.M.fasta
-      md5sum: 7b4b60c7ed0c3b02be1095913c8a19e0
+      md5sum: 665563797b25a2f8c317f1de5bfd3100
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.N.fasta
-      md5sum: b07a3ee9b75d9a5e85561e2fed5cccfc
+      md5sum: 37f9705280adf60301e46846e4244df2
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1a.fasta
-      md5sum: 28e0341110fd8c446ea1c4a2c14bcff1
+      md5sum: abafdd46ce000786c30719975cbae293
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF1b.fasta
-      md5sum: 5fea3fa7473ea78ce7d67840377fe5e8
+      md5sum: 2f92eb27dd46628b9fc92e72a22995e3
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF3a.fasta
-      md5sum: 9a53be681f7d92d46200438d03f8a16b
+      md5sum: f0a567079160c44c65e6702373223ce1
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF6.fasta
-      md5sum: c1d610f9e45acd3915e40f0d643f0188
+      md5sum: 01f0c1f6fc3f5ab763d687548926b7e5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF7a.fasta
-      md5sum: a209e21c4a9a49649746b39ee449331f
+      md5sum: 0940fd46f48d302bc5d369aca02da8fb
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF7b.fasta
-      md5sum: 4ba532a9baaf5454f662eb67fa2caa74
+      md5sum: 7c1e739e9036385620101b55689f1a23
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF8.fasta
-      md5sum: c9b62e72831fa3198ebd28758aca5b29
+      md5sum: b6fea260f3a7ab5fcc9c8745f4ae038b
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.ORF9b.fasta
-      md5sum: 0f55e05f70734e109cca95918da37881
+      md5sum: 44afb04dc2cfa4a89c3cf5c83093cfe5
     - path: miniwdl_run/call-nextclade_v3/work/nextclade.cds_translation.S.fasta
-      md5sum: 9efd0dad1c8fc8bd802f20a6d5105bb0
-    - path: miniwdl_run/call-nextclade_v3/work/ont.medaka.consensus.nextclade.auspice.json
-    - path: miniwdl_run/call-nextclade_v3/work/ont.medaka.consensus.nextclade.json
-    - path: miniwdl_run/call-nextclade_v3/work/ont.medaka.consensus.nextclade.tsv
+      md5sum: b3680ba0128f39230d9cbaf62edf1f23
+    - path: miniwdl_run/call-nextclade_v3/work/ont.consensus.nextclade.auspice.json
+    - path: miniwdl_run/call-nextclade_v3/work/ont.consensus.nextclade.json
+    - path: miniwdl_run/call-nextclade_v3/work/ont.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_output_parser/command
       md5sum: 6b2d20d9df7c656a76755a4048acf3ec
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
@@ -188,7 +171,7 @@
       md5sum: dc20c75a91e9d9de3d98af59d035f17c
     - path: miniwdl_run/call-nextclade_output_parser/work/TAMIFLU_AASUBS
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/ont.medaka.consensus.nextclade.tsv
+    - path: miniwdl_run/call-nextclade_output_parser/work/_miniwdl_inputs/0/ont.consensus.nextclade.tsv
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_output_parser/work/input.tsv
     - path: miniwdl_run/call-pangolin4/command
@@ -215,8 +198,7 @@
       md5sum: 36f64a1cd7c6844309e8ad2121358088
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
       md5sum: dfd90750c8776f46bad1de214c1d1a57
-    - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+    - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ont.consensus.fasta
     - path: miniwdl_run/call-pangolin4/work/ont.pangolin_report.csv
     - path: miniwdl_run/call-raw_check_reads/command
       md5sum: 5df9a70c852960f82c84c7da611cd177
@@ -293,11 +275,9 @@
       contains: ["wdl", "theiacov_ont", "done"]
     - path: miniwdl_run/call-vadr/work/NUM_ALERTS
       md5sum: 897316929176464ebc9ad085f31e7284
-    - path: miniwdl_run/call-vadr/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/ont.medaka.consensus.vadr.alerts.tsv
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-vadr/work/ont.medaka.consensus.vadr.tar.gz
+    - path: miniwdl_run/call-vadr/work/_miniwdl_inputs/0/ont.consensus.fasta
+    - path: miniwdl_run/call-vadr/work/ont.consensus.vadr.alerts.tsv
+    - path: miniwdl_run/call-vadr/work/ont.consensus.vadr.tar.gz
     - path: miniwdl_run/call-version_capture/inputs.json
     - path: miniwdl_run/call-version_capture/outputs.json
       contains: ["version_capture", "date", "version"]

--- a/tests/workflows/theiacov/test_wf_theiacov_ont.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_ont.yml
@@ -77,7 +77,7 @@
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam
     - path: miniwdl_run/call-consensus/work/ont.trimmed.rg.sorted.bam.bai
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 11ad9f5b0130528f5f2f77a7ea048333
+      md5sum: 31dfee1552f68e5c6f72431458a33535
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -151,7 +151,7 @@
     - path: miniwdl_run/call-nextclade_v3/work/ont.consensus.nextclade.json
     - path: miniwdl_run/call-nextclade_v3/work/ont.consensus.nextclade.tsv
     - path: miniwdl_run/call-nextclade_output_parser/command
-      md5sum: 6b2d20d9df7c656a76755a4048acf3ec
+      md5sum: 11ad9f5b0130528f5f2f77a7ea048333
     - path: miniwdl_run/call-nextclade_output_parser/inputs.json
       contains: ["nextclade_tsv", "tsv"]
     - path: miniwdl_run/call-nextclade_output_parser/outputs.json

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -29,6 +29,7 @@ workflow theiacov_clearlabs {
     Int normalise = 20000
     # artic clair 3 model
     String? clair3_model
+    String? artic_docker_image
     # reference values
     File? reference_genome
     # nextclade inputs
@@ -80,7 +81,8 @@ workflow theiacov_clearlabs {
       normalise = normalise,
       clair3_model = clair3_model,
       reference_genome = organism_parameters.reference,
-      organism = organism
+      organism = organism,
+      docker = artic_docker_image
   }
   call assembly_metrics.stats_n_coverage {
     input:

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -27,7 +27,8 @@ workflow theiacov_clearlabs {
     File primer_bed
     # assembly parameters
     Int normalise = 20000
-    String medaka_docker = "us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
+    # artic clair 3 model
+    String? clair3_model
     # reference values
     File? reference_genome
     # nextclade inputs
@@ -77,7 +78,7 @@ workflow theiacov_clearlabs {
       read1 = ncbi_scrub_se.read1_dehosted,
       primer_bed = primer_bed,
       normalise = normalise,
-      docker = medaka_docker,
+      clair3_model = clair3_model,
       reference_genome = organism_parameters.reference,
       organism = organism
   }
@@ -187,13 +188,13 @@ workflow theiacov_clearlabs {
     # Read Alignment - Artic consensus outputs
     File aligned_bam = consensus.trim_sorted_bam
     File aligned_bai = consensus.trim_sorted_bai
-    File variants_from_ref_vcf = consensus.medaka_pass_vcf
+    File variants_from_ref_vcf = consensus.artic_clair3_pass_vcf
     File assembly_fasta = consensus.consensus_seq
     File? read1_aligned = consensus.reads_aligned
     # Read Alignment - Artic consensus versioning outputs
     String artic_version = consensus.artic_pipeline_version
     String artic_docker = consensus.artic_pipeline_docker
-    String medaka_reference = consensus.medaka_reference
+    String artic_reference = consensus.artic_pipeline_reference
     String primer_bed_name = consensus.primer_bed_name
     String assembly_method = "TheiaCoV (~{version_capture.phb_version}): ~{consensus.artic_pipeline_version}"
     # Read Alignment - consensus assembly qc outputs

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -130,7 +130,7 @@ workflow theiacov_ont {
             clair3_model = clair3_model,
             primer_bed = organism_parameters.primer_bed,
             normalise = normalise,
-            reference_genome = organism_parameters.reference,
+            reference_genome = organism_parameters.reference
         }
         call assembly_metrics.stats_n_coverage {
           input:

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -31,6 +31,8 @@ workflow theiacov_ont {
     Int normalise = 200
     Int max_length = 700
     Int min_length = 400
+    # artic clair 3 model
+    String? clair3_model
     # nextclade inputs
     String? nextclade_dataset_tag
     String? nextclade_dataset_name
@@ -125,6 +127,7 @@ workflow theiacov_ont {
             samplename = samplename,
             organism = organism_parameters.standardized_organism,
             read1 = read_qc_trim.read1_clean,
+            clair3_model = clair3_model,
             primer_bed = organism_parameters.primer_bed,
             normalise = normalise,
             reference_genome = organism_parameters.reference,
@@ -300,13 +303,13 @@ workflow theiacov_ont {
     String assembly_fasta = select_first([consensus.consensus_seq, flu_track.irma_assembly_fasta, "Assembly could not be generated"])
     File? aligned_bam = consensus.trim_sorted_bam
     File? aligned_bai = consensus.trim_sorted_bai
-    File? medaka_vcf = consensus.medaka_pass_vcf
+    File? clair3_vcf = consensus.artic_clair3_pass_vcf
     File? read1_aligned = consensus.reads_aligned
     File? read1_trimmed = consensus.trim_fastq
     # Read Alignment - Artic consensus versioning outputs
     String? artic_version = consensus.artic_pipeline_version
     String? artic_docker = consensus.artic_pipeline_docker
-    String? medaka_reference = consensus.medaka_reference
+    String? artic_reference = consensus.artic_pipeline_reference
     String? primer_bed_name = consensus.primer_bed_name
     String assembly_method = "TheiaCoV (~{version_capture.phb_version}): " + select_first([consensus.artic_pipeline_version, flu_track.irma_version, ""])
     # Assembly QC - consensus assembly qc outputs

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -305,7 +305,6 @@ workflow theiacov_ont {
     File? aligned_bai = consensus.trim_sorted_bai
     File? clair3_vcf = consensus.artic_clair3_pass_vcf
     File? read1_aligned = consensus.reads_aligned
-    File? read1_trimmed = consensus.trim_fastq
     # Read Alignment - Artic consensus versioning outputs
     String? artic_version = consensus.artic_pipeline_version
     String? artic_docker = consensus.artic_pipeline_docker


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #697 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Updates to the latest version of `Artic` (1.6.0 at the time of writing) from previous version `1.3.0` being used. As of `Artic 1.5.1` medaka is no longer supported in favor of clair3. The `artic minion medaka` is dropped in favor of `artic minion` with other arguments being changed as well. In order to support the new version and multiple clair3 model options, a new docker image has been made: https://github.com/theiagen/theiagen_docker_builds/blob/mb-clair3-models/artic-ncov2019/1.6.0_rerio/Dockerfile. This PR introduces a large overhaul to `task_artic_consensus` and only changes the docker image in `task_artic_guppyplex`. These changes impact `wf_theiacov_ont` and `wf_theacov_clearlabs`.
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
Workflows:
- `wf_theiacov_ont`
- `wf_theiacov_clearlabs`
Tasks:
- `task_artic_consensus`
- `task_artic_guppyplex`

This PR may lead to different results in pre-existing outputs: **Yes**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

Small changes to `task_artic_guppyplex`:
`us-docker.pkg.dev/general-theiagen/staphb/artic-ncov2019:1.3.0-medaka-1.4.3` -> `us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0_rerio`
Remove `echo "DIRNAME: $(dirname)"` since variable never set. 

Large change to `task_artic_consensus`:
The ARTIC pipeline underwent a significant overhaul to support new versions, transitioning from Medaka's variant calling system (`r941_min_high_g360` as default model) to the more modern Clair3 (`r1041_e82_400bps_hac_v420` as default model). The new artic command replaces complex nested scheme directories (`/Vuser`) with direct reference handling through `--bed` and `--ref` flags. The pipeline also supports remote scheme fetching from [primerschemes](https://github.com/quick-lab/primerschemes) repo and expands organism coverage to include MPXV alongside SARS-CoV-2 for scenarios where no primer bed and no reference genome are provided. We are also supporting more stringent flags for extracting aligned reads (moving from `-F4` to `-F0x904`). A new Docker image (us-docker.pkg.dev/general-theiagen/theiagen/artic:1.6.0_rerio) is introduced.

Input additions and output changes to `wf_theiacov_ont`:
Inputs:
`String? clair3_model` added as optional input and passed to ` call artic_consensus.consensus`, 
Outputs:
`File? read1_trimmed` deprecated
`medaka_vcf` -> `clair3_vcf`
`medaka_reference` -> `artic_reference`

Input additions and output changes to `wf_theiacov_clearlabs`:
Inputs:
`String? clair3_model` added as optional input and passed to ` call artic_consensus.consensus`, 
Outputs:
`File variants_from_ref_vcf = consensus.medaka_pass_vcf` -> `File variants_from_ref_vcf = consensus.artic_clair3_pass_vcf`
`String medaka_reference = consensus.medaka_reference` -> `String artic_reference = consensus.artic_pipeline_reference`

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

#### New ARTIC/Clair3 Pipeline Flow:
1. Read Mapping
- `minimap2`: ONT reads → reference (`-x map-ont`)
- BAM conversion, unmapped read filtering, sorting
2. Primer Processing  
- Dual `align_trim` passes:
 1. Coverage normalization (200x) + pair validation
 2. Primer trimming + amplicon depth calculation
3. Variant Detection
- `Clair3` variant calling per read group:
 - ONT model: r1041_e82_400bps_hac_v420 as default (can be changed)
 - Settings: haploid mode, min coverage 20x, long indel detection
4. Consensus Building
- Variant merging and filtration
- Coverage masking
- `bcftools consensus` for final sequence generation


The newest version of Artic also changes up how the base command is instantiated, so everything is routed through `artic minion`, where if bed file and reference are provided we run:
```
 artic minion --model ~{clair3_model} \
        --normalise ~{normalise} \
        --threads ~{cpu} \
        --bed ~{primer_bed} \
        --ref reference.fasta \
        --read-file ~{read1} \
        ~{samplename}
```

NOTE: 
Newer versions of Artic has changed how bed files are being parsed. There are two instances in which this caused existing primer beds to fail in testing, but worked when updated. HIV primer beds and Midngight primer beds. We can update and host these newer beds, but for now the current locations are here:
`Location of updated Midnight primers: gs://fc-secure-50c9efc6-4ca8-4bf5-9752-5bd6a6da17dd/Midnight_Primers_SARS-CoV-2.scheme_updated.bed`
`Location of updated HIV primers: gs://fc-secure-50c9efc6-4ca8-4bf5-9752-5bd6a6da17dd/HIV-1_v2.0.primer.hyphen1200.1.bed`

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
In `wf_theiacov_ont` and `wf_theiacov_clearlabs`:
- `String? clair3_model` has been added

In `wf_theiacov_clearlabs`:
`medaka_docker` -> `artic_docker_image`

In `task_artic_consensus`:
- `String medaka_model` -> `String clair3_model`

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

In `wf_theiacov_ont`:
`File? read1_trimmed` deprecated
`File medaka_vcf` -> `File clair3_vcf`
`String medaka_reference` -> `String artic_reference`

In `wf_theiacov_clearlabs`:
`File variants_from_ref_vcf = consensus.medaka_pass_vcf` -> `File variants_from_ref_vcf = consensus.artic_clair3_pass_vcf`
`String medaka_reference = consensus.medaka_reference` -> `String artic_reference = consensus.artic_pipeline_reference`

In `task_artic_consensus`:
- `{samplename}.medaka.consensus.fasta` -> `{samplename}.consensus.fasta`
- `medaka_reference` -> `artic_pipeline_reference`
- `medaka_pass_vcf` -> `artic_clair3_pass_vcf`
- `trim_fastq: {samplename}.primertrimmed.rg.fastq` has been removed

Note: I tried to keep some of the naming more neutral to artic since clair3 technically is just doing the variant calling. I am completely open to any naming scheme we may want to adhere to.

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

Tests performed against non-hiv organisms in the [theiacov_ont validation data](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/404c3d18-1bc9-4076-a209-22e569078da5)
Hiv test was performed separately to use updated primers that work with it [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/e1e54d37-f753-4a80-8023-9ec8f0a2d9e0), the primer bed file is currently just uploaded to my sandbox:  gs://fc-secure-50c9efc6-4ca8-4bf5-9752-5bd6a6da17dd/HIV-1_v2.0.primer.hyphen1200.1.bed
Similarly with clearlabs, the primers had to be updated in order for the new version of ARTIC to work, test can be found [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/b8d738ba-5cdf-4d30-85f6-337f4a9ddbf6), and the primer bed is here: gs://fc-secure-50c9efc6-4ca8-4bf5-9752-5bd6a6da17dd/Midnight_Primers_SARS-CoV-2.scheme_updated.bed

Here is another test case with Puerto Rico ONT data that [passes when updated primer bed files are used](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/e4c1680b-75c1-40e5-b1ae-950753ff2598), but [fails with the current primer bed](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/a1035144-cb73-4d26-b577-2320e6fd2975).
Puerto Rico uses the V3 Midnight Primers: gs://theiagen-public-files/terra/titan-files/SARS-CoV-2.Midnight-ONT.V3.scheme.bed, the updated ones are currently here: gs://fc-secure-50c9efc6-4ca8-4bf5-9752-5bd6a6da17dd/SARS-CoV-2.Midnight-ONT.V3.scheme_updated.bed

I also tested a scenario where `sars-cov-2` is set as default with no primer bed as input and empty.bed get's selected between the [new version](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/9b2839ab-9f57-4e13-82d7-6f8c08a56370) and [current version](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Babinski_Sandbox/job_history/a6569194-f900-4fe0-9ed3-b04d92b0afe5) to confirm they both fail.

On terra, all testing was done with provided bed file and reference picked up by organism parameters, to hit the scheme autodetection I tested locally directly against the task. I am happy to provide the test data if the reviewer wishes to repeat these tests.
For sars-cov-2:
`miniwdl run tasks/quality_control/read_filtering/task_artic_guppyplex.wdl read1=barcode01.fastq.gz samplename=test`,
For mpox:
`miniwdl run tasks/assembly/task_artic_consensus.wdl samplename=test read1=barcode01.fastq.gz organism=MPXV`

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

Testing on theiacov_ont and theiacov_clearlabs validation sets will be a good confirmation. Please test with any other data that is relevant to this workflow. We will need to update the primer bed files before merging this PR. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [x] You have updated the latest version for any affected worklows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables.

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
