### PR TITLE
[Merlin_magic; Sonneityping] harden workflow against failures due to sonnei typing disagreement

### DIFF
--- a/tasks/species_typing/escherichia_shigella/task_sonneityping.wdl
+++ b/tasks/species_typing/escherichia_shigella/task_sonneityping.wdl
@@ -8,7 +8,7 @@ task sonneityping {
     Boolean ont_data = false
     String samplename
     String? mykrobe_opts
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1-parser-7d18a7c"
     Int disk_size = 100
     Int cpu = 4
     Int memory = 8
@@ -34,34 +34,50 @@ task sonneityping {
     python /sonneityping/parse_mykrobe_predict.py \
     --jsons ~{samplename}.mykrobe.json --alleles /sonneityping/alleles.txt \
     --prefix ~{samplename}.sonneityping
+    
+    #Used for testing the soft fail if mykrobe doesnt return predictions as seen before, keeping for posterity's sake
+    #echo "DEBUG: Removing output to test if sonneityping script soft fails"
+    #rm -rf ~{samplename}.sonneityping_predictResults.tsv
 
-    # rename output TSV to something prettier
-    mv -v ~{samplename}.sonneityping_predictResults.tsv ~{samplename}.sonneityping.tsv
-
+    if [ -f ~{samplename}.sonneityping_predictResults.tsv ]; then
+      echo "DEBUG: sonneityping produced expected output file"
+      # rename output TSV to something prettier
+      mv -v ~{samplename}.sonneityping_predictResults.tsv ~{samplename}.sonneityping.tsv
+    else 
+      echo "Error: sonneityping did not produce expected output file. Check mykrobe logs."
+      touch SPECIES.txt
+      touch FINAL_GENOTYPE.txt
+      touch GENOTYPE_NAME.txt
+      touch CONFIDENCE.txt
+    fi
     # Run a python block to parse output sonneityping TSV file for terra data tables
     python3 <<CODE
+    import os
     import csv
-    with open("./~{samplename}.sonneityping.tsv",'r') as tsv_file:
-      tsv_reader = list(csv.DictReader(tsv_file, delimiter="\t"))
-      for line in tsv_reader:
-        with open ("SPECIES.txt", 'wt') as sonneityping_species:
-          species=line["species"]
-          sonneityping_species.write(species)
-        with open ("FINAL_GENOTYPE.txt", 'wt') as final_genotype:
-          genotype=line["final genotype"]
-          final_genotype.write(genotype)
-        with open ("GENOTYPE_NAME.txt", 'wt') as genotype_name:
-          genotypename=line["name"]
-          genotype_name.write(genotypename)
-        with open ("CONFIDENCE.txt", 'wt') as sonneityping_confidence:
-          confidence=line["confidence"]
-          sonneityping_confidence.write(confidence)
+    if os.path.exists("./~{samplename}.sonneityping.tsv"):
+      with open("./~{samplename}.sonneityping.tsv",'r') as tsv_file:
+        tsv_reader = list(csv.DictReader(tsv_file, delimiter="\t"))
+        for line in tsv_reader:
+          with open ("SPECIES.txt", 'wt') as sonneityping_species:
+            species=line["species"]
+            sonneityping_species.write(species)
+          with open ("FINAL_GENOTYPE.txt", 'wt') as final_genotype:
+            genotype=line["final genotype"]
+            final_genotype.write(genotype)
+          with open ("GENOTYPE_NAME.txt", 'wt') as genotype_name:
+            genotypename=line["name"]
+            genotype_name.write(genotypename)
+          with open ("CONFIDENCE.txt", 'wt') as sonneityping_confidence:
+            confidence=line["confidence"]
+            sonneityping_confidence.write(confidence)
+    else:
+      print("DEBUG: Skipping parsing, output files will be empty.")
     CODE
   >>>
   output {
-    File sonneityping_mykrobe_report_csv = "~{samplename}.mykrobe.csv"
-    File sonneityping_mykrobe_report_json = "~{samplename}.mykrobe.json"
-    File sonneityping_final_report_tsv = "~{samplename}.sonneityping.tsv"
+    File? sonneityping_mykrobe_report_csv = "~{samplename}.mykrobe.csv"
+    File? sonneityping_mykrobe_report_json = "~{samplename}.mykrobe.json"
+    File? sonneityping_final_report_tsv = "~{samplename}.sonneityping.tsv"
     String sonneityping_mykrobe_version = read_string("MYKROBE_VERSION.txt")
     String sonneityping_mykrobe_docker = docker
     String sonneityping_species = read_string("SPECIES.txt")


### PR DESCRIPTION

<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #600

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Samples that would return percent_coverage < 90 would not produce indices that were required from the parser parse_mykrobe_predict.py housed within the mykrobe container. This would lead to mislabeled or dubiously characterized samples failing at sonneityper. Commit [`7d18a7c`](https://github.com/katholt/sonneityping/commit/7d18a7cbfdb1f931765cc0b243a17605b7cff570) of [`sonneityping`](https://github.com/katholt/sonneityping)committed by Sage solves this issue along with a typo correction. This PR implements this commit into a new docker container, [us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1-parser-7d18a7c](https://console.cloud.google.com/artifacts/docker/general-theiagen/us/staphb/mykrobe) along with error handling to still deal with the possibility of missing output from mykrobe. I do not foresee this occurring with the new fix to the parser in place as it will report at "not sonnei" but I have kept the error handling present.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
task_sonneityping.wdl
wf_merlin_magic.wdl
TheiaProk_PE
TheiaProk_SE
TheiaProk_ONT

This PR may lead to different results in pre-existing outputs: **No**
Samples already with a classification of Sonnei from sonneityper will not be changed, only samples that would fail will now have a classification of "not sonnei" returned.

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Docker image changed to updated parser version.

Error Handling:
A check added to check for sonneityping_predictResults.tsv with debug messages hinting at if the file was found or not.
If file is not found the necessary output text files are returned as empty, per the [slack discussion](https://theiagen.slack.com/archives/C04GMT7TPTR/p1724974576036859), and the python code block is skipped.
File outputs have been made optional to also handle the event of a missing output.
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
Docker image changed to pull newest commit of parse_mykrobe_predict.py

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
`us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1 -> us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1-parser-7d18a7c`

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
File outputs are now optional outputs.

```
File sonneityping_mykrobe_report_csv = "~{samplename}.mykrobe.csv" -> File? sonneityping_mykrobe_report_csv = "~{samplename}.mykrobe.csv"
File sonneityping_mykrobe_report_json = "~{samplename}.mykrobe.json" -> File? sonneityping_mykrobe_report_json = "~{samplename}.mykrobe.json"
File sonneityping_final_report_tsv = "~{samplename}.sonneityping.tsv" -> File? sonneityping_final_report_tsv = "~{samplename}.sonneityping.tsv"
```

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
Each of the affected workflows was tested using non sonnei and sonnei sequences.

[TheiaProk_PE](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/job_history/f4245be7-86e8-46a9-ad60-a49c0669fb45)
[TheiaProk_SE](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/job_history/f0e34123-7580-474a-a0a8-0fe6e438322c)
[TheiaProk_ONT](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/job_history/ea45a41a-130b-4bdd-9e30-55be1893673f)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] Documentation and/or workflow diagrams have been updated if applicable
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated
