### PR TITLE
Propose specifying `disk` and `disks`

### DIFF
--- a/docs/contributing/code_contribution.md
+++ b/docs/contributing/code_contribution.md
@@ -207,6 +207,7 @@ task example_task {
 ### The `runtime` block
 
 - The runtime block defines the compute resources and environment for the task.
+- Cromwell uses `disk` for [TES](https://cromwell.readthedocs.io/en/stable/backends/TES/) and `disks` for GCP backends; consider setting both
 - Always specify a Docker:
 
     ```bash
@@ -214,7 +215,8 @@ task example_task {
       docker: docker
       cpu: cpu
       memory: memory
-      disk: disk_size
+      disks: "local-disk " + disk_size + " SSD"
+      disk: disk_size + " GB"
     }
     ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our DOCUMENTATION style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/doc_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Delete the < > around "NOT" if your branch should be retained after merging -->
🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
Proposed formalization of including both `disk` and `disks` for Cromwell workflows. Most (all?) workflows seem to do this already, so this is just clarifying what's already being done.

Context: https://cromwell.readthedocs.io/en/stable/backends/TES/#gcp-disks-to-tes-disk-compatibility

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] I have checked my updates for any errors or typos.
- [x] I have checked my updates for any rending issues. If not, please explain why or request help below.
- [x] My updates follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changes have been confirmed to be accurate
- [ ] You have verified all changes render correctly in the documnentation by serving it locally.
- [ ] The changes adhere to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
- [ ] The PR author has addressed all comments
