### PR TITLE
[Reorder Matrix] Changed output file name to more general {cluster}_distance_matrix.csv

### DIFF
--- a/tasks/phylogenetic_inference/utilities/task_reorder_matrix.wdl
+++ b/tasks/phylogenetic_inference/utilities/task_reorder_matrix.wdl
@@ -56,7 +56,7 @@ task reorder_matrix {
     snps_out2.index.name = ""
 
     # write out the reordered matrix to a file
-    snps_out2.to_csv("~{cluster_name}_snp_matrix.csv", sep=",")
+    snps_out2.to_csv("~{cluster_name}_distance_matrix.csv", sep=",")
 
     # write tree to a file (same as input tree if not midpoint rooted)
     Phylo.write(tree, "~{cluster_name}_tree.nwk", "newick")
@@ -64,7 +64,7 @@ task reorder_matrix {
     CODE
   >>>
   output {
-    File ordered_matrix = "~{cluster_name}_snp_matrix.csv"
+    File ordered_matrix = "~{cluster_name}_distance_matrix.csv"
     File tree = "~{cluster_name}_tree.nwk"
   }
   runtime {


### PR DESCRIPTION

<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #549 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Change to output matrix file for task_reorder_matrix.wdl to reflect a more generalized output. This is because the workflows that utilize this task don't always output SNP matrices so the file name could be misleading.
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
task_reorder_matrix.wdl
wf_augur.wdl
wf_core_gene_snp.wdl
wf_ksnp3.wdl
wf_mashtree_fasta.wdl
wf)snippy_tree.wdl

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Instances of ```~{cluster_name}_snp_matrix.csv``` changed to ```~{cluster_name}_distance_matrix.csv```
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
Call block:
```
snps_out2.to_csv("~{cluster_name}_snp_matrix.csv", sep=",") -> snps_out2.to_csv("~{cluster_name}_distance_matrix.csv", sep=",")
```
Output block:
```
File ordered_matrix = "~{cluster_name}_snp_matrix.csv" -> File ordered_matrix = "~{cluster_name}_distance_matrix.csv"
```
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
The above workflows have been tested in order to ensure that output file names reflect change to ```*_distance_matrix.csv```.
[task_reorder_matrix](url)
[wf_augur](url)
[wf_core_gene_snp](url)
[wf_ksnp3](url)
[wf_mashtree_fasta](url)
[wf_snippy_tree](url)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] Documentation and/or workflow diagrams have been updated if applicable
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
