### PR TITLE
[Basespace_Fetch] Bolstering Grep Functionality 

### DIFF
--- a/tasks/utilities/data_import/task_basespace_cli.wdl
+++ b/tasks/utilities/data_import/task_basespace_cli.wdl
@@ -71,6 +71,7 @@ task fetch_bs {
     echo "Concatenating and renaming FASTQ files to add back underscores in basespace_sample_name"
     # setting a new bash variable to use for renaming during concatenation of FASTQs
     for elm in ./dataset_${dataset_id}/*.fastq.gz; do
+      echo "Checking Basespace file: $elm"
       if [[ $(echo "$elm" | cut -d '/' -f 3) =~ [-] && $sample_identifier =~ [_] ]]; then
         echo "Basespace sample name for $(echo "$elm" | cut -d '/' -f 3) contains dashes, input sample identifier $sample_identifier contains underscores, renaming identifier..."
         SAMPLENAME_RENAMED=$(echo $sample_identifier | sed 's|_|-|g' | sed 's|\.|-|g')
@@ -81,6 +82,10 @@ task fetch_bs {
       fi
       if [[ ($(echo "$elm" | cut -d '/' -f 3) =~ [_] && $sample_identifier =~ [_]) || ($(echo "$elm" | cut -d '/' -f 3) =~ [-] && $sample_identifier =~ [-]) ]]; then
         echo "Both Basespace sample name and input sample identifier for $(echo "$elm" | cut -d '/' -f 3) contain matching separators..."
+        SAMPLENAME_RENAMED=$sample_identifier
+      fi
+      if [[ ! ($(echo "$elm" | cut -d '/' -f 3) =~ [_]) || ! ($(echo "$elm" | cut -d '/' -f 3) =~ [-]) ]]; then
+        echo "Filename doesn't use underscore or hyphen separators, using input sample identifier as-is"
         SAMPLENAME_RENAMED=$sample_identifier
       fi
     done


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
No PR Associated

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

Basespace_Fetch
task_basespace_cli

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

Additional functionality has been added to the usage of grep using `-E` and regex. This was needed because of an issue encountered with "Blank_1" samples were run through Basespace_Fetch, grep would pull other samples such as "Blank_11" or "Blank_12" causing more samples than needed to be pulled. The addition of the regex statement with the grep function only returns lines that contain the sample name requested followed by "_" or whitespace. This ensures that only the requested sample is pulled. 

Additionally during testing a shortcoming was found when input sample names don't contain any separators. This was addressed by adding an additional conditional to handle this case. 

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->
NA
### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->
NA
## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

Testing for retained functionality and application of desired changes performed.

Terra Testing:
[Test 1](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/0f6ff662-f0da-4121-9a19-b596931da785)
[Test 2](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/5940def3-170c-4bed-b864-2349907ffa89) 
Failures on Test 2 seem to be due to samples lacking data in Basespace. 

Local Testing:
<details>
<summary>Main functionality; multiple samples downloaded:</summary>

```
dataset download: bs --api-server=https://api.basespace.illumina.com --access-token=
download dataset -i ds.-o . --retry
downloaded data: 
 ./dataset_ds./Blank_11Sep2025_18_L1_ds..json
./dataset_ds./Blank_11Sep2025_18_S89_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_18_S89_L001_R2_001.fastq.gz
dataset download: bs --api-server=https://api.basespace.illumina.com --access-token=
download dataset -i ds.-o . --retry
downloaded data: 
 ./dataset_ds./Blank_11Sep2025_18_L1_ds..json
./dataset_ds./Blank_11Sep2025_18_S89_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_18_S89_L001_R2_001.fastq.gz
./dataset_ds./Blank_11Sep2025_14_L1_ds..json
./dataset_ds./Blank_11Sep2025_14_S85_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_14_S85_L001_R2_001.fastq.gz
dataset download: bs --api-server=https://api.basespace.illumina.com --access-token=
download dataset -i ds.-o . --retry
downloaded data: 
 ./dataset_ds./Blank_11Sep2025_18_L1_ds..json
./dataset_ds./Blank_11Sep2025_18_S89_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_18_S89_L001_R2_001.fastq.gz
./dataset_ds./Blank_11Sep2025_17_L1_ds..json
./dataset_ds./Blank_11Sep2025_17_S88_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_17_S88_L001_R2_001.fastq.gz
./dataset_ds./Blank_11Sep2025_14_L1_ds..json
./dataset_ds./Blank_11Sep2025_14_S85_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_14_S85_L001_R2_001.fastq.gz
dataset download: bs --api-server=https://api.basespace.illumina.com --access-token=
download dataset -i ds.-o . --retry
downloaded data: 
```

</details>

<details>
<summary>New functionality; addition of `grep -E` with regex:</summary>

```
run_id: *
dataset_id: ds.
dataset download: bs --api-server=https://api.basespace.illumina.com --access-token=
download dataset -i ds -o . --retry
downloaded data: 
 ./dataset_ds./Blank_11Sep2025_1_L1_ds..json
./dataset_ds./Blank_11Sep2025_1_S56_L001_R1_001.fastq.gz
./dataset_ds./Blank_11Sep2025_1_S56_L001_R2_001.fastq.gz
Concatenating and renaming FASTQ files to add back underscores in basespace_sample_name
```

</details>

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

Any other combinations of Basespace inputs.

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
