### PR TITLE
[TS_MLST] Unbound variable fix when Phoenix container used

### DIFF
--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -7,7 +7,7 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-12-31"
+    String docker = "quay.io/jvhagey/mlst@sha256:e24cec23ab7300dbb5daf4f4ccd1e4aef9d3befcedae8a14c156cba0bbd952b1"
     Int disk_size = 50
     Int cpu = 1
     Int memory = 2
@@ -113,10 +113,10 @@ task ts_mlst {
 
             cat ~{samplename}_1.tsv ~{samplename}_2.tsv >> ~{samplename}_ts_mlst.tsv
             # Check for the presence of novel alleles for the secondary scheme, concatentation will fail if both dont exist
-            if [[ -f "~{samplename}_novel_mlst_alleles_${secondary_scheme}.fasta" && -f "~{samplename}_novel_mlst_alleles.fasta" ]]; then
-              cat ~{samplename}_novel_mlst_alleles_${secondary_scheme}.fasta ~{samplename}_novel_mlst_alleles.fasta > ~{samplename}_novel_mlst_alleles.fasta
-            elif [[ -f "~{samplename}_novel_mlst_alleles_${secondary_scheme}.fasta" ]]; then
-              mv ~{samplename}_novel_mlst_alleles_${secondary_scheme}.fasta ~{samplename}_novel_mlst_alleles.fasta
+            if [[ -f "~{samplename}_novel_mlst_alleles_2.fasta" && -f "~{samplename}_novel_mlst_alleles.fasta" ]]; then
+              cat ~{samplename}_novel_mlst_alleles_2.fasta ~{samplename}_novel_mlst_alleles.fasta > ~{samplename}_novel_mlst_alleles.fasta
+            elif [[ -f "~{samplename}_novel_mlst_alleles_2.fasta" ]]; then
+              mv ~{samplename}_novel_mlst_alleles_2.fasta ~{samplename}_novel_mlst_alleles.fasta
             else
               echo "No novel alleles found for concatenation"
             fi


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
No issue related

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
Fixes a bug in `ts_mlst` that occurs when using the Phoenix MLST docker container. 

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->
`ts_mlst`
TheiaProk Suite

This PR may lead to different results in pre-existing outputs: **Yes**

This PR uses an element that could cause duplicate runs to have different results: **Yes**
For runs that used affected Phoenix container.

<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->
Removed the utilization of a variable in an if statement where it would never have been declared, causing an unbound variable error. 
### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->
Since this variable would never be declared when the if statement in question is triggered, `${secondary_scheme}, it was swapped to `2` since the affected if statement will always run ts_mlst with hardcoded `~{samplename}_novel_mlst_alleles_2.fasta`

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
