### PR TITLE
[srst2_vibrio, merlin_magic] Removed instances of srst2_ from inputs

### DIFF
--- a/tasks/species_typing/vibrio/task_srst2_vibrio.wdl
+++ b/tasks/species_typing/vibrio/task_srst2_vibrio.wdl
@@ -8,11 +8,11 @@ task srst2_vibrio {
     File read1
     File? read2
     String samplename
-    Int srst2_min_cov
-    Int srst2_max_divergence
-    Int srst2_min_depth
-    Int srst2_min_edge_depth
-    Int srst2_gene_max_mismatch
+    Int min_cov
+    Int max_divergence
+    Int min_depth
+    Int min_edge_depth
+    Int gene_max_mismatch
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/srst2:0.2.0-vcholerae"
     Int disk_size = 100
     Int cpu = 4
@@ -32,11 +32,11 @@ task srst2_vibrio {
       ${INPUT_READS} \
       --gene_db /vibrio-cholerae-db/vibrio_230224.fasta \
       --output ~{samplename} \
-      --min_coverage ~{srst2_min_cov} \
-      --max_divergence ~{srst2_max_divergence} \
-      --min_depth ~{srst2_min_depth} \
-      --min_edge_depth ~{srst2_min_edge_depth} \
-      --gene_max_mismatch ~{srst2_gene_max_mismatch}
+      --min_coverage ~{min_cov} \
+      --max_divergence ~{max_divergence} \
+      --min_depth ~{min_depth} \
+      --min_edge_depth ~{min_edge_depth} \
+      --gene_max_mismatch ~{gene_max_mismatch}
     
     # capture output TSV
     mv ~{samplename}__genes__*__results.txt ~{samplename}.tsv

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -556,7 +556,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: ac49217c129add7c000eedf38acee8f3
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 3c9c727d4a40ca936f58446103becb34
+      md5sum: 3547638e39dcf408234a6c1df57d198d
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -524,7 +524,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 5e735ae6cb60f86ec7983274f3baf9f8
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 3c9c727d4a40ca936f58446103becb34
+      md5sum: 3547638e39dcf408234a6c1df57d198d
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 09d9f68b9ca8bf94b6145ff9bed2edd1
     - path: miniwdl_run/workflow.log

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -610,11 +610,11 @@ workflow merlin_magic {
           read1 = select_first([read1]),
           read2 = read2,
           samplename = samplename,
-          srst2_min_cov = srst2_min_cov,
-          srst2_max_divergence = srst2_max_divergence,
-          srst2_min_depth = srst2_min_depth,
-          srst2_min_edge_depth = srst2_min_edge_depth,
-          srst2_gene_max_mismatch = srst2_gene_max_mismatch,
+          min_cov = srst2_min_cov,
+          max_divergence = srst2_max_divergence,
+          min_depth = srst2_min_depth,
+          min_edge_depth = srst2_min_edge_depth,
+          gene_max_mismatch = srst2_gene_max_mismatch,
           docker = srst2_docker_image
       }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #560

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Removes prefix of srst2_ from inputs of srst2_vibrio task within wf_merlin_magic.
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
For each of the parameters within srst2_vibrio, the prefix of srst2_ was removed. This was then reflected within the command block as well as the call block of srst2_vibrio within wf_merlin_magic. 
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
#### task_srst2_vibrio.wdl Inputs
|main|awh-srst2vibrio-dev|
|-----|----------------------|
|Int srst2_min_cov|Int min_cov|
|Int srst2_max_divergence|Int max_divergence|
|Int srst2_min_depth|Int min_depth|
|Int srst2_min_edge_depth|Int min_edge_depth|
|Int srst2_gene_max_mismatch|Int gene_max_mismatch|

#### task_srst2_vibrio.wdl command block
```
main
srst2 \
      ${INPUT_READS} \
      --gene_db /vibrio-cholerae-db/vibrio_230224.fasta \
      --output ~{samplename} \
      --min_coverage ~{srst2_min_cov} \
      --max_divergence ~{srst2_max_divergence} \
      --min_depth ~{srst2_min_depth} \
      --min_edge_depth ~{srst2_min_edge_depth} \
      --gene_max_mismatch ~{srst2_gene_max_mismatch}

awh-srst2vibrio-dev
srst2 \
      ${INPUT_READS} \
      --gene_db /vibrio-cholerae-db/vibrio_230224.fasta \
      --output ~{samplename} \
      --min_coverage ~{min_cov} \
      --max_divergence ~{max_divergence} \
      --min_depth ~{min_depth} \
      --min_edge_depth ~{min_edge_depth} \
      --gene_max_mismatch ~{gene_max_mismatch}
```

#### wf_merlin_magic.wdl call srst2_vibrio_task
```
main
call srst2_vibrio_task.srst2_vibrio {
        input:
          read1 = select_first([read1]),
          read2 = read2,
          samplename = samplename,
          srst2_min_cov = srst2_min_cov,
          srst2_max_divergence = srst2_max_divergence,
          srst2_min_depth = srst2_min_depth,
          srst2_min_edge_depth = srst2_min_edge_depth,
          srst2_gene_max_mismatch = srst2_gene_max_mismatch,
          docker = srst2_docker_image
}

awh-srst2vibrio-dev
call srst2_vibrio_task.srst2_vibrio {
        input:
          read1 = select_first([read1]),
          read2 = read2,
          samplename = samplename,
          min_cov = srst2_min_cov,
          max_divergence = srst2_max_divergence,
          min_depth = srst2_min_depth,
          min_edge_depth = srst2_min_edge_depth,
          gene_max_mismatch = srst2_gene_max_mismatch,
          docker = srst2_docker_image
}
```
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
No outputs were modified.
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
Testing was done using TheiaProk datasets within NE-PGCOE_sandbox.
Each TheiaProk workflow was tested on seven samples twice, one with default parameters and another with slightly altering the wf_merlin_magic.wdl srst2 parameters that are passed to task_srst2_vibrio.wd to ensure that the correct values are being passed. 

[TheiaProk_Illumina_PE Default Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/0f6d267e-8bba-4891-ad24-16dfe1059375)
[TheiaProk_Illumina_PE Changed Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/d1059767-440d-4972-a5ae-e1d1f354f6aa)

[TheiaProk_FASTA Default Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/d8145331-9507-4c92-9733-5bb77e9fcff7)
[TheiaProk_FASTA Changed Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/055b7da3-62aa-4d37-ad8c-718342bc04ef)

[TheiaProk_Illumina_SE Default Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/6677cac4-6dba-4a5c-ba5c-8958b43ec854)
[TheiaProk_Illumina_SE Changed Inputs](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/ae0516c5-70f5-4022-8218-6761ecc34229)

[TheiaProk_ONT](https://app.terra.bio/#workspaces/theiagen-nepgcoe/NE-PGCoE_sandbox/job_history/3ab9d246-cbf3-42be-84a9-1f3d4fabb4b3)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
