### PR TITLE
Handle edge case of extremely low coverage

### DIFF
--- a/tasks/species_typing/mycobacterium/task_tbp_parser.wdl
+++ b/tasks/species_typing/mycobacterium/task_tbp_parser.wdl
@@ -70,7 +70,7 @@ task tbp_parser {
     python3 -c "print ( ($genome / 4411532 ) * 100 )" | tee GENOME_PC
 
     # get genome average depth
-    samtools depth -J ~{tbprofiler_bam} | awk -F "\t" '{sum+=$3} END { print sum/NR }' | tee AVG_DEPTH
+    samtools depth -J ~{tbprofiler_bam} | awk -F "\t" '{sum+=$3} END { if (NR > 0) print sum/NR; else print 0 }' | tee AVG_DEPTH
 
     # add sample id to the beginning of the coverage report
     awk '{s=(NR==1)?"Sample_accession_number,":"~{samplename},"; $0=s$0}1' ~{samplename}.percent_gene_coverage.csv > tmp.csv && mv -f tmp.csv ~{samplename}.percent_gene_coverage.csv


### PR DESCRIPTION
## :brain: Summary
It is possible for `samtools depth -J` to output nothing when working with an extremely low coverage BAM file. This is less-than-ideal when this null output is piped to `awk`.

In the TBProfiler parser, $GENOME_PC is not directly affected because it pipes to `wc -l`, but $AVG_DEPTH uses a different approach, resulting in null output. Once the WDL task tries to outputs, it errors, because it cannot interpret an empty file's contents as Float. 

This PR fixes the issue, allowing WDL output delocalization to occur properly.

## :zap: Impacted Workflows/Tasks
Only directly affects task_tbp_parser.wdl.

This PR may lead to different results in pre-existing outputs: **Yes, but in a good way**

This PR uses an element that could cause duplicate runs to have different results: **No**

## :hammer_and_wrench: Changes
This changes $AVG_DEPTH's awk command so it won't try to divide by zero.

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
No changes

### ⬅️ Outputs
Average depth output effectively has a fallback of 0 instead of [GCP_hard_drive_spinning_down.mp3]

## :test_tube: Testing
1. Found a TBCalNet BAM file that causes the issue in the context of TBD/myco_raw
2. Confirmed the issue is `samtools depth -J` giving null output
3. Modified the awk command
4. Tested locally to confirm the modified string will indeed `tee` a file with 0 instead of an empty file

### Suggested Scenarios for Reviewer to Test
BAM files with:
* Garbage coverage (<1x)
* Very poor coverage (~2x)
* Normal coverage (10x < n < 100x)

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for every entry in the three `workflows_overview` tables to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
