### PR TITLE
[TheiaEuk_Illumina_PE] Add theiaeuk to kraken2 conditional and workflow series to read_QC_trim call

### DIFF
--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -81,7 +81,8 @@ workflow theiaeuk_illumina_pe {
         read2 = select_first([rasusa_task.read2_subsampled, read2]),
         trim_min_length = trim_min_length,
         trim_quality_min_score = trim_quality_min_score,
-        trim_window_size = trim_window_size
+        trim_window_size = trim_window_size,
+        workflow_series = "theiaeuk"
     }
     if (! skip_screen) {
       call screen.check_reads as clean_check_reads {

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -251,6 +251,11 @@ workflow theiaeuk_illumina_pe {
     Float? r2_mean_readlength_raw = cg_pipeline_raw.r2_mean_readlength
     Float? combined_mean_readlength_raw = cg_pipeline_raw.combined_mean_readlength
     Float? combined_mean_readlength_clean = cg_pipeline_clean.combined_mean_readlength
+    # Read QC - kraken outputs
+    String? kraken2_version = read_QC_trim.kraken_version
+    String? kraken2_report = read_QC_trim.kraken_report
+    String? kraken2_database = read_QC_trim.kraken_database
+    String? kraken_docker = read_QC_trim.kraken_docker
     # Assembly - shovill outputs and Assembly QC
     File? assembly_fasta = shovill_pe.assembly_fasta
     File? contigs_gfa = shovill_pe.contigs_gfa

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -138,7 +138,7 @@ workflow read_QC_trim_pe {
       }
     }
   }
-  if ("~{workflow_series}" == "theiaprok") {
+  if ("~{workflow_series}" == "theiaprok" || "~{workflow_series}" == "theiaeuk") {
     if ((call_kraken) && defined(kraken_db)) {
       call kraken.kraken2_standalone {
         input:


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #822

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Fully enables kraken2 into TheiaEuk_PE as it was unable to be run before, outlined in the linked issue.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
TheiaEuk_Illumina_PE
Read_QC_Trim

This PR may lead to different results in pre-existing outputs: **Yes**
Could add kraken outputs.

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Enable the running of `kraken2standalone` within TheiaEuk_Illumina_PE.
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
Added `theiaeuk` to the conditional that controls the running of `kraken2standalone` within `read_QC_trim` as well as adding the `workflow_series = "theiaeuk"` to the call of `read_QC_trim`.
### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
NA
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
This will add kraken2 outputs when call_kraken and DB are provided.
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
I have run TheiaEuk_Illumina_PE enabling kraken, providing the DB, and checked outputs to make sure kraken2 is running correctly. 
[TheiaEuk_Illumina_PE](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/57af63bc-1da6-4998-b747-8434ec016d29)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [X] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [X] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [X] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [X] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
