### PR TITLE
[Freyja] Add GFF flag and make primer_bed optional

### DIFF
--- a/docs/workflows/genomic_characterization/freyja.md
+++ b/docs/workflows/genomic_characterization/freyja.md
@@ -112,9 +112,10 @@ This workflow runs on the sample level.
 
 | **Terra Task Name** | **Variable** | **Type** | **Description** | **Default Value** | **Terra Status** |
 |---|---|---|---|---|---|
-| freyja_fastq | **primer_bed** | File | The bed file containing the primers used when sequencing was performed |  | Required |
+| freyja_fastq | **primer_bed** | File | The bed file containing the primers used when sequencing was performed |  | Optional |
 | freyja_fastq | **read1** | File | The raw forward-facing FASTQ file (Illumina or ONT) |  | Required |
 | freyja_fastq | **reference_genome** | File | The reference genome to use; should match the reference used for alignment (Wuhan-Hu-1)  |  | Required |
+| freyja_fastq | **reference_gff** | File | The GFF file for reference; should match the reference used for alignment (Wuhan-Hu-1) |  | Optional |
 | freyja_fastq | **samplename** | String | The name of the sample |  | Required |
 | bwa | **cpu** | Int | Number of CPUs to allocate to the task | 6 | Optional |
 | bwa | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 100 | Optional |

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -2,9 +2,11 @@ version 1.0
 
 task freyja_one_sample {
   input {
-    File primer_trimmed_bam
+    File? primer_trimmed_bam
+    File? bamfile
     String samplename
     File reference_genome
+    File? reference_gff
     String? freyja_pathogen
     File? freyja_barcodes
     File? freyja_lineage_metadata
@@ -67,7 +69,8 @@ task freyja_one_sample {
   # Call variants and capture sequencing depth information
   echo "Running: freyja variants ~{primer_trimmed_bam} --variants ~{samplename}_freyja_variants.tsv --depths ~{samplename}_freyja_depths.tsv --ref ~{reference_genome}"
   freyja variants \
-    ~{primer_trimmed_bam} \
+    ~{select_first([primer_trimmed_bam, bamfile])} \
+    ~{"--annot " + reference_gff} \
     --variants ~{samplename}_freyja_variants.tsv \
     --depths ~{samplename}_freyja_depths.tsv \
     --ref ~{reference_genome}

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -18,7 +18,7 @@ task freyja_one_sample {
     Int? depth_cutoff
     Int memory = 8
     Int cpu = 2
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.2-11_30_2024-02-00-2024-12-02"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.3"
     Int disk_size = 100
   }
   command <<<

--- a/tasks/taxon_id/freyja/task_freyja.wdl
+++ b/tasks/taxon_id/freyja/task_freyja.wdl
@@ -2,8 +2,7 @@ version 1.0
 
 task freyja_one_sample {
   input {
-    File? primer_trimmed_bam
-    File? bamfile
+    File bamfile
     String samplename
     File reference_genome
     File? reference_gff
@@ -67,9 +66,9 @@ task freyja_one_sample {
   echo ${freyja_metadata_version} | tee FREYJA_METADATA
   
   # Call variants and capture sequencing depth information
-  echo "Running: freyja variants ~{primer_trimmed_bam} --variants ~{samplename}_freyja_variants.tsv --depths ~{samplename}_freyja_depths.tsv --ref ~{reference_genome}"
+  echo "Running: freyja variants ~{bamfile} --variants ~{samplename}_freyja_variants.tsv --depths ~{samplename}_freyja_depths.tsv --ref ~{reference_genome}"
   freyja variants \
-    ~{select_first([primer_trimmed_bam, bamfile])} \
+    ~{bamfile} \
     ~{"--annot " + reference_gff} \
     --variants ~{samplename}_freyja_variants.tsv \
     --depths ~{samplename}_freyja_depths.tsv \

--- a/workflows/freyja/wf_freyja_fastq.wdl
+++ b/workflows/freyja/wf_freyja_fastq.wdl
@@ -103,27 +103,17 @@ workflow freyja_fastq {
         primer_bed = select_first([primer_bed]),
         bamfile = select_first([sam_to_sorted_bam.bam, bwa.sorted_bam])
     }
-    call freyja_task.freyja_one_sample as freyja {
-      input:
-        primer_trimmed_bam = primer_trim.trim_sorted_bam,
-        samplename = samplename,
-        reference_genome = reference_genome,
-        reference_gff = reference_gff,
-        depth_cutoff = depth_cutoff
-    }
   }
 
-  # When primer_bed is not present. Sorted bam is passed to freyja passing trimming process.
-  if (!defined(primer_bed)){
-    call freyja_task.freyja_one_sample as freyja_no_primer_trim {
-      input:
-        bamfile = select_first([sam_to_sorted_bam.bam, bwa.sorted_bam]),
-        samplename = samplename,
-        reference_genome = reference_genome,
-        reference_gff = reference_gff,
-        depth_cutoff = depth_cutoff
-    }
+  call freyja_task.freyja_one_sample as freyja {
+    input:
+      bamfile = select_first([primer_trim.trim_sorted_bam, sam_to_sorted_bam.bam, bwa.sorted_bam]),
+      samplename = samplename,
+      reference_genome = reference_genome,
+      reference_gff = reference_gff,
+      depth_cutoff = depth_cutoff
   }
+
 
   call versioning.version_capture {
     input:
@@ -223,23 +213,23 @@ workflow freyja_fastq {
     String? samtools_version_primtrim = primer_trim.samtools_version
     String? primer_bed_name = primer_trim.primer_bed_name
     # Freyja Analysis outputs
-    String freyja_version = select_first([freyja.freyja_version,freyja_no_primer_trim.freyja_version])
-    File freyja_variants = select_first([freyja.freyja_variants, freyja_no_primer_trim.freyja_variants])
-    File freyja_depths = select_first([freyja.freyja_depths, freyja_no_primer_trim.freyja_depths])
-    File freyja_demixed = select_first([freyja.freyja_demixed, freyja_no_primer_trim.freyja_demixed]) 
-    Float freyja_coverage = select_first([freyja.freyja_coverage, freyja_no_primer_trim.freyja_coverage]) 
-    File freyja_barcode_file = select_first([freyja.freyja_barcode_file, freyja_no_primer_trim.freyja_barcode_file])  
-    File freyja_lineage_metadata_file = select_first([freyja.freyja_lineage_metadata_file, freyja_no_primer_trim.freyja_lineage_metadata_file]) 
-    String freyja_barcode_version = select_first([freyja.freyja_barcode_version, freyja_no_primer_trim.freyja_barcode_version])
-    String freyja_metadata_version = select_first([freyja.freyja_metadata_version, freyja_no_primer_trim.freyja_metadata_version])
-    String? freyja_bootstrap_lineages = select_first([freyja.freyja_bootstrap_lineages, freyja_no_primer_trim.freyja_bootstrap_lineages,""])
-    String? freyja_bootstrap_lineages_pdf = select_first([freyja.freyja_bootstrap_lineages_pdf, freyja_no_primer_trim.freyja_bootstrap_lineages_pdf,""])
-    String? freyja_bootstrap_summary = select_first([freyja.freyja_bootstrap_summary, freyja_no_primer_trim.freyja_bootstrap_summary,""])
-    String? freyja_bootstrap_summary_pdf = select_first([freyja.freyja_bootstrap_summary_pdf, freyja_no_primer_trim.freyja_bootstrap_summary_pdf,""])
-    File freyja_demixed_parsed = select_first([freyja.freyja_demixed_parsed, freyja_no_primer_trim.freyja_demixed_parsed])
-    String freyja_resid = select_first([freyja.freyja_resid, freyja_no_primer_trim.freyja_resid])
-    String freyja_summarized = select_first([freyja.freyja_summarized, freyja_no_primer_trim.freyja_summarized])
-    String freyja_lineages = select_first([freyja.freyja_lineages, freyja_no_primer_trim.freyja_lineages])
-    String freyja_abundances = select_first([freyja.freyja_abundances, freyja_no_primer_trim.freyja_abundances])
+    String freyja_version = freyja.freyja_version
+    File freyja_variants = freyja.freyja_variants
+    File freyja_depths = freyja.freyja_depths
+    File freyja_demixed = freyja.freyja_demixed 
+    Float freyja_coverage = freyja.freyja_coverage
+    File freyja_barcode_file = freyja.freyja_barcode_file  
+    File freyja_lineage_metadata_file = freyja.freyja_lineage_metadata_file 
+    String freyja_barcode_version = freyja.freyja_barcode_version
+    String freyja_metadata_version = freyja.freyja_metadata_version
+    String? freyja_bootstrap_lineages = freyja.freyja_bootstrap_lineages
+    String? freyja_bootstrap_lineages_pdf = freyja.freyja_bootstrap_lineages_pdf
+    String? freyja_bootstrap_summary = freyja.freyja_bootstrap_summary
+    String? freyja_bootstrap_summary_pdf = freyja.freyja_bootstrap_summary_pdf
+    File freyja_demixed_parsed = freyja.freyja_demixed_parsed
+    String freyja_resid = freyja.freyja_resid
+    String freyja_summarized = freyja.freyja_summarized
+    String freyja_lineages = freyja.freyja_lineages
+    String freyja_abundances = freyja.freyja_abundances
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #752 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR adds the functionality of --gff to task_freyja.wdl. This will populate the remaining columns of the output file to include the genomic feature that contains the mutation as well as the amino acid mutation. Along side this is a change that makes primer_bed an optional input for those who are using approaches not utilizing a primer amplicon scheme. Finally this PR is looking to incorporate Freyja v1.5.3.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

- wf_freyja_fastq
- task_freyja

This PR may lead to different results in pre-existing outputs: **Yes**
If pre-existing outputs are now run with --gff and the reference GFF passed there will be new mutation information present.

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

- `primer_bed` is now an optional input.
- `reference_gff` has also been added as an optional input.
- insert new freyja version once merged

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

`primer_trim` is only run when the `pimer_bed` is provided. When this file is not provided `freyja` is passed the sorted bam file as opposed to a trimmed bam file. `task_freyja` now has a generic `bamfile` input that will accept either the trimmed or sorted bam as input.

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

#### wf_freyja_fastq.wdl
reference_gff: added as optional
primer_bed: made optional

#### task_freyja.wdl
bamfile: previously primer_trimmed_bam

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

SC2 dataset was run with no `primer_bed` as well as passing the new GFF file and once more for testing normal functionality of passing the `primer_bed` file

[No passing `primer_bed`](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/f4f58a90-8a4b-4992-ba75-6e66c6f10639)

[Passing GFF File](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/35550bf5-930d-43da-81ef-537a93b4f57b)

[Usual Functionality with `primer_bed`](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/a1691bfc-af36-4be4-8604-bc78cc79d52a)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
