### PR TITLE
[Ivar Variants] Refactor to succeed with message when no variants found

### DIFF
--- a/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
+++ b/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
@@ -71,18 +71,16 @@ task variant_call {
     cut -f 1-14 ~{samplename}.variants.tsv | awk '!seen[$0]++ {print}' > unique_variants.tsv
 
     # filter variants that pass fisher's exact test
-    grep "TRUE" unique_variants.tsv > passed_variants.tsv
+    grep "TRUE" unique_variants.tsv > passed_variants.tsv || touch passed_variants.tsv
 
     # calculate total number of variants
-    variants_num=$(cat passed_variants.tsv | wc -l)
-    if [ -z "$variants_num" ] ; then variants_num="0" ; fi
+    variants_num=$(wc -l < passed_variants.tsv || echo 0)
     echo $variants_num | tee VARIANT_NUM
 
     # calculate proportion of variants with allele frequencies between 0.6 and 0.9
     # find number of variants at intermediate frequencies 
     awk -F "\t" '{ if(($11 >= 0.6) && ($11 <= 0.9)) {print }}' passed_variants.tsv > intermediate_variants.tsv
-    intermediates_num=$(cat intermediate_variants.tsv | wc -l)
-    if [ -z "$intermediates_num" ] ; then intermediates_num="0" ; fi
+    intermediates_num=$(wc -l < intermediate_variants.tsv || echo 0)
 
     # if number of total variants is not zero, divide number of intermediate variants by total number of variants
     if [[ "$variants_num" -eq "0" ]]; then

--- a/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
+++ b/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
@@ -74,13 +74,13 @@ task variant_call {
     grep "TRUE" unique_variants.tsv > passed_variants.tsv || touch passed_variants.tsv
 
     # calculate total number of variants
-    variants_num=$(wc -l < passed_variants.tsv || echo 0)
+    variants_num=$(wc -l < passed_variants.tsv)
     echo $variants_num | tee VARIANT_NUM
 
     # calculate proportion of variants with allele frequencies between 0.6 and 0.9
     # find number of variants at intermediate frequencies 
     awk -F "\t" '{ if(($11 >= 0.6) && ($11 <= 0.9)) {print }}' passed_variants.tsv > intermediate_variants.tsv
-    intermediates_num=$(wc -l < intermediate_variants.tsv || echo 0)
+    intermediates_num=$(wc -l < intermediate_variants.tsv)
 
     # if number of total variants is not zero, divide number of intermediate variants by total number of variants
     if [[ "$variants_num" -eq "0" ]]; then

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -235,7 +235,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 871e716bb580f4157f34d4356f681482
+      md5sum: 1d6d68c786185025234cde20d5f120bc
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_pe.yml
@@ -235,7 +235,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 1d6d68c786185025234cde20d5f120bc
+      md5sum: da7011aeb44b10f39201559c18f2b866
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -187,7 +187,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 29c95a3f59a2b5cc180951752774a667
+      md5sum: 8e31a46ca086b193dd72acabf87e7ee2
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json

--- a/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
+++ b/tests/workflows/theiacov/test_wf_theiacov_illumina_se.yml
@@ -187,7 +187,7 @@
     - path: miniwdl_run/call-ivar_consensus/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     # variant call
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/command
-      md5sum: 0e927e531c7c66c130fbb69e4fece330
+      md5sum: 29c95a3f59a2b5cc180951752774a667
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/inputs.json
       contains: ["bamfile", "variant_min_freq", "samplename"]
     - path: miniwdl_run/call-ivar_consensus/call-variant_call/outputs.json


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #716 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
We have run into a few issues where data quality is bad ivar variants calling will fail after we most recently added `set -eou pipefail` to the task. While adding `set -euo pipefail` is generally good practice to avoid silent failures, but after further discussion there are certain scenarios where we want to be more graceful in handling outputs. When it comes specifically to ivar variant calling, if there is bad quality data, we may not necessarily want it to hard fail but report "Not computed: no variants detected" instead is reported for `ivar_variant_proportion_intermediate`, so on the users end there is a clear implication of status in the datatable. 

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Substitution commands were put in place of where certain failures may occur with `set -euo pipefail`, to track where no variants were found, and instead of hard failing, manipulating the behavior so we can catch when no variants where found and report gracefully "Not computed: no variants detected" so users are informed. 

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
Substitution commands implemented in potential places for failure to catch where variants are none. 
1. Touch empty passing_variants.tsv where `grep "TRUE" unique_variants.tsv > passed_variants.tsv` may err out do to no passing variants. 
2. Count passing variants directly or echo 0
3. Count intermediates directly or echo 0


### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
None
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
None
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

This testing was performed first on a subset of samples from cdph county Los Angeles to help narrow in on the issue. For v2.3.0 of PHB, we can see that 2 samples are [failing](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/d478d055-162d-49a6-8a03-ea323389e560), with this update, all samples [succeed](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/20637c26-f516-47d9-b18f-3f4d6283ce22) and the two samples that were failing before are now gracefully reporting no variants found. 

I also tested a before and after on the phb validation datasets for Illumina PE and SE:
[v2.3.0 TheiaCoV_Illumina_PE](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/4ec42da5-3f29-4c46-8da5-fdd79fa54907)
[v2.3.0 TheiaCoV_Illumina_SE](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/441463e1-39db-4785-a8a6-0cea501a2835)

[Ivar Fix Branch TheiaCoV_Illumina_PE](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/35ecb1d6-da7c-4e70-a3ce-225dbc3d3d4a)
[Ivar Fix Branch TheiaCoV_Illumina_SE](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/441463e1-39db-4785-a8a6-0cea501a2835)

In v2.3.0 you can see that a few fail at the ivar variant call step while with the fix, the samples pass and "Not computed: no variants detected" is output in place for `ivar_variant_proportion_intermediate`. I also compared samples that were passing before and after to make sure that `ivar_variant_proportion_intermediate` was the same for both. 

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

The validation sets for SE and PE are a good start to re-confirm and any other pathogen data that might be run through TheiaCoV often. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
