### PR TITLE
[TheiaViral] Prevent selecting single gene references by selecting references with respect to query coverage

### DIFF
--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -1128,7 +1128,7 @@ skani_report	File	Report from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_accession	String	Top accession ID from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_ani	Float	Top ANI score from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_ani_fasta	File	FASTA file of top ANI match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
-skani_top_ref_coverage	Float	Reference coverage of top match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
+skani_top_query_coverage	Float	Query coverage of top match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_score	Float	Top score from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_warning	String	Skani warning message	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_status	String	Status of Skani analysis	TheiaViral_Illumina_PE, TheiaViral_ONT

--- a/docs/common_text/skani_task.md
+++ b/docs/common_text/skani_task.md
@@ -3,9 +3,9 @@
     The `skani` task is used to identify and select the most closely related reference genome to the *de novo* assembly. Skani uses an approximate mapping method without base-level alignment to calculate average nucleotide identity (ANI). It is magnitudes faster than BLAST-based methods and almost as accurate.
 
 <!-- if: theiaviral -->
-    By default, the reference genome is selected from a database of approximately 200,000 complete viral genomes. This database was constructed with the following methodology:
+    By default, the reference genome is selected from a database of approximately 200,000 viral genomes. This database was constructed with the following methodology:
     
-    1. Extracting all [complete NCBI viral genomes](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNuclMetadata/), excluding RefSeq accessions (redundancy), SARS-CoV-2 accessions, and segmented families (Orthomyxoviridae, Hantaviridae, Arenaviridae, and Phenuiviridae)
+    1. Extracting all [complete NCBI viral genomes](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNuclMetadata/), excluding RefSeq accessions (redundancy), SARS-CoV-2 accessions, and segmented families (Orthomyxoviridae, Hantaviridae, Arenaviridae, and Phenuiviridae). Some complete gene accessions, and not complete genomes, are included because NCBI `datasets` completeness parameters are susceptible to metadata errors.
     
     2. Adding complete RefSeq segmented viral assembly accessions, which represent segments as individual contigs within the FASTA
 

--- a/docs/workflows/genomic_characterization/theiaviral.md
+++ b/docs/workflows/genomic_characterization/theiaviral.md
@@ -6,7 +6,7 @@
 
 ## TheiaViral Workflows
 
-**TheiaViral** workflows assemble, quality assess, and characterize viral genomes from diverse data sources, including metagenomic samples. TheiaViral workflows can generate consensus assemblies of recalcitrant viruses, including diverse or recombinant lineages, such as rabies virus and norovirus, through a three-step approach: 1) generating an intermediate *de novo* assembly from taxonomy-filtered reads, 2) selecting the best reference from a database of ~200,000 complete viral genomes using average nucleotide identity, and 3) producing a final consensus assembly through reference-based read mapping and variant calling. Reference genomes can be directly provided to TheiaViral to bypass *de novo* assembly, which enables compatibility with tiled amplicon sequencing data. Targeted viral characterization is currently ongoing and functional for *Lyssavirus rabies*.
+**TheiaViral** workflows assemble, quality assess, and characterize viral genomes from diverse data sources, including metagenomic samples. TheiaViral workflows can generate consensus assemblies of recalcitrant viruses, including diverse or recombinant lineages, such as rabies virus and norovirus, through a three-step approach: 1) generating an intermediate *de novo* assembly from taxonomy-filtered reads, 2) selecting the best reference from a database of ~200,000 viral genomes using average nucleotide identity, and 3) producing a final consensus assembly through reference-based read mapping and variant calling. Reference genomes can be directly provided to TheiaViral to bypass *de novo* assembly, which enables compatibility with tiled amplicon sequencing data. Targeted viral characterization is currently ongoing and functional for *Lyssavirus rabies*.
 
 ???+ question "What are the main differences between the TheiaViral and TheiaCov workflows?"
 
@@ -306,8 +306,8 @@ The TheiaViral workflows automatically activate taxa-specific sub-workflows afte
     <br>
 
     - `skani_top_ani`: The percent average nucleotide identity (ANI) for the top Skani hit is ideally 100% if the sequenced virus is highly similar to a reference genome. However, if the virus is divergent, ANI is not a good indication of assembly quality.
-    - `skani_top_ref_coverage`: The percent reference coverage for the top Skani hit is ideally 100% if the sequenced virus has not undergone significant recombination/structural variation. 
-    - `skani_top_score`: The score for the top Skani hit is the ANI x Reference coverage and is ideally 100% if the sequenced virus is not substantially divergent from the reference dataset.
+    - `skani_top_query_coverage`: The percent query coverage for the top Skani hit is ideally 100% if the sequenced virus has not undergone significant recombination/structural variation. 
+    - `skani_top_score`: The score for the top Skani hit is the ANI x Query (*de novo* assembly) coverage and is ideally 100% if the sequenced virus is not substantially divergent from the reference dataset.
 
 ??? question "How is consensus assembly quality evaluated?"
 

--- a/tasks/taxon_id/task_skani.wdl
+++ b/tasks/taxon_id/task_skani.wdl
@@ -76,16 +76,16 @@ task skani {
 
     # add new column header
     echo "DEBUG: Extracting Skani results"
-    new_header=$(awk 'NR==1 {OFS="\t"; print $0, "ANI_x_Ref_Coverage"}' ~{samplename}_skani_results.tsv)
+    new_header=$(awk 'NR==1 {OFS="\t"; print $0, "ANI_x_Query_Coverage"}' ~{samplename}_skani_results.tsv)
 
     # initialize output files
     echo "N/A" > TOP_ACCESSION
     echo 0 > TOP_ANI
-    echo 0 > TOP_REF_COVERAGE
+    echo 0 > TOP_QUERY_COVERAGE
     echo 0 > TOP_SCORE
 
     # create a new column and sort by the product of ANI (col 3) and Align_fraction_ref (col 4)
-    awk -F'\t' 'NR > 1 {OFS="\t"; new_col = sprintf("%.5f", $3 * $4 / 100); print $0, new_col}' ~{samplename}_skani_results.tsv | \
+    awk -F'\t' 'NR > 1 {OFS="\t"; new_col = sprintf("%.5f", $3 * $5 / 100); print $0, new_col}' ~{samplename}_skani_results.tsv | \
       sort -t$'\t' -k21,21nr | \
       { echo "$new_header"; cat -; } > ~{samplename}_skani_results_sorted.tsv
 
@@ -99,7 +99,7 @@ task skani {
       # get accession number from file name (and version number if it exists)
       echo $top_hit_name | awk -F'[.]' '{print $1 ($2 ~ /^[0-9]+$/ ? "."$2 : "")}' | tee TOP_ACCESSION
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 3 | tee TOP_ANI
-      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 4 | tee TOP_REF_COVERAGE
+      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 4 | tee TOP_QUERY_COVERAGE
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 21 | tee TOP_SCORE
     fi
 
@@ -115,7 +115,7 @@ task skani {
     File skani_report = "~{samplename}_skani_results_sorted.tsv"
     String skani_top_accession = read_string("TOP_ACCESSION")
     Float skani_top_ani = read_float("TOP_ANI")
-    Float skani_top_ref_coverage = read_float("TOP_REF_COVERAGE")
+    Float skani_top_query_coverage = read_float("TOP_QUERY_COVERAGE")
     Float skani_top_score = read_float("TOP_SCORE")
     String skani_database = skani_db
     String skani_warning = read_string("SKANI_WARNING")

--- a/tasks/taxon_id/task_skani.wdl
+++ b/tasks/taxon_id/task_skani.wdl
@@ -99,7 +99,7 @@ task skani {
       # get accession number from file name (and version number if it exists)
       echo $top_hit_name | awk -F'[.]' '{print $1 ($2 ~ /^[0-9]+$/ ? "."$2 : "")}' | tee TOP_ACCESSION
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 3 | tee TOP_ANI
-      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 4 | tee TOP_QUERY_COVERAGE
+      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 5 | tee TOP_QUERY_COVERAGE
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 21 | tee TOP_SCORE
     fi
 

--- a/workflows/theiaviral/wf_theiaviral_illumina_pe.wdl
+++ b/workflows/theiaviral/wf_theiaviral_illumina_pe.wdl
@@ -297,7 +297,7 @@ workflow theiaviral_illumina_pe {
     String? skani_top_accession = skani.skani_top_accession
     Float? skani_top_score = skani.skani_top_score
     Float? skani_top_ani = skani.skani_top_ani
-    Float? skani_top_ref_coverage = skani.skani_top_ref_coverage
+    Float? skani_top_query_coverage = skani.skani_top_query_coverage
     String? skani_warning = skani.skani_warning
     String? skani_status = skani.skani_status
     String? skani_database = skani.skani_database

--- a/workflows/theiaviral/wf_theiaviral_ont.wdl
+++ b/workflows/theiaviral/wf_theiaviral_ont.wdl
@@ -362,7 +362,7 @@ workflow theiaviral_ont {
     String? skani_top_accession = skani.skani_top_accession
     Float? skani_top_score = skani.skani_top_score
     Float? skani_top_ani = skani.skani_top_ani
-    Float? skani_top_ref_coverage = skani.skani_top_ref_coverage
+    Float? skani_top_query_coverage = skani.skani_top_query_coverage
     String? skani_warning = skani.skani_warning
     String? skani_status = skani.skani_status
     String? skani_database = skani.skani_database


### PR DESCRIPTION
## :brain: Summary
Inhibits selection of partial genome/gene references by weighting Skani's score by the coverage of the query *de novo* genome instead of the coverage of the reference sequence, which can be a gene or full genome. This would not be an issue if we could trust that only complete genomes are in the database, but NCBI does not have completely reliable metadata.

## :zap: Impacted Workflows/Tasks
```
task_skani
wf_theiaviral*
```

## :hammer_and_wrench: Changes
skani_score = ANI * top_query_coverage

This means that scores are weighted by how well the reference genome covers the *de novo* query genome, not the other way around. Previously, when it was based on reference coverage, single gene references can have an advantage in score calculation because a partial query can fully cover a gene, while not fully covering a genome. We want full genomes as references for consensus building, so we do not want to bias against partial coverage of a reference.

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

### ⬅️ Outputs
skani_query_coverage

## :test_tube: Testing
- [ ] [full theiaviral rabv dataset](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Konkel_Sandbox/submission_history/1f1d0388-537f-4189-8546-3c7be56c3eef)

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
