### PR TITLE
[Documentation] Fix formatting in TheiaValidate and link typo in digger_denovo

### DIFF
--- a/docs/common_text/digger_denovo_task.md
+++ b/docs/common_text/digger_denovo_task.md
@@ -10,4 +10,4 @@
     !!! techdetails "Digger-Denovo Technical Details"
         |  | Links |
         | --- | --- |
-        | SubWorkflow File | [wf_digger_denovo.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/main/workflows/utilities/wf_digger_denovo.wd) |
+        | SubWorkflow File | [wf_digger_denovo.wdl](https://github.com/theiagen/public_health_bioinformatics/blob/main/workflows/utilities/wf_digger_denovo.wdl) |

--- a/docs/workflows/standalone/theiavalidate.md
+++ b/docs/workflows/standalone/theiavalidate.md
@@ -34,9 +34,9 @@ If additional validation metrics are desired, the user has the ability to provid
 - **IGNORE** does not check the values and says there are 0 failures
 - **SET** checks list items (such as `amrfinder_plus_genes` which is a comma-delimited list of genes) for identical content — order does not matter; that is, `mdsA,mdsB` is determined to be same as `mdsB,mdsA`. The EXACT match does not consider these to be the same, but the SET match does.
 - **<PERCENT_DIFF\>**, which is an actual decimal value such as **0.02**, calculates the percent difference between _numerical_ columns. If the columns are not numerical, this function will **not** work and will lead to workflow failure. For example, if the decimal percentage is 0.02, the test will indicate a failure if the values in the two columns are more than 2% different.
-- Dates, integers, and object-type values are ignored and indicate 0 failures.
-- **<RANGE>**, which is an actual integer value such as **10**, calculates the numerical difference between _numerical_ columns. If the columns are not numerical, this function will **not** work and will lead to workflow failure. For example, if the range is 10, the test will indicate a failure if the values in the two columns are more than 10 apart (units ignored).
+- **<RANGE\>**, which is an actual integer value such as **10**, calculates the numerical difference between _numerical_ columns. If the columns are not numerical, this function will **not** work and will lead to workflow failure. For example, if the range is 10, the test will indicate a failure if the values in the two columns are more than 10 apart (units ignored).
 - **CRITERIA1,CRITERIA2,...** checks the values for the two columns with CRITERIA1 (which must be one of the above) and _then_ with CRITERIA2, etc.; values will pass if at least one criteria is met; the separate criteria **must** be comma-delimited.
+- Dates and object-type values are ignored and indicate 0 failures.
 
 ### File Comparisons
 


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our DOCUMENTATION style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/doc_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->

<!-- Delete the < > around "NOT" if your branch should be retained after merging -->
🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
 - [Digger denovo](https://theiagen.github.io/public_health_bioinformatics/latest/common_text/digger_denovo_task) 
   -  The link to wf_digger_denovo.wdl was serving 404 due to a missing "l" in ".wdl" 
 - [TheiaValidate](https://theiagen.github.io/public_health_bioinformatics/latest/workflows/standalone/theiavalidate/)
   - **<RANGE\>** was absent due to a missing backslash in formatting
   - Exclusion criteria was living in the past 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] I have checked my updates for any errors or typos.
- [x] I have checked my updates for any rending issues. If not, please explain why or request help below.
- [x] My updates follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changes have been confirmed to be accurate
- [ ] You have verified all changes render correctly in the documnentation by serving it locally.
- [ ] The changes adhere to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
- [ ] The PR author has addressed all comments
