### PR TITLE
[iVar Version] Include iVar Consensus Version in assembly_method

### DIFF
--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -141,7 +141,7 @@ workflow ivar_consensus {
     String ivar_variant_proportion_intermediate = variant_call.variant_proportion_intermediate
     String ivar_variant_version = variant_call.ivar_version
     # assembly outputs
-    String assembly_method_nonflu = "~{bwa.bwa_version}~{if defined(primer_trim.ivar_version) then '; Primer Trim: ' + select_first([primer_trim.ivar_version]) else ''}; Consensus: ~{consensus.ivar_version}"
+    String assembly_method_nonflu = "~{bwa.bwa_version}~{if defined(primer_trim.ivar_version) then '; Primer Trim: ' + primer_trim.ivar_version else ''}; Consensus: ~{consensus.ivar_version}"
     File assembly_fasta = consensus.consensus_seq
     String ivar_version_consensus = consensus.ivar_version
     String samtools_version_consensus = consensus.samtools_version

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -141,7 +141,7 @@ workflow ivar_consensus {
     String ivar_variant_proportion_intermediate = variant_call.variant_proportion_intermediate
     String ivar_variant_version = variant_call.ivar_version
     # assembly outputs
-    String assembly_method_nonflu = "~{bwa.bwa_version}; ~{select_first(['Primer Trim: ' + primer_trim.ivar_version + '; ' + 'Consensus: ' + consensus.ivar_version, consensus.ivar_version])}"
+    String assembly_method_nonflu = "~{bwa.bwa_version}~{if defined(primer_trim.ivar_version) then '; Primer Trim: ' + select_first([primer_trim.ivar_version]) else ''}; Consensus: ~{consensus.ivar_version}"
     File assembly_fasta = consensus.consensus_seq
     String ivar_version_consensus = consensus.ivar_version
     String samtools_version_consensus = consensus.samtools_version

--- a/workflows/utilities/wf_ivar_consensus.wdl
+++ b/workflows/utilities/wf_ivar_consensus.wdl
@@ -141,7 +141,7 @@ workflow ivar_consensus {
     String ivar_variant_proportion_intermediate = variant_call.variant_proportion_intermediate
     String ivar_variant_version = variant_call.ivar_version
     # assembly outputs
-    String assembly_method_nonflu = "~{bwa.bwa_version}; ~{primer_trim.ivar_version}"
+    String assembly_method_nonflu = "~{bwa.bwa_version}; ~{select_first(['Primer Trim: ' + primer_trim.ivar_version + '; ' + 'Consensus: ' + consensus.ivar_version, consensus.ivar_version])}"
     File assembly_fasta = consensus.consensus_seq
     String ivar_version_consensus = consensus.ivar_version
     String samtools_version_consensus = consensus.samtools_version


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #919 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR updates `assembly_method` output in `wf_ivar_consensus` to include the `ivar_consensus` version. Previously the iVar version for this output was only pulled from the primer_trim task. Being optional, this would not return an iVar version with `trim_primers` was set to false. 

The solution to this was to include both primer trim and consensus versions in the `assembly_method` output. Ideally these versions will be the same version but that is just an assumption so it is better to include both as they are both a part of the assembly. 

## :zap: Impacted Workflows/Tasks

### Workflows
Δ `ivar_consensus`

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

Included a conditional and select_first in the iVar `assembly_method` output that will include the primer trim iVar version when present along side the consensus version or just the consensus version when primer trimming is turned off. 

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs

### ⬅️ Outputs

`assembly_method` has been improved

## :test_tube: Testing
- [x] <details><summary>theiacov_illumina_pe</summary>[`trim_primers` false](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/95d1ef0c-4cca-4b85-ae9b-75d709a7bc5d), [`trim_primers` true](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/163cd19a-7d75-40de-b472-b22444fb0ee0)</details>
- [x] <details><summary>theiacov_illumina_se</summary>[`trim_primers` false](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/0d6f6404-54d9-4b0f-9c66-3327a0a07d13), [`trim_primers` true](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/df7c7ffd-afe0-45b0-be0e-521ae1fee5b1)</details>

<!-- Please describe how you tested this PR. -->

Both workflows were run with `trim_primers` set to true and false and the formats of `assembly_method` from `ivar_consesus` was checked.

With primer trim: "BWA Version: 0.7.17-r1188; Primer Trim: iVar version 1.3.1; Consensus: iVar version 1.3.1"
Without primer trim: "BWA Version: 0.7.17-r1188; Consensus: iVar version 1.3.1"

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)