### PR TITLE
[AMRsearch] Parse Resistance Outputs

### DIFF
--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -40,6 +40,8 @@ aligned_fai	File	Index file for the reference genome	Clair3_Variants_ONT
 alignment_method	String	The method used to generate the alignment	Freyja_FASTQ
 amr_results_csv	File	CSV formatted AMR profile	AMR_Search
 amr_results_pdf	File	PDF formatted AMR profile	AMR_Search
+amr_search_all_resistances	String	All resistances returned by AMRsearch	AMR_Search, TheiaEuk_Illumina_PE, TheiaEuk_ONT, TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT
+amr_search_associated_resistances	String	Resistances paired with their agent returned by AMRsearch	AMR_Search, TheiaEuk_Illumina_PE, TheiaEuk_ONT, TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT
 amr_search_csv	File	CSV formatted AMR profile	TheiaEuk_Illumina_PE, TheiaEuk_ONT, TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT
 amr_search_docker	String	Docker image used to run AMR_Search	AMR_Search, TheiaEuk_Illumina_PE, TheiaEuk_ONT, TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT
 amr_search_results	File	JSON formatted AMR profile including BLAST results	AMR_Search, TheiaEuk_Illumina_PE, TheiaEuk_ONT, TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT

--- a/tasks/gene_typing/drug_resistance/task_amr_search.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amr_search.wdl
@@ -32,11 +32,12 @@ task amr_search {
     # Fix carriage return characters
     sed -i 's/\r$//' "~{samplename}_amr_results.csv"
 
-    # Pull all resistances
-    grep "Resistant" "~{samplename}_amr_results.csv" | awk -F ',' '{print $3}' | tr ';' '\n' | sed 's/ //g' | sort -u | paste -sd ',' -  > RESISTANCES
+    # Pull all resistances and place them into comma separated string similar to AMRFinder
+    awk -F ',' '/Resistant/ {gsub(/; /, "\n", $3); print $3}' "~{samplename}_amr_results.csv" | sort -u | paste -sd ',' -  > RESISTANCES
 
     # Paired resistances with agent
-    grep "Resistant" "~{samplename}_amr_results.csv" | awk -F ',' '{print $1","$3}' | paste -sd ";" - | sed 's/,/: /g' | sed 's/; /,/g' | sed 's/;/; /g' > ASSOCIATED_RESISTANCES
+    # Place into Agent_1: gene/mutation, gene/mutation; Agent_2: gene/mutation, gene/mutation; format
+    awk -F ',' '/Resistant/ {gsub("; ", ", ", $3); printf "%s: %s; ", $1, $3}' "~{samplename}_amr_results.csv" | sed 's/; $//' > ASSOCIATED_RESISTANCES
 
     if [[ ! -s RESISTANCES || "$(cat RESISTANCES)" == "none" ]]; then
       echo "No resistances reported" > RESISTANCES

--- a/tasks/gene_typing/drug_resistance/task_amr_search.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amr_search.wdl
@@ -36,7 +36,7 @@ task amr_search {
     grep "Resistant" "~{samplename}_amr_results.csv" | awk -F ',' '{print $3}' | tr ';' '\n' | sed 's/ //g' | sort -u | paste -sd ',' -  > RESISTANCES
 
     # Paired resistances with agent
-    grep "Resistant" "~{samplename}_amr_results.csv" | awk -F ',' '{print $1","$3}' | paste -sd "; " - | sed 's/,/: /g' | sed 's/; /,/g' | sed 's/;/; /g' > ASSOCIATED_RESISTANCES
+    grep "Resistant" "~{samplename}_amr_results.csv" | awk -F ',' '{print $1","$3}' | paste -sd ";" - | sed 's/,/: /g' | sed 's/; /,/g' | sed 's/;/; /g' > ASSOCIATED_RESISTANCES
 
     if [[ ! -s RESISTANCES || "$(cat RESISTANCES)" == "none" ]]; then
       echo "No resistances reported" > RESISTANCES

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_pe.yml
@@ -458,7 +458,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
       md5sum: 481f5fbce5aa1abf93acd912797821cc
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
-      md5sum: 68ca5ef61b5b66fcae09ce03b4d7de1a
+      md5sum: e5626b062172e8bff267aa04cdedf5e9
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_pe.wdl
       contains: ["version", "QC", "output"]
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
+++ b/tests/workflows/theiaprok/test_wf_theiaprok_illumina_se.yml
@@ -438,7 +438,7 @@
     - path: miniwdl_run/wdl/tasks/taxon_id/contamination/task_midas.wdl
       md5sum: 481f5fbce5aa1abf93acd912797821cc
     - path: miniwdl_run/wdl/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
-      md5sum: 65d2d61e8a83a5b2b37ae50773ab04af
+      md5sum: 815c06e0ff6c90c172be481684795dda
     - path: miniwdl_run/wdl/workflows/utilities/wf_read_QC_trim_se.wdl
       md5sum: 78ab14f79289f52005faf15693cf3497
     - path: miniwdl_run/workflow.log

--- a/workflows/standalone_modules/wf_amr_search.wdl
+++ b/workflows/standalone_modules/wf_amr_search.wdl
@@ -25,6 +25,8 @@ workflow amr_search_workflow {
     File amr_search_results = amr_search.amr_search_json_output
     File amr_results_csv = amr_search.amr_search_output_csv
     File amr_results_pdf = amr_search.amr_search_output_pdf
+    String amr_search_all_resistances = amr_search.amr_search_all_resistances
+    String amr_search_associated_resistances = amr_search.amr_search_associated_resistances
     String amr_search_docker = amr_search.amr_search_docker_image
     String amr_search_version = amr_search.amr_search_version
 

--- a/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl
@@ -296,6 +296,8 @@ workflow theiaeuk_illumina_pe {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version    
     # Cladetyper Outputs

--- a/workflows/theiaeuk/wf_theiaeuk_ont.wdl
+++ b/workflows/theiaeuk/wf_theiaeuk_ont.wdl
@@ -210,6 +210,8 @@ workflow theiaeuk_ont {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version  
     # Snippy variants outputs

--- a/workflows/theiaprok/wf_theiaprok_fasta.wdl
+++ b/workflows/theiaprok/wf_theiaprok_fasta.wdl
@@ -572,6 +572,8 @@ workflow theiaprok_fasta {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version
     # Resfinder Outputs

--- a/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl
@@ -1000,6 +1000,8 @@ workflow theiaprok_illumina_pe {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version
     # Ecoli Typing

--- a/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
+++ b/workflows/theiaprok/wf_theiaprok_illumina_se.wdl
@@ -846,6 +846,8 @@ workflow theiaprok_illumina_se {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version
     # Resfinder Outputs

--- a/workflows/theiaprok/wf_theiaprok_ont.wdl
+++ b/workflows/theiaprok/wf_theiaprok_ont.wdl
@@ -805,6 +805,8 @@ workflow theiaprok_ont {
     File? amr_search_results = merlin_magic.amr_search_results
     File? amr_search_csv = merlin_magic.amr_results_csv
     File? amr_search_results_pdf = merlin_magic.amr_results_pdf
+    String? amr_search_all_resistances = merlin_magic.amr_search_all_resistances
+    String? amr_search_associated_resistances = merlin_magic.amr_search_associated_resistances
     String? amr_search_docker = merlin_magic.amr_search_docker
     String? amr_search_version = merlin_magic.amr_search_version    
     # Resfinder Outputs

--- a/workflows/utilities/wf_merlin_magic.wdl
+++ b/workflows/utilities/wf_merlin_magic.wdl
@@ -859,6 +859,8 @@ workflow merlin_magic {
     File? amr_search_results = amr_search.amr_search_json_output
     File? amr_results_csv = amr_search.amr_search_output_csv
     File? amr_results_pdf = amr_search.amr_search_output_pdf
+    String? amr_search_all_resistances = amr_search.amr_search_all_resistances
+    String? amr_search_associated_resistances = amr_search.amr_search_associated_resistances
     String? amr_search_docker = amr_search.amr_search_docker_image
     String? amr_search_version = amr_search.amr_search_version
     # Ecoli Typing


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #963 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
This PR adds two new outputs to `amr_search` containing parsed resistances allowing for easier resistance identification. 
## :zap: Impacted Workflows/Tasks

### Workflows
Δ `amr_search_workflow`

Δ `merlin_magic`

Δ `theiaeuk_illumina_pe`

Δ `theiaeuk_ont`

Δ `theiaprok_fasta`

Δ `theiaprok_illumina_pe`

Δ `theiaprok_illumina_se`

Δ `theiaprok_ont`

### Tasks
Δ `amr_search`

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

The resistances are pulled from the `amr_search_output_csv`. All are added to a comma separated string, like AMRFinder reportings, and are returned as `amr_search_all_resistances`. 

A second round of parsing pulls both the agent and the associated resistance genes/mutations and outputs them as a string formatted as such; `Agent_1: gene/mutation_1, gene/mutation_2; Agent_2: etc.`. Due to the amount of organisms and agents available we are unable to have columns specific to each agent. 

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
NA

### ⬅️ Outputs

<details>
<summary>amr_search_workflow +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaprok_fasta +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaprok_illumina_se +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaprok_ont +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaeuk_ont +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>merlin_magic +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaeuk_illumina_pe +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

<details>
<summary>theiaprok_illumina_pe +2 -0</summary>

	+ amr_search_all_resistances
	+ amr_search_associated_resistances

</details>

## :test_tube: Testing
- [x] <details><summary>[amr_search_workflow](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/b65475fe-3f0e-4353-a2b8-f095ad92e4f5)</summary>amr_search, amr_search_workflow</details>
- [x] <details><summary>[theiaeuk_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/5f308f8b-cd95-4b53-963c-746a3f625af1)</summary>amr_search, merlin_magic, theiaeuk_illumina_pe</details>
- [x] <details><summary>[theiaeuk_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/55666639-7e89-4f6d-9827-cfed3d6393b5)</summary>amr_search, merlin_magic, theiaeuk_ont</details>
- [x] <details><summary>[theiaprok_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/d124cdf4-e5dd-468d-bde3-a828c4cc3618)</summary>amr_search, merlin_magic, theiaprok_fasta</details>
- [x] <details><summary>[theiaprok_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/fed007fe-a4ea-47fc-8ea9-a0797aadefd0)</summary>amr_search, merlin_magic, theiaprok_illumina_pe</details>
- [x] <details><summary>[theiaprok_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/a6e2bea1-ad35-4d51-8c98-a536c489746f)</summary>amr_search, merlin_magic, theiaprok_illumina_se</details>
- [x] <details><summary>[theiaprok_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/8c78e0de-b8e2-42e3-9063-f38b88e8561f)</summary>amr_search, merlin_magic, theiaprok_ont</details>

<!-- Please describe how you tested this PR. -->

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)