### PR TITLE
[STXtyper] Update to container version 1.0.42

### DIFF
--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -1031,7 +1031,7 @@ merlin_magic	staphopia_sccmec_docker_image	String	Internal component, do not mod
 merlin_magic	staphopia_sccmec_docker_image	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/biocontainers/staphopia-sccmec:1.0.0--hdfd78af_0	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
 merlin_magic	stxtyper_cpu	Int	Number of CPUs to allocate to the task	1	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
 merlin_magic	stxtyper_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
-merlin_magic	stxtyper_docker_image	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.24	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
+merlin_magic	stxtyper_docker_image	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.42	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
 merlin_magic	stxtyper_enable_debug	Boolean	When enabled, additional messages are printed and files in $TMPDIR are not removed after running	FALSE	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
 merlin_magic	stxtyper_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	4	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	
 merlin_magic	tbp_parser_add_cs_lims	Boolean	Set to true add cycloserine results to the LIMS report	FALSE	Optional	TheiaProk_FASTA, TheiaProk_ONT, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE	

--- a/docs/common_text/stxtyper_task.md
+++ b/docs/common_text/stxtyper_task.md
@@ -1,0 +1,23 @@
+??? task "`StxTyper`: Identification and typing of Shiga toxin (Stx) genes ==_using the assembly file as input_=="
+
+        StxTyper screens bacterial genome assemblies for shiga toxin genes and subtypes them into known subtypes and also looks for novel subtypes in cases where the detected sequences diverge from the reference sequences.
+        
+        Shiga toxin is the main virulence factor of Shiga-toxin-producing E. coli (STEC), though these genes are also found in Shigella species as well as some other genera more rarely, such as Klebsiella. [Please see this review paper that describes shiga toxins in great detail.](https://doi.org/10.3390/microorganisms12040687)
+
+        !!! tip "Running StxTyper via the TheiaProk workflows"
+            The TheiaProk workflow will automatically run `stxtyper` on all E. coli and Shigella spp. samples, but ==*the user can opt-in to running the tool on any sample by setting the optional input variable `call_stxtyper` to `true` when configuring the workflow.*==
+        
+        Generally, `stxtyper` looks for _stxA_ and _stxB_ subunits that compose a complete operon. The A subunit is longer (in amino acid length) than the B subunit. Stxtyper attempts to detect these, compare them to a database of known sequences, and type them based on amino acid composition.  There typing algorithm and rules defining how to type these genes & operons will be described more completely in a publication that will be available in the future.
+        
+        The `stxtyper_report` output TSV is provided in [this output format.](https://github.com/ncbi/stxtyper/tree/v1.0.24?tab=readme-ov-file#output)
+
+        This tool has been incorporated into v4.0.3 of AMRFinderPlus and runs behind-the-scenes when the user (or in this case, the TheiaProk workflow) provides the `amrfinder --organism Escherichia --plus` options.
+
+        !!! techdetails "StxTyper Technical Details"
+
+            |  | Links |
+            | --- | --- |
+            | Task | [task_stxtyper.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/main/tasks/species_typing/escherichia_shigella/task_stxtyper.wdl) |
+            | Software Source Code | [ncbi/stxtyper GitHub repository](https://github.com/ncbi/stxtyper) |
+            | Software Documentation | [ncbi/stxtyper GitHub repository](https://github.com/ncbi/stxtyper) |
+            | Original Publication(s) | No publication currently available, as this is a new tool. One will be available in the future. |

--- a/docs/workflows/genomic_characterization/theiaprok.md
+++ b/docs/workflows/genomic_characterization/theiaprok.md
@@ -497,29 +497,7 @@ All input reads are processed through "[core tasks](#core-tasks)" in the TheiaPr
 
     **Shigella XDR prediction.** Please see the documentation section above for ResFinder for details regarding this taxa-specific analysis. 
 
-    ??? task "`StxTyper`: Identification and typing of Shiga toxin (Stx) genes ==_using the assembly file as input_=="
-        
-        StxTyper screens bacterial genome assemblies for shiga toxin genes and subtypes them into known subtypes and also looks for novel subtypes in cases where the detected sequences diverge from the reference sequences.
-        
-        Shiga toxin is the main virulence factor of Shiga-toxin-producing E. coli (STEC), though these genes are also found in Shigella species as well as some other genera more rarely, such as Klebsiella. [Please see this review paper that describes shiga toxins in great detail.](https://doi.org/10.3390/microorganisms12040687)
-
-        !!! tip "Running StxTyper via the TheiaProk workflows"
-            The TheiaProk workflow will automatically run `stxtyper` on all E. coli and Shigella spp. samples, but ==*the user can opt-in to running the tool on any sample by setting the optional input variable `call_stxtyper` to `true` when configuring the workflow.*==
-        
-        Generally, `stxtyper` looks for _stxA_ and _stxB_ subunits that compose a complete operon. The A subunit is longer (in amino acid length) than the B subunit. Stxtyper attempts to detect these, compare them to a database of known sequences, and type them based on amino acid composition.  There typing algorithm and rules defining how to type these genes & operons will be described more completely in a publication that will be available in the future.
-        
-        The `stxtyper_report` output TSV is provided in [this output format.](https://github.com/ncbi/stxtyper/tree/v1.0.24?tab=readme-ov-file#output)
-
-        This tool has been incorporated into v4.0.3 of AMRFinderPlus and runs behind-the-scenes when the user (or in this case, the TheiaProk workflow) provides the `amrfinder --organism Escherichia --plus` options.
-
-        !!! techdetails "StxTyper Technical Details"
-
-            |  | Links |
-            | --- | --- |
-            | Task | [task_stxtyper.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/main/tasks/species_typing/escherichia_shigella/task_stxtyper.wdl) |
-            | Software Source Code | [ncbi/stxtyper GitHub repository](https://github.com/ncbi/stxtyper) |
-            | Software Documentation | [ncbi/stxtyper GitHub repository](https://github.com/ncbi/stxtyper) |
-            | Original Publication(s) | No publication currently available, as this is a new tool. One will be available in the future. |
+    {{ include_md("common_text/stxtyper_task.md") }}
 
 ??? toggle "_Haemophilus influenzae_"
     ##### _Haemophilus influenzae_ {% raw %} {#haemophilus-influenzae} {% endraw %}

--- a/tasks/species_typing/escherichia_shigella/task_stxtyper.wdl
+++ b/tasks/species_typing/escherichia_shigella/task_stxtyper.wdl
@@ -5,7 +5,7 @@ task stxtyper {
     File assembly
     String samplename
     Boolean enable_debugging = false # Additional messages are printed and files in $TMPDIR are not removed after running
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.40"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.42"
     Int disk_size = 50
     Int cpu = 1
     Int memory = 4


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #817 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Updates Docker container of STXtyper to v 1.0.42 from 1.0.24.
## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
TheiaProk Series

This PR may lead to different results in pre-existing outputs: **Yes**
It may, per the release notes of STXtyper there are improvements to result differentiation.

"This version is a minor improvement to the differentiation between PARTIAL, PARTIAL_END_OF_CONTIG, and COMPLETE_NOVEL. These changes will not affect the type symbol returned and thus will have no effect on operons that are 'COMPLETE'."

[Release Page](https://github.com/ncbi/stxtyper/releases/tag/v1.0.42)

This PR uses an element that could cause duplicate runs to have different results: **Yes**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->
Per above, this could lead to differences in PARTIAL results within STXtyper.

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Bumped container version to v1.0.42.

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
`String docker = "us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.40"` -> `String docker = "us-docker.pkg.dev/general-theiagen/staphb/stxtyper:1.0.42"`
### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
NA
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
NA
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->
Ran TheiaProk Suite tools with `call_stxtyper `set to `true `in order to fully test all organisms. 

[FASTA](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/6eee1b80-5ff9-4937-8e92-9b057da85598)
[Illumina_PE](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/5771910c-8e86-418b-99c7-b7e24734885e)
[Illumina_SE](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/c0213315-2346-45c0-ac4b-4e745afbd3ca)
[ONT](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/708f569c-9b56-4605-a53c-c92a825568e7)

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->
Run using other E. coli and Shigella organisms through TheiaProk suite, throw in some other organisms with `call_stxtyper `set to `true` to force running. 
## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
