### PR TITLE
[TheiaViral] Mask Ambiguous Bases and Consider Reads with Deletions

### DIFF
--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -1128,7 +1128,7 @@ skani_report	File	Report from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_accession	String	Top accession ID from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_ani	Float	Top ANI score from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_ani_fasta	File	FASTA file of top ANI match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
-skani_top_ref_coverage	Float	Reference coverage of top match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
+skani_top_query_coverage	Float	Query coverage of top match from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_top_score	Float	Top score from Skani	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_warning	String	Skani warning message	TheiaViral_Illumina_PE, TheiaViral_ONT
 skani_status	String	Status of Skani analysis	TheiaViral_Illumina_PE, TheiaViral_ONT

--- a/docs/common_text/skani_task.md
+++ b/docs/common_text/skani_task.md
@@ -3,9 +3,9 @@
     The `skani` task is used to identify and select the most closely related reference genome to the *de novo* assembly. Skani uses an approximate mapping method without base-level alignment to calculate average nucleotide identity (ANI). It is magnitudes faster than BLAST-based methods and almost as accurate.
 
 <!-- if: theiaviral -->
-    By default, the reference genome is selected from a database of approximately 200,000 complete viral genomes. This database was constructed with the following methodology:
+    By default, the reference genome is selected from a database of approximately 200,000 viral genomes. This database was constructed with the following methodology:
     
-    1. Extracting all [complete NCBI viral genomes](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNuclMetadata/), excluding RefSeq accessions (redundancy), SARS-CoV-2 accessions, and segmented families (Orthomyxoviridae, Hantaviridae, Arenaviridae, and Phenuiviridae)
+    1. Extracting all [complete NCBI viral genomes](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNuclMetadata/), excluding RefSeq accessions (redundancy), SARS-CoV-2 accessions, and segmented families (Orthomyxoviridae, Hantaviridae, Arenaviridae, and Phenuiviridae). Some complete gene accessions, and not complete genomes, are included because NCBI `datasets` completeness parameters are susceptible to metadata errors.
     
     2. Adding complete RefSeq segmented viral assembly accessions, which represent segments as individual contigs within the FASTA
 

--- a/docs/workflows/genomic_characterization/theiaviral.md
+++ b/docs/workflows/genomic_characterization/theiaviral.md
@@ -6,7 +6,7 @@
 
 ## TheiaViral Workflows
 
-**TheiaViral** workflows assemble, quality assess, and characterize viral genomes from diverse data sources, including metagenomic samples. TheiaViral workflows can generate consensus assemblies of recalcitrant viruses, including diverse or recombinant lineages, such as rabies virus and norovirus, through a three-step approach: 1) generating an intermediate *de novo* assembly from taxonomy-filtered reads, 2) selecting the best reference from a database of ~200,000 complete viral genomes using average nucleotide identity, and 3) producing a final consensus assembly through reference-based read mapping and variant calling. Reference genomes can be directly provided to TheiaViral to bypass *de novo* assembly, which enables compatibility with tiled amplicon sequencing data. Targeted viral characterization is currently ongoing and functional for *Lyssavirus rabies*.
+**TheiaViral** workflows assemble, quality assess, and characterize viral genomes from diverse data sources, including metagenomic samples. TheiaViral workflows can generate consensus assemblies of recalcitrant viruses, including diverse or recombinant lineages, such as rabies virus and norovirus, through a three-step approach: 1) generating an intermediate *de novo* assembly from taxonomy-filtered reads, 2) selecting the best reference from a database of ~200,000 viral genomes using average nucleotide identity, and 3) producing a final consensus assembly through reference-based read mapping and variant calling. Reference genomes can be directly provided to TheiaViral to bypass *de novo* assembly, which enables compatibility with tiled amplicon sequencing data. Targeted viral characterization is currently ongoing and functional for *Lyssavirus rabies*.
 
 ???+ question "What are the main differences between the TheiaViral and TheiaCov workflows?"
 
@@ -306,8 +306,8 @@ The TheiaViral workflows automatically activate taxa-specific sub-workflows afte
     <br>
 
     - `skani_top_ani`: The percent average nucleotide identity (ANI) for the top Skani hit is ideally 100% if the sequenced virus is highly similar to a reference genome. However, if the virus is divergent, ANI is not a good indication of assembly quality.
-    - `skani_top_ref_coverage`: The percent reference coverage for the top Skani hit is ideally 100% if the sequenced virus has not undergone significant recombination/structural variation. 
-    - `skani_top_score`: The score for the top Skani hit is the ANI x Reference coverage and is ideally 100% if the sequenced virus is not substantially divergent from the reference dataset.
+    - `skani_top_query_coverage`: The percent query coverage for the top Skani hit is ideally 100% if the sequenced virus has not undergone significant recombination/structural variation. 
+    - `skani_top_score`: The score for the top Skani hit is the ANI x Query (*de novo* assembly) coverage and is ideally 100% if the sequenced virus is not substantially divergent from the reference dataset.
 
 ??? question "How is consensus assembly quality evaluated?"
 

--- a/tasks/taxon_id/task_skani.wdl
+++ b/tasks/taxon_id/task_skani.wdl
@@ -76,16 +76,16 @@ task skani {
 
     # add new column header
     echo "DEBUG: Extracting Skani results"
-    new_header=$(awk 'NR==1 {OFS="\t"; print $0, "ANI_x_Ref_Coverage"}' ~{samplename}_skani_results.tsv)
+    new_header=$(awk 'NR==1 {OFS="\t"; print $0, "ANI_x_Query_Coverage"}' ~{samplename}_skani_results.tsv)
 
     # initialize output files
     echo "N/A" > TOP_ACCESSION
     echo 0 > TOP_ANI
-    echo 0 > TOP_REF_COVERAGE
+    echo 0 > TOP_QUERY_COVERAGE
     echo 0 > TOP_SCORE
 
     # create a new column and sort by the product of ANI (col 3) and Align_fraction_ref (col 4)
-    awk -F'\t' 'NR > 1 {OFS="\t"; new_col = sprintf("%.5f", $3 * $4 / 100); print $0, new_col}' ~{samplename}_skani_results.tsv | \
+    awk -F'\t' 'NR > 1 {OFS="\t"; new_col = sprintf("%.5f", $3 * $5 / 100); print $0, new_col}' ~{samplename}_skani_results.tsv | \
       sort -t$'\t' -k21,21nr | \
       { echo "$new_header"; cat -; } > ~{samplename}_skani_results_sorted.tsv
 
@@ -99,7 +99,7 @@ task skani {
       # get accession number from file name (and version number if it exists)
       echo $top_hit_name | awk -F'[.]' '{print $1 ($2 ~ /^[0-9]+$/ ? "."$2 : "")}' | tee TOP_ACCESSION
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 3 | tee TOP_ANI
-      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 4 | tee TOP_REF_COVERAGE
+      head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 5 | tee TOP_QUERY_COVERAGE
       head -n 2 ~{samplename}_skani_results_sorted.tsv | tail -n 1 | cut -f 21 | tee TOP_SCORE
     fi
 
@@ -115,7 +115,7 @@ task skani {
     File skani_report = "~{samplename}_skani_results_sorted.tsv"
     String skani_top_accession = read_string("TOP_ACCESSION")
     Float skani_top_ani = read_float("TOP_ANI")
-    Float skani_top_ref_coverage = read_float("TOP_REF_COVERAGE")
+    Float skani_top_query_coverage = read_float("TOP_QUERY_COVERAGE")
     Float skani_top_score = read_float("TOP_SCORE")
     String skani_database = skani_db
     String skani_warning = read_string("SKANI_WARNING")

--- a/tasks/utilities/data_handling/task_parse_mapping.wdl
+++ b/tasks/utilities/data_handling/task_parse_mapping.wdl
@@ -287,7 +287,10 @@ task mask_low_coverage {
 
     # make a temporary reference fasta and make sure the header is ONLY the ">" + reference accession number.
     # bedtools maskfasta requires the header to be the same as the reference name in the bam file
-    awk '{if (/^>/) print $1; else print}' ~{reference_fasta} > mod_reference.fasta
+    awk '{if (/^>/) print $1; else print}' ~{reference_fasta} > mod_header_reference.fasta
+
+    # replace all ambiguous bases (non ATCG) with Ns while ignoring fasta header lines.
+    cat mod_header_reference.fasta | sed '/^[^>]/ s/[^AGTCagtc]/N/g' > mod_reference.fasta
 
     # report depth at all regions of a genome including regions with 0 coverage
     bedtools genomecov -bga -ibam ~{bam} > all_coverage_regions.bed

--- a/tasks/utilities/data_handling/task_parse_mapping.wdl
+++ b/tasks/utilities/data_handling/task_parse_mapping.wdl
@@ -292,8 +292,8 @@ task mask_low_coverage {
     # replace all ambiguous bases (non ATCG) with Ns while ignoring fasta header lines.
     cat mod_header_reference.fasta | sed '/^[^>]/ s/[^AGTCagtc]/N/g' > mod_reference.fasta
 
-    # report depth at all regions of a genome including regions with 0 coverage
-    bedtools genomecov -bga -ibam ~{bam} > all_coverage_regions.bed
+    # report depth at all regions of a genome including regions with 0 coverage. include reads with deletions in coverage depth calculations.
+    bedtools genomecov -bga -ignoreD -ibam ~{bam} > all_coverage_regions.bed
 
     # filter out regions that have a coverage greater than {min_depth}. Only need low coverage regions here.
     awk -v min_depth=~{min_depth} '$4 < min_depth' all_coverage_regions.bed > low_coverage_regions.bed

--- a/workflows/theiaviral/wf_theiaviral_illumina_pe.wdl
+++ b/workflows/theiaviral/wf_theiaviral_illumina_pe.wdl
@@ -297,7 +297,7 @@ workflow theiaviral_illumina_pe {
     String? skani_top_accession = skani.skani_top_accession
     Float? skani_top_score = skani.skani_top_score
     Float? skani_top_ani = skani.skani_top_ani
-    Float? skani_top_ref_coverage = skani.skani_top_ref_coverage
+    Float? skani_top_query_coverage = skani.skani_top_query_coverage
     String? skani_warning = skani.skani_warning
     String? skani_status = skani.skani_status
     String? skani_database = skani.skani_database

--- a/workflows/theiaviral/wf_theiaviral_ont.wdl
+++ b/workflows/theiaviral/wf_theiaviral_ont.wdl
@@ -362,7 +362,7 @@ workflow theiaviral_ont {
     String? skani_top_accession = skani.skani_top_accession
     Float? skani_top_score = skani.skani_top_score
     Float? skani_top_ani = skani.skani_top_ani
-    Float? skani_top_ref_coverage = skani.skani_top_ref_coverage
+    Float? skani_top_query_coverage = skani.skani_top_query_coverage
     String? skani_warning = skani.skani_warning
     String? skani_status = skani.skani_status
     String? skani_database = skani.skani_database


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR addresses two issues, both related to masking low coverage regions in the reference genome prior to consensus generation.

- replace all ambiguous bases with "N"s
- include reads containing deletions when calculating coverage depth

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
- `task_parse_mapping.wdl`
- `wf_theiaviral_ont.wdl`

This PR may lead to different results in pre-existing outputs: **Yes**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

Ambiguous Bases
- Occasionally, reference fastas downloaded from NCBI can include ambiguous bases (e.g., "S") that are not A/C/G/T. During variant calling, Clair3 will interpret these bases as "N"s, which can lead to mismatches when comparing the reference base against the `REF` field in the VCF. To resolve this, we now mask all non-ACGT bases in the reference as "N"s prior to consensus generation.

Reads with Deletions

- The `bedtools genomecov` tool is used to find the read depth at each position aligned to the reference and masks all reference bases below the `min_depth` threshold with "N". By default, `bedtools` excludes reads with deletions (`D`s in the CIGAR string), which can significantly impact ONT data due to its high indel error rate. Because of this, regions with many aligned reads can appear to have a sudden drops in coverage.

- This PR adds the `-ignoreD` option to `bedtools genomecov`, ensuring that reads containing deletions are included in the coverage calculations. This prevents mismatch errors between regions masked due to low depth and variants called by Clair3. This also leads to a more accurate representation of read support across the genome, similar to how [`samtools depth -J`](https://www.htslib.org/doc/samtools-depth.html) behaves in other tasks (e.g., [`tbp_parser`](https://github.com/theiagen/public_health_bioinformatics/blob/main/tasks/species_typing/mycobacterium/task_tbp_parser.wdl)).

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

When calculating coverage, the `-ignoreD` parameter will treat any `D`s in the CIGAR string as being equivalent to M/X/=.
```
        -ignoreD        Ignore local deletions (CIGAR "D" operations) in BAM entries
                        when computing coverage.
```

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

None

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

None

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

## Ambiguous Bases
BEFORE:
Sample: [sample02-hiv](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/submission_history/d062ed61-dc84-4745-9954-b0cda3f70612)
AFTER:
Sample: [sample02-hiv](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/submission_history/9749037d-8305-4687-9fa2-1f91ee9d6674)

## Reads with Deletions
BEFORE:
Sample: [HSV-1_SRR20796393_skipraven](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Konkel_Sandbox/submission_history/f3807891-3d93-40e9-9eed-76e340772d1b)
Error: 
```
bcftools 1.20
DEBUG: Filtering variants with low coverage: 10 and low frequency: 0.6
Left-normalizing indels
REF_MISMATCH	MH999850.1	20	CG	CN
```
File: [`all_coverage_regions.bed`](https://storage.cloud.google.com/fc-ea7c0ec3-9dcb-40a4-9ff1-a14099d23e91/submissions/f3807891-3d93-40e9-9eed-76e340772d1b/theiaviral_ont/e7acfe9b-d959-4d6c-b15d-464f47b343d8/call-mask_low_coverage/all_coverage_regions.bed?authuser=0)
```
MH999850.1	0	1	25
MH999850.1	1	2	29
MH999850.1	2	3	31
MH999850.1	3	4	34
MH999850.1	4	5	39
MH999850.1	5	6	38
MH999850.1	6	7	45
MH999850.1	7	8	47
MH999850.1	8	9	43
MH999850.1	9	11	47
MH999850.1	11	12	48
MH999850.1	12	15	51
MH999850.1	15	16	49
MH999850.1	16	17	48
MH999850.1	17	20	50
MH999850.1	20	21	6              <-------------------------
MH999850.1	21	22	48
MH999850.1	22	23	50
MH999850.1	23	25	53
MH999850.1	25	26	39
MH999850.1	26	30	66
MH999850.1	30	31	65
```
AFTER with `-ignoreD`:
Sample: [HSV-1_SRR20796393_skipraven](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Theron_Sandbox/submission_history/e7a754c4-0ed8-44d7-8d2b-727700036003)
File: [`all_coverage_regions.bed`](https://storage.cloud.google.com/fc-3a278075-fad0-4d87-aa3d-ae3556328c87/submissions/e7a754c4-0ed8-44d7-8d2b-727700036003/theiaviral_ont/8797e508-d129-421d-96c7-854fc0182285/call-mask_low_coverage/all_coverage_regions.bed?authuser=0)
```
MH999850.1	0	1	25
MH999850.1	1	2	29
MH999850.1	2	3	31
MH999850.1	3	4	34
MH999850.1	4	6	39
MH999850.1	6	7	45
MH999850.1	7	11	47
MH999850.1	11	12	48
MH999850.1	12	21	51
MH999850.1	21	22	54
MH999850.1	22	26	56
MH999850.1	26	34	66
MH999850.1	34	35	67
MH999850.1	35	72	68
MH999850.1	72	209	69
MH999850.1	209	210	72
MH999850.1	210	211	84
MH999850.1	211	212	95
```

## Sanity check with `samtools depth -a -J` on same bam used above
`samtools depth -a HSV-1_SRR20796393_skipraven.sorted.bam | head -n 1000`
```
MH999850.1	1	25
MH999850.1	2	29
MH999850.1	3	31
MH999850.1	4	34
MH999850.1	5	39
MH999850.1	6	38
MH999850.1	7	45
MH999850.1	8	47
MH999850.1	9	43
MH999850.1	10	47
MH999850.1	11	47
MH999850.1	12	48
MH999850.1	13	51
MH999850.1	14	51
MH999850.1	15	51
MH999850.1	16	49
MH999850.1	17	48
MH999850.1	18	50
MH999850.1	19	50
MH999850.1	20	50
MH999850.1	21	6      <------------
MH999850.1	22	48
MH999850.1	23	50
```

`samtools depth -a -J HSV-1_SRR20796393_skipraven.sorted.bam | head -n 1000`
```
MH999850.1	1	25
MH999850.1	2	29
MH999850.1	3	31
MH999850.1	4	34
MH999850.1	5	39
MH999850.1	6	39
MH999850.1	7	45
MH999850.1	8	47
MH999850.1	9	47
MH999850.1	10	47
MH999850.1	11	47
MH999850.1	12	48
MH999850.1	13	51
MH999850.1	14	51
MH999850.1	15	51
MH999850.1	16	51
MH999850.1	17	51
MH999850.1	18	51
MH999850.1	19	51
MH999850.1	20	51
MH999850.1	21	51
MH999850.1	22	54
MH999850.1	23	56
```

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
