### PR TITLE
[Snippy_Streamline] use the centroid genome as the reference if indicated

### DIFF
--- a/docs/workflows/phylogenetic_construction/snippy_streamline.md
+++ b/docs/workflows/phylogenetic_construction/snippy_streamline.md
@@ -19,8 +19,9 @@ The `Snippy_Streamline` workflow is an all-in-one approach to generating a refer
 
     ==In order to generate a phylogenetic tree, a reference genome is required.== This can be:
 
-    1. provided by the user
-    2. automatically selected using the `centroid` task and `reference_seeker` task to find a close reference genome to your dataset
+    1. provided by the user by filling the `reference_genome_file` input variable
+    2. the identified `centroid` genome by setting `use_centroid_as_reference` to true
+    3. automatically selected using the `centroid` task and `reference_seeker` task to find a close reference genome to your dataset by providing data in the `assembly_fasta` input variable and leaving the `reference_genome_file` and `use_centroid_as_reference` fields blank
 
     !!! warning "Automatic Reference Selection"
         If no reference genome is provided, then the user MUST fill in the `assembly_fasta` field for automatic reference genome selection.
@@ -89,6 +90,7 @@ To run Snippy_Streamline, either a reference genome must be provided (`reference
 | centroid | **memory** | Int | Amount of memory/RAM (in GB) to allocate to the task | 4 | Optional |
 | snippy_streamline | **assembly_fasta** | Array[File] | The assembly files for your samples (Required if a reference genome is not provided) |  | Optional |
 | snippy_streamline | **reference_genome_file** | File | Reference genome in FASTA or GENBANK format (must be the same reference used in Snippy_Variants workflow); provide this if you want to skip the detection of a suitable reference |  | Optional |
+| snippy_streamline | **use_centroid_as_reference** | Booolean | Set to true if you want to use the centroid sample as the reference sample instead of using the centroid to detect a suitable one | false  | Optional |
 | ncbi_datasets_download_genome_accession | **cpu** | Int | Number of CPUs to allocate to the task | 1 | Optional |
 | ncbi_datasets_download_genome_accession | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 50 | Optional |
 | ncbi_datasets_download_genome_accession | **docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/staphb/ncbi-datasets:14.13.2 | Optional |

--- a/docs/workflows/phylogenetic_construction/snippy_streamline_fasta.md
+++ b/docs/workflows/phylogenetic_construction/snippy_streamline_fasta.md
@@ -21,8 +21,10 @@ The `Snippy_Streamline_FASTA` workflow is an all-in-one approach to generating a
 
     ==In order to generate a phylogenetic tree, a reference genome is required.== This can be:
 
-    1. provided by the user
-    2. automatically selected using the `centroid` task and `reference_seeker` task to find a close reference genome to your dataset
+    1. provided by the user by filling the `reference_genome_file` input variable
+    2. the identified `centroid` genome by setting `use_centroid_as_reference` to true
+    3. automatically selected using the `centroid` task and `reference_seeker` task to find a close reference genome to your dataset by leaving the `reference_genome_file` and `use_centroid_as_reference` fields blank
+    
 
 !!! dna "Phylogenetic Tree Construction Options"
     There are several options that can be used to customize the phylogenetic tree, including:
@@ -79,7 +81,6 @@ The `Snippy_Streamline_FASTA` workflow is an all-in-one approach to generating a
 | snippy_streamline_fasta | **assembly_fasta** | Array[File] | The assembly files for your samples |  | Required |
 | snippy_streamline_fasta | **samplenames** | Array[String] | The names of your samples |  | Required |
 | snippy_streamline_fasta | **tree_name** | String | String of your choice to prefix output files |  | Required |
-| snippy_streamline_fasta | **reference_genome_file** | File | Reference genome in FASTA or GENBANK format (must be the same reference used in Snippy_Variants workflow); provide this if you want to skip the detection of a suitable reference |  | Optional |
 | centroid | **cpu** | Int | Number of CPUs to allocate to the task | 1 | Optional |
 | centroid | **disk_size** | Int | Amount of storage (in GB) to allocate to the task | 50 | Optional |
 | centroid | **docker** | String | The Docker container to use for the task | us-docker.pkg.dev/general-theiagen/theiagen/centroid:0.1.0 | Optional |
@@ -98,6 +99,8 @@ The `Snippy_Streamline_FASTA` workflow is an all-in-one approach to generating a
 | referenceseeker | **referenceseeker_ani_threshold** | Float | Bidirectional average nucleotide identity to use as a cut off for identifying reference assemblies with ReferenceSeeker; default value set according to <https://github.com/oschwengers/referenceseeker#description> | 0.95 | Optional |
 | referenceseeker | **referenceseeker_conserved_dna_threshold** | Float | Conserved DNA % to use as a cut off for identifying reference assemblies with ReferenceSeeker; default value set according to <https://github.com/oschwengers/referenceseeker#description> | 0.69 | Optional |
 | referenceseeker | **referenceseeker_db** | File | Database to use with ReferenceSeeker | gs://theiagen-public-files-rp/terra/theiaprok-files/referenceseeker-bacteria-refseq-205.v20210406.tar.gz | Optional |
+| snippy_streamline_fasta | **reference_genome_file** | File | Reference genome in FASTA or GENBANK format (must be the same reference used in Snippy_Variants workflow); provide this if you want to skip the detection of a suitable reference |  | Optional |
+| snippy_streamline_fasta | **use_centroid_as_reference** | Booolean | Set to true if you want to use the centroid sample as the reference sample instead of using the centroid to detect a suitable one | false  | Optional |
 | snippy_tree_wf | **call_shared_variants** | Boolean | Activates the shared variants analysis task | TRUE | Optional |
 | snippy_tree_wf | **core_genome** | Boolean | When "true", workflow generates core genome phylogeny; when "false", whole genome is used | TRUE | Optional |
 | snippy_tree_wf | **data_summary_column_names** | String | A comma-separated list of the column names from the sample-level data table for generating a data summary (presence/absence .csv matrix) |  | Optional |

--- a/workflows/phylogenetics/wf_snippy_streamline.wdl
+++ b/workflows/phylogenetics/wf_snippy_streamline.wdl
@@ -26,7 +26,7 @@ workflow snippy_streamline {
         assembly_fasta = select_first([assembly_fasta])
     }
     if (! use_centroid_as_reference) {
-    call referenceseeker_task.referenceseeker {
+      call referenceseeker_task.referenceseeker {
         input:
           assembly_fasta = centroid.centroid_genome_fasta,
           samplename = centroid.centroid_genome_samplename

--- a/workflows/phylogenetics/wf_snippy_streamline.wdl
+++ b/workflows/phylogenetics/wf_snippy_streamline.wdl
@@ -16,6 +16,7 @@ workflow snippy_streamline {
     String tree_name
     # this input file can be a FASTA or GBK
     File? reference_genome_file
+    Boolean use_centroid_as_reference = false
   }
   String tree_name_updated = sub(tree_name, " ", "_")
   # if user does not provide reference genome fasta, determine one for the user by running centroid, referenceseeker, and ncbi datasets to acquire one
@@ -24,14 +25,16 @@ workflow snippy_streamline {
       input:
         assembly_fasta = select_first([assembly_fasta])
     }
+    if (! use_centroid_as_reference) {
     call referenceseeker_task.referenceseeker {
-      input:
-        assembly_fasta = centroid.centroid_genome_fasta,
-        samplename = centroid.centroid_genome_samplename
-    }
-    call ncbi_datasets_task.ncbi_datasets_download_genome_accession {
-      input:
-        ncbi_accession = referenceseeker.referenceseeker_top_hit_ncbi_accession
+        input:
+          assembly_fasta = centroid.centroid_genome_fasta,
+          samplename = centroid.centroid_genome_samplename
+      }
+      call ncbi_datasets_task.ncbi_datasets_download_genome_accession {
+        input:
+          ncbi_accession = referenceseeker.referenceseeker_top_hit_ncbi_accession
+      }
     }
   }
   # see https://github.com/openwdl/wdl/issues/279 for syntax explanation
@@ -41,7 +44,7 @@ workflow snippy_streamline {
       input:
         read1 = triplet.left.left, # access the left-most object (read 1)
         read2 = triplet.left.right, # access the right-side object on the left (read 2)
-        reference_genome_file = select_first([reference_genome_file, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta]),
+        reference_genome_file = select_first([reference_genome_file, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta, centroid.centroid_genome_fasta]),
         samplename = triplet.right # access the right-most object (samplename)
     }
   }
@@ -50,7 +53,7 @@ workflow snippy_streamline {
       tree_name = tree_name_updated,
       snippy_variants_outdir_tarball = snippy_variants_wf.snippy_variants_outdir_tarball,
       samplenames = samplenames,
-      reference_genome_file = select_first([reference_genome_file, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta]),
+      reference_genome_file = select_first([reference_genome_file, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta, centroid.centroid_genome_fasta]),
       snippy_variants_qc_metrics = snippy_variants_wf.snippy_variants_qc_metrics
   }
   call versioning.version_capture {
@@ -95,7 +98,7 @@ workflow snippy_streamline {
     String snippy_iqtree2_model_used = snippy_tree_wf.snippy_iqtree2_model_used
     File snippy_final_alignment = snippy_tree_wf.snippy_final_alignment
     File snippy_final_tree = snippy_tree_wf.snippy_final_tree
-    File snippy_ref = select_first([snippy_tree_wf.snippy_ref, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta])
+    File snippy_ref = select_first([snippy_tree_wf.snippy_ref, ncbi_datasets_download_genome_accession.ncbi_datasets_gbff, ncbi_datasets_download_genome_accession.ncbi_datasets_assembly_fasta, centroid.centroid_genome_fasta])
     File snippy_msa_snps_summary = snippy_tree_wf.snippy_msa_snps_summary
     String? snippy_snp_sites_version = snippy_tree_wf.snippy_snp_sites_version
     String? snippy_snp_sites_docker = snippy_tree_wf.snippy_snp_sites_docker


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #773 

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR adds the `use_centroid_as_reference` boolean variable that will indicate the genome identified as the centroid should be used as the reference genome in snippy_streamline and snippy_streamline_fasta.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

- snippy_streamline
- snippy_streamline_fasta

This PR may lead to different results in pre-existing outputs: **Yes**, if boolean option turned on

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

If `use_centroid_as_reference` is true AND a reference genome has NOT been supplied, centroid WILL run but NCBI datasets will NOT be queried and a reference assembly will NOT be downloaded. Through select_first, the centroid genome will be passed to snippy_variants and snippy_tree and will be output as appropriate

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

- `Boolean use_centroid_as_reference = false`

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

If snippy_tree doesn't return the used reference (very unlikely), it'll output the centroid assembly for the `snippy_ref` variable.

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

- [Snippy_Streamline_FASTA here](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/508312b7-5722-4ce7-b1f2-cac0367db591) showed the centroid genome was being passed along and it appears in the output file
- [Snippy_Streamline here](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/7802f692-d2e3-43c8-b413-428b0ef0373f) shows same thing
### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated
