### PR TITLE
[Snippy_Streamline] Expose snp_dist resource inputs

### DIFF
--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -616,7 +616,7 @@ core_reorder_matrix	outgroup_root	String	Tip name to root phylogenetic tree upon
 core_snp_dists	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 core_snp_dists	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 core_snp_dists	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Core_Gene_SNP, kSNP3, kSNP4	docker	
-core_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
+core_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	4	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 core_snp_sites	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Core_Gene_SNP	runtime	
 core_snp_sites	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Core_Gene_SNP	runtime	
 core_snp_sites	docker	String	Docker image to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-sites:2.5.1	Optional	Core_Gene_SNP	docker	
@@ -1808,7 +1808,7 @@ pan_reorder_matrix	outgroup_root	String	Tip name to root phylogenetic tree upon 
 pan_snp_dists	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 pan_snp_dists	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 pan_snp_dists	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Core_Gene_SNP, kSNP3, kSNP4	docker	
-pan_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
+pan_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	4	Optional	Core_Gene_SNP, kSNP3, kSNP4	runtime	
 pangolin4	analysis_mode	String	Used to switch between usher and pangolearn analysis modes. Only use usher because pangolearn is no longer supported as of Pangolin v4.3 and higher versions.		Optional	Pangolin_Update	general	
 pangolin4	cpu	Int	Number of CPUs to allocate to the task	4	Optional	Pangolin_Update	runtime	
 pangolin4	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Pangolin_Update	runtime	
@@ -2201,10 +2201,6 @@ snippy_streamline	use_centroid_as_reference	Boolean	Set to true if you want to u
 snippy_streamline_fasta	reference_genome_file	File	Reference genome in FASTA or GENBANK format (must be the same reference used in Snippy_Variants workflow); provide this if you want to skip the detection of a suitable reference		Optional	Snippy_Streamline_FASTA	general	
 snippy_streamline_fasta	use_centroid_as_reference	Boolean	Set to true if you want to use the centroid sample as the reference sample instead of using the centroid to detect a suitable one	False	Optional	Snippy_Streamline_FASTA	general	True
 snippy_tree_wf	call_shared_variants	Boolean	When true, workflow generates table that combines variants across all samples and a table showing variants shared across samples	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
-snippy_tree_wf	cg_snp_dists_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
-snippy_tree_wf	cg_snp_dists_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
-snippy_tree_wf	cg_snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
-snippy_tree_wf	cg_snp_dists_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	core_genome	Boolean	When true, workflow generates core genome phylogeny; when false, whole genome is used	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
 snippy_tree_wf	data_summary_column_names	String	A comma-separated list of the column names from the sample-level data table for generating a data summary (presence/absence .csv matrix)		Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
 snippy_tree_wf	data_summary_terra_project	String	The billing project for your current workspace. This can be found after the "#workspaces/" section in the workspace's URL		Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
@@ -2229,15 +2225,15 @@ snippy_tree_wf	snippy_core_disk_size	Int	Amount of storage (in GB) to allocate t
 snippy_tree_wf	snippy_core_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snippy:4.6.0	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
 snippy_tree_wf	snippy_core_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	16	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snippy_variants_qc_metrics	Array[File]	Files produced by the Snippy_Variants workflow used to concatenate the reports for each sample in the tree		Optional	Snippy_Tree	general	
+snippy_tree_wf	snp_dists_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	snp_dists_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
+snippy_tree_wf	snp_dists_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	4	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snp_sites_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snp_sites_disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snp_sites_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-sites:2.5.1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
 snippy_tree_wf	snp_sites_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	use_gubbins	Boolean	When "true", workflow removes recombination with gubbins tasks; when "false", gubbins is not used	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
-snippy_tree_wf	wg_snp_dists_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
-snippy_tree_wf	wg_snp_dists_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
-snippy_tree_wf	wg_snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
-snippy_tree_wf	wg_snp_dists_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_variants	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Snippy_Variants	runtime	
 snippy_variants_wf	assembly_fasta	File	The assembly file for your sample in FASTA format		Optional	Snippy_Streamline, Snippy_Variants	general	
 snippy_variants_wf	base_quality	Int	Minimum quality for a nucleotide to be used in variant calling	13	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Variants	general	
@@ -2257,7 +2253,7 @@ snippy_variants_wf	read2	File	FASTQ file containing read2 sequences		Optional	Sn
 snp_dists	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Augur	runtime	
 snp_dists	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Augur	runtime	
 snp_dists	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Augur	docker	
-snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Augur	runtime	
+snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	4	Optional	Augur	runtime	
 sort_bam_assembly_correction	cpu	Int	Number of CPUs to allocate to the task	2	Optional	TheiaMeta_Illumina_PE	runtime	
 sort_bam_assembly_correction	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	TheiaMeta_Illumina_PE	runtime	
 sort_bam_assembly_correction	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/samtools:1.17	Optional	TheiaMeta_Illumina_PE	docker	

--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -465,9 +465,6 @@ cg_reorder_matrix	disk_size	Int	Amount of storage (in GB) to allocate to the tas
 cg_reorder_matrix	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1	Optional	Snippy_Tree	docker	
 cg_reorder_matrix	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Tree	runtime	
 cg_reorder_matrix	outgroup_root	String	Tip name to root phylogenetic tree upon (overrides midpoint root)		Optional	Snippy_Tree	general	
-cg_snp_dists	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Tree	runtime	
-cg_snp_dists	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Tree	runtime	
-cg_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Tree	runtime	
 checkv_consensus	checkv_db	File	CheckV database file	gs://theiagen-public-resources-rp/reference_data/databases/checkv/checkv-db-v1.5.tar.gz	Optional	TheiaViral_ONT	database	
 checkv_consensus	cpu	Int	Number of CPUs to allocate to the task	2	Optional	TheiaViral_Illumina_PE, TheiaViral_ONT	runtime	
 checkv_consensus	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	TheiaViral_Illumina_PE, TheiaViral_ONT	runtime	
@@ -2204,6 +2201,10 @@ snippy_streamline	use_centroid_as_reference	Boolean	Set to true if you want to u
 snippy_streamline_fasta	reference_genome_file	File	Reference genome in FASTA or GENBANK format (must be the same reference used in Snippy_Variants workflow); provide this if you want to skip the detection of a suitable reference		Optional	Snippy_Streamline_FASTA	general	
 snippy_streamline_fasta	use_centroid_as_reference	Boolean	Set to true if you want to use the centroid sample as the reference sample instead of using the centroid to detect a suitable one	False	Optional	Snippy_Streamline_FASTA	general	True
 snippy_tree_wf	call_shared_variants	Boolean	When true, workflow generates table that combines variants across all samples and a table showing variants shared across samples	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
+snippy_tree_wf	cg_snp_dists_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	cg_snp_dists_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	cg_snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
+snippy_tree_wf	cg_snp_dists_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	core_genome	Boolean	When true, workflow generates core genome phylogeny; when false, whole genome is used	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
 snippy_tree_wf	data_summary_column_names	String	A comma-separated list of the column names from the sample-level data table for generating a data summary (presence/absence .csv matrix)		Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
 snippy_tree_wf	data_summary_terra_project	String	The billing project for your current workspace. This can be found after the "#workspaces/" section in the workspace's URL		Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
@@ -2228,12 +2229,15 @@ snippy_tree_wf	snippy_core_disk_size	Int	Amount of storage (in GB) to allocate t
 snippy_tree_wf	snippy_core_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snippy:4.6.0	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
 snippy_tree_wf	snippy_core_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	16	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snippy_variants_qc_metrics	Array[File]	Files produced by the Snippy_Variants workflow used to concatenate the reports for each sample in the tree		Optional	Snippy_Tree	general	
-snippy_tree_wf	snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
 snippy_tree_wf	snp_sites_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snp_sites_disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	snp_sites_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-sites:2.5.1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
 snippy_tree_wf	snp_sites_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_tree_wf	use_gubbins	Boolean	When "true", workflow removes recombination with gubbins tasks; when "false", gubbins is not used	True	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	general	
+snippy_tree_wf	wg_snp_dists_cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	wg_snp_dists_disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
+snippy_tree_wf	wg_snp_dists_docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	docker	
+snippy_tree_wf	wg_snp_dists_memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Tree	runtime	
 snippy_variants	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Snippy_Variants	runtime	
 snippy_variants_wf	assembly_fasta	File	The assembly file for your sample in FASTA format		Optional	Snippy_Streamline, Snippy_Variants	general	
 snippy_variants_wf	base_quality	Int	Minimum quality for a nucleotide to be used in variant calling	13	Optional	Snippy_Streamline, Snippy_Streamline_FASTA, Snippy_Variants	general	
@@ -2748,9 +2752,6 @@ wg_reorder_matrix	disk_size	Int	Amount of storage (in GB) to allocate to the tas
 wg_reorder_matrix	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/mykrobe:0.12.1	Optional	Snippy_Tree	docker	
 wg_reorder_matrix	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Tree	runtime	
 wg_reorder_matrix	outgroup_root	String	Tip name to root phylogenetic tree upon (overrides midpoint root)		Optional	Snippy_Tree	general	
-wg_snp_dists	cpu	Int	Number of CPUs to allocate to the task	1	Optional	Snippy_Tree	runtime	
-wg_snp_dists	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	Snippy_Tree	runtime	
-wg_snp_dists	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	Snippy_Tree	runtime	
 zip_files	cpu	Int	Number of CPUs to allocate to the task	2	Optional	Zip_Column_Content	runtime	
 zip_files	disk_size	Int	Amount of storage (in GB) to allocate to the task	100	Optional	Zip_Column_Content	runtime	
 zip_files	docker_image	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/theiagen/utility:1.1	Optional	Zip_Column_Content	docker	

--- a/tasks/phylogenetic_inference/utilities/task_snp_dists.wdl
+++ b/tasks/phylogenetic_inference/utilities/task_snp_dists.wdl
@@ -6,7 +6,7 @@ task snp_dists {
     String cluster_name
     Int disk_size = 50
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/snp-dists:0.8.2"
-    Int memory = 2
+    Int memory = 4
     Int cpu = 1
   }
   command <<<

--- a/workflows/phylogenetics/wf_snippy_tree.wdl
+++ b/workflows/phylogenetics/wf_snippy_tree.wdl
@@ -51,15 +51,10 @@ workflow snippy_tree_wf {
     Int? iqtree2_ultrafast_bootstraps
     String? iqtree2_model
     
-    Int? wg_snp_dists_cpu
-    Int? wg_snp_dists_memory
-    Int? wg_snp_dists_disk_size
-    String? wg_snp_dists_docker
-
-    Int? cg_snp_dists_cpu
-    Int? cg_snp_dists_memory
-    Int? cg_snp_dists_disk_size
-    String? cg_snp_dists_docker
+    Int? snp_dists_cpu
+    Int? snp_dists_memory
+    Int? snp_dists_disk_size
+    String? snp_dists_docker
     
     Int? snp_sites_cpu
     Int? snp_sites_disk_size
@@ -138,10 +133,10 @@ workflow snippy_tree_wf {
     input:
       alignment = select_first([gubbins.gubbins_polymorphic_fasta, snippy_core.snippy_full_alignment_clean]),
       cluster_name = tree_name_updated,
-      docker = wg_snp_dists_docker,
-      cpu = wg_snp_dists_cpu,
-      memory = wg_snp_dists_memory,
-      disk_size = wg_snp_dists_disk_size
+      docker = snp_dists_docker,
+      cpu = snp_dists_cpu,
+      memory = snp_dists_memory,
+      disk_size = snp_dists_disk_size
   }
   # mid-point roots the phylogenetic tree, and reorders the columns in the wgSNP matrix according to the tree tip order
   # NB the tree will remain a core genome tree is core_genome = true, and a whole-genome tree if core_genome = false
@@ -159,10 +154,10 @@ workflow snippy_tree_wf {
       input:
         alignment = select_first([snp_sites.snp_sites_multifasta]),
         cluster_name = tree_name_updated,
-        docker = cg_snp_dists_docker,   
-        cpu = cg_snp_dists_cpu,
-        memory = cg_snp_dists_memory,
-        disk_size = cg_snp_dists_disk_size
+        docker = snp_dists_docker,   
+        cpu = snp_dists_cpu,
+        memory = snp_dists_memory,
+        disk_size = snp_dists_disk_size
     }
     # reorders the columns in the cgSNP matrix according to the tree tip order
     # input tree is the midpoint rooted tree from the wg_reorder_matrix task, and midpoint rooting is turned off here, so the tree remains unchanged

--- a/workflows/phylogenetics/wf_snippy_tree.wdl
+++ b/workflows/phylogenetics/wf_snippy_tree.wdl
@@ -51,10 +51,15 @@ workflow snippy_tree_wf {
     Int? iqtree2_ultrafast_bootstraps
     String? iqtree2_model
     
-    Int? snp_dists_cpu
-    Int? snp_dists_memory
-    Int? snp_dists_disk_size
-    String? snp_dists_docker
+    Int? wg_snp_dists_cpu
+    Int? wg_snp_dists_memory
+    Int? wg_snp_dists_disk_size
+    String? wg_snp_dists_docker
+
+    Int? cg_snp_dists_cpu
+    Int? cg_snp_dists_memory
+    Int? cg_snp_dists_disk_size
+    String? cg_snp_dists_docker
     
     Int? snp_sites_cpu
     Int? snp_sites_disk_size
@@ -133,10 +138,10 @@ workflow snippy_tree_wf {
     input:
       alignment = select_first([gubbins.gubbins_polymorphic_fasta, snippy_core.snippy_full_alignment_clean]),
       cluster_name = tree_name_updated,
-      docker = snp_dists_docker,
-      cpu = snp_dists_cpu,
-      memory = snp_dists_memory,
-      disk_size = snp_dists_disk_size
+      docker = wg_snp_dists_docker,
+      cpu = wg_snp_dists_cpu,
+      memory = wg_snp_dists_memory,
+      disk_size = wg_snp_dists_disk_size
   }
   # mid-point roots the phylogenetic tree, and reorders the columns in the wgSNP matrix according to the tree tip order
   # NB the tree will remain a core genome tree is core_genome = true, and a whole-genome tree if core_genome = false
@@ -154,10 +159,10 @@ workflow snippy_tree_wf {
       input:
         alignment = select_first([snp_sites.snp_sites_multifasta]),
         cluster_name = tree_name_updated,
-        docker = snp_dists_docker,   
-        cpu = snp_dists_cpu,
-        memory = snp_dists_memory,
-        disk_size = snp_dists_disk_size
+        docker = cg_snp_dists_docker,   
+        cpu = cg_snp_dists_cpu,
+        memory = cg_snp_dists_memory,
+        disk_size = cg_snp_dists_disk_size
     }
     # reorders the columns in the cgSNP matrix according to the tree tip order
     # input tree is the midpoint rooted tree from the wg_reorder_matrix task, and midpoint rooting is turned off here, so the tree remains unchanged

--- a/workflows/phylogenetics/wf_snippy_tree.wdl
+++ b/workflows/phylogenetics/wf_snippy_tree.wdl
@@ -51,6 +51,9 @@ workflow snippy_tree_wf {
     Int? iqtree2_ultrafast_bootstraps
     String? iqtree2_model
     
+    Int? snp_dists_cpu
+    Int? snp_dists_memory
+    Int? snp_dists_disk_size
     String? snp_dists_docker
     
     Int? snp_sites_cpu
@@ -130,7 +133,10 @@ workflow snippy_tree_wf {
     input:
       alignment = select_first([gubbins.gubbins_polymorphic_fasta, snippy_core.snippy_full_alignment_clean]),
       cluster_name = tree_name_updated,
-      docker = snp_dists_docker
+      docker = snp_dists_docker,
+      cpu = snp_dists_cpu,
+      memory = snp_dists_memory,
+      disk_size = snp_dists_disk_size
   }
   # mid-point roots the phylogenetic tree, and reorders the columns in the wgSNP matrix according to the tree tip order
   # NB the tree will remain a core genome tree is core_genome = true, and a whole-genome tree if core_genome = false
@@ -148,7 +154,10 @@ workflow snippy_tree_wf {
       input:
         alignment = select_first([snp_sites.snp_sites_multifasta]),
         cluster_name = tree_name_updated,
-        docker = snp_dists_docker
+        docker = snp_dists_docker,   
+        cpu = snp_dists_cpu,
+        memory = snp_dists_memory,
+        disk_size = snp_dists_disk_size
     }
     # reorders the columns in the cgSNP matrix according to the tree tip order
     # input tree is the midpoint rooted tree from the wg_reorder_matrix task, and midpoint rooting is turned off here, so the tree remains unchanged


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #765 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR exposes the `snp_dists` resource inputs to the workflow level so that they are able to be modified by the user as running larger datasets require more resources than default. WG and CG `snp_dists` were exposed separately as they are separate tasks even though they both run `snp_dists`. Opted not to change the default as exposing inputs should give users enough ability to adjust as needed. We don't want to overshoot resource allocation. 

## :zap: Impacted Workflows/Tasks

### Workflows
Δ `snippy_tree_wf`

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs

<details>
<summary>snippy_tree_wf +8 -7</summary>

	+ cg_snp_dists_cpu
	+ cg_snp_dists_disk_size
	+ cg_snp_dists_docker
	+ cg_snp_dists_memory
	+ wg_snp_dists_cpu
	+ wg_snp_dists_disk_size
	+ wg_snp_dists_docker
	+ wg_snp_dists_memory
	- cg_snp_dists.cpu
	- cg_snp_dists.disk_size
	- cg_snp_dists.memory
	- snp_dists_docker
	- wg_snp_dists.cpu
	- wg_snp_dists.disk_size
	- wg_snp_dists.memory

</details>

<details>
<summary>snippy_streamline_fasta +8 -1</summary>

	+ snippy_tree_wf.cg_snp_dists_cpu
	+ snippy_tree_wf.cg_snp_dists_disk_size
	+ snippy_tree_wf.cg_snp_dists_docker
	+ snippy_tree_wf.cg_snp_dists_memory
	+ snippy_tree_wf.wg_snp_dists_cpu
	+ snippy_tree_wf.wg_snp_dists_disk_size
	+ snippy_tree_wf.wg_snp_dists_docker
	+ snippy_tree_wf.wg_snp_dists_memory
	- snippy_tree_wf.snp_dists_docker

</details>

<details>
<summary>snippy_streamline +8 -1</summary>

	+ snippy_tree_wf.cg_snp_dists_cpu
	+ snippy_tree_wf.cg_snp_dists_disk_size
	+ snippy_tree_wf.cg_snp_dists_docker
	+ snippy_tree_wf.cg_snp_dists_memory
	+ snippy_tree_wf.wg_snp_dists_cpu
	+ snippy_tree_wf.wg_snp_dists_disk_size
	+ snippy_tree_wf.wg_snp_dists_docker
	+ snippy_tree_wf.wg_snp_dists_memory
	- snippy_tree_wf.snp_dists_docker

</details>

### ⬅️ Outputs


## :test_tube: Testing
- [x] <details><summary>[snippy_streamline](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/647bc90a-1a0c-447e-a862-0c73c74c5482)</summary>snippy_tree_wf</details>
- [x] <details><summary>[snippy_streamline_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/3685eba7-d587-47ef-aa76-8f74745ca302)</summary>snippy_tree_wf</details>
- [x] <details><summary>~~snippy_tree_wf~~</summary>snippy_tree_wf</details>

<!-- Please describe how you tested this PR. -->

Snippy_Streamline and Snippy_Streamline_FASTA were run with values passed to exposed resource inputs for both core and whole genome. Snippy_Tree_WF is run within Snippy_Streamline workflows so it is included in run tests. 

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
