### PR TITLE
[Snippy Variants] Preserve current memory allocation & add error handling to prevent silent failures

### DIFF
--- a/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
+++ b/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
@@ -26,7 +26,9 @@ task snippy_variants {
     Int? maxsoft
   }
   command <<<
+    # set -euo pipefail to avoid silent failure
     set -euo pipefail
+
     snippy --version | head -1 | tee VERSION
 
     # set input variable

--- a/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
+++ b/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
@@ -26,6 +26,7 @@ task snippy_variants {
     Int? maxsoft
   }
   command <<<
+    set -euo pipefail
     snippy --version | head -1 | tee VERSION
 
     # set input variable

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -444,7 +444,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_resfinder.wdl
       md5sum: 27528633723303b462d095b642649453
     - path: miniwdl_run/wdl/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
-      md5sum: 440a620a10ccdafe612f0b33ef05f86d
+      md5sum: b66f4306b61fa3bc7bbc242556866b6c
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_bbduk.wdl
       md5sum: aec6ef024d6dff31723f44290f6b9cf5
     - path: miniwdl_run/wdl/tasks/quality_control/advanced_metrics/task_busco.wdl
@@ -516,7 +516,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
       md5sum: 9b8e2da62c8572a369c786a9bbc3a36e
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 1bcb64a5e28d26e3603f456e99bfa7b6
+      md5sum: adf5789053a7f720f4555be4472270d0
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -417,7 +417,7 @@
     - path: miniwdl_run/wdl/tasks/gene_typing/drug_resistance/task_resfinder.wdl
       md5sum: 27528633723303b462d095b642649453
     - path: miniwdl_run/wdl/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
-      md5sum: 440a620a10ccdafe612f0b33ef05f86d
+      md5sum: b66f4306b61fa3bc7bbc242556866b6c
     - path: miniwdl_run/wdl/tasks/quality_control/read_filtering/task_bbduk.wdl
       md5sum: aec6ef024d6dff31723f44290f6b9cf5
     - path: miniwdl_run/wdl/tasks/quality_control/advanced_metrics/task_busco.wdl
@@ -487,7 +487,7 @@
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
       md5sum: 02dc0075bf28d557d7b81aa2dc61feab
     - path: miniwdl_run/wdl/workflows/utilities/wf_merlin_magic.wdl
-      md5sum: 1bcb64a5e28d26e3603f456e99bfa7b6
+      md5sum: adf5789053a7f720f4555be4472270d0
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 09d9f68b9ca8bf94b6145ff9bed2edd1
     - path: miniwdl_run/workflow.log

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -131,7 +131,7 @@ workflow merlin_magic {
     Int? emmtyper_min_perfect
     Int? emmtyper_min_good
     Int? emmtyper_max_size
-    #hicap options
+    # hicap options
     Float? hicap_gene_coverage
     Float? hicap_gene_identity
     Float? hicap_broken_gene_identity


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #570 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
This PR addresses the issue brought up in #570 regarding the necessary resource requirements for the `snippy_variants` task. No changes were made to memory allocation. Added error handling and minor formatting fixes.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
- task_snippy_variants.wdl
- wf_merlin_magic.wdl
- wf_snippy_variants.wdl 
- wf_snippy_streamline_fasta.wdl 
- wf_snippy_streamline.wdl 

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Added `set -euo pipefail` at the beginning of the command to catch potential errors and prevent silent failures.

I encountered an issue where Snippy was terminated by the system due to memory constraints, but the job was still reported as successful in Terra. In cases like this, I also found that a different number of variants were reported for the same sample depending on the amount of memory that was allocated (16 GB vs 32 GB) (see testing below).

Michal suggested that we add `set -euo pipefail` to the task, in order to fix this silent failure. However, the issue persisted even after implementing this. It seems like the problem lies above the shell level, with Snippy not setting its own proper exit code on failure. Although the `set -euo pipefail` did not resolve this specific issue, it should still be useful as a safeguard for future updates.

Based on my testing and other feedback, I think the best option is to include the `set -euo pipefail` and leave the memory allocation unchanged (@ 32 GB) for now. 
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
None.
### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
None.
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
None.
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
To test memory usage for the `task_snippy_variants.wdl`, I implemented [this](https://github.com/talkowski-lab/gatk-sv-internal/blob/main/scripts/cromwell/cromwell_monitoring_script2.sh) resource monitoring script from GATK into my Terra workflows. This creates a file called `monitoring.log` that reports % CPU and memory usage every 10 seconds.

***TESTS:***
- To determine if a Snippy process was terminated I grepped for the word "Killed" in the `snippy_variants.log` for each sample.
![killed_anno](https://github.com/user-attachments/assets/213e0701-5f03-4b94-95c1-b28806edae53)



[Snippy_Variants_PHB Workflow - 36 validation samples @ Memory = 32 GB (default)](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/job_history/b3fedb35-cb5b-4539-a388-0f75c020a0fa)
- All samples passed successfully @ 32 GB (default). None of the 36 samples had their Snippy processes killed.
- The maximum memory utilized in this set of samples was ~28 GB. This data frame was generated using the data found in the `monitoring.log` file.
![mem32_reads](https://github.com/user-attachments/assets/a80d1d15-938c-4e69-8617-801afe7f18eb)


[Snippy_Variants_PHB Workflow - 36 validation samples @ Memory = 16 GB](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/job_history/0f017964-50e6-410e-ae2e-84c883486d72)
- All but two samples ran successfully according to Terra.
- However, in reality 14/36 samples were killed and silently failed @ 16 GB. (See below for specific example).
- 14 samples show that the maximum memory utilized hit the maximum memory allocated ~16 GB. This data frame was generated using the data found in the `monitoring.log` file.
![mem16_reads](https://github.com/user-attachments/assets/55a72e48-0f2b-462b-8246-ec245a5b70cb)



***Specific Example:***
> Sample: 22-00052862b
Memory Allocated: 32GB
Max Memory Utilized: 23.47 GB (see `monitoring.log`)
Terra Status: Succeeded
Total Variants: 375

> Sample: 22-00052862b
Memory Allocated: 16GB
Max Memory Utilized: 15.39 GB (see `monitoring.log`)
Terra Status: Succeeded (but snippy was killed - see `snippy_variants.log`)
Total Variants: 389

Additionally, I tested the Snippy_Variants_PHB workflow with `assembly.fasta` as an input (instead of `read1 & read2`), and none of the samples came close to running out of memory (the maximum I saw was ~3 GB). The data for that can be found [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/job_history/6c937379-2815-425e-9b2a-649762aa5258).



### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->
It might be worth testing a different set of samples with different levels of memory. I also only tested with 8 CPUs which could potentially influence how Snippy operates under the hood. I did not test with the Snippy_Streamline_PHB or Snippy_Streamline_FASTA_PHB workflows either.

I considered dynamically adjusting memory based on the number of reads per sample, but a high read count doesn't necessarily correlate with high memory usage. I think the number of variants in a sample drives these memory requirements, which would be difficult to predict in advance. Further investigation may be needed to confirm this.

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
