### PR TITLE
[Read Screen] fail gracefully if files are empty

### DIFF
--- a/tasks/quality_control/comparisons/task_screen.wdl
+++ b/tasks/quality_control/comparisons/task_screen.wdl
@@ -38,120 +38,126 @@ task check_reads {
       cat_reads="cat"
     fi
 
-    # check one: number of reads
-    read1_num=$($cat_reads ~{read1} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    read2_num=$($cat_reads ~{read2} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    echo "DEBUG: Number of reads in R1: ${read1_num}"
-    echo "DEBUG: Number of reads in R2: ${read2_num}"
+    if [[ ! -s "~{read1}" || ! -s "~{read2}" ]]; then
+      echo "DEBUG: CAUTION! one of the read files is empty!"
+      fail_log+="; one or both of the read files are empty"
+    else
+      # check one: number of reads
+      read1_num=$($cat_reads ~{read1} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      read2_num=$($cat_reads ~{read2} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      echo "DEBUG: Number of reads in R1: ${read1_num}"
+      echo "DEBUG: Number of reads in R2: ${read2_num}"
 
-    reads_total=$(expr $read1_num + $read2_num)
-    echo "DEBUG: Number of reads total in R1 and R2: ${reads_total}"
+      reads_total=$(expr $read1_num + $read2_num)
+      echo "DEBUG: Number of reads total in R1 and R2: ${reads_total}"
 
-    if [ "${reads_total}" -le "~{min_reads}" ]; then
-      fail_log+="; the total number of reads is below the minimum of ~{min_reads}"
-    fi
+      if [ "${reads_total}" -le "~{min_reads}" ]; then
+        fail_log+="; the total number of reads is below the minimum of ~{min_reads}"
+      fi
 
-    # count number of basepairs
-    # using fastq-scan to count the number of basepairs in each fastq
-    read1_bp=$(eval "${cat_reads} ~{read1}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    read2_bp=$(eval "${cat_reads} ~{read2}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    echo "DEBUG: Number of basepairs in R1: $read1_bp"
-    echo "DEBUG: Number of basepairs in R2: $read2_bp"
+      # count number of basepairs
+      # using fastq-scan to count the number of basepairs in each fastq
+      read1_bp=$(eval "${cat_reads} ~{read1}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      read2_bp=$(eval "${cat_reads} ~{read2}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      echo "DEBUG: Number of basepairs in R1: $read1_bp"
+      echo "DEBUG: Number of basepairs in R2: $read2_bp"
 
-    # set proportion variables for easy comparison
-    # removing the , 2) to make these integers instead of floats
-    percent_read1=$(python3 -c "print(round(($read1_bp / ($read1_bp + $read2_bp))*100))")
-    percent_read2=$(python3 -c "print(round(($read2_bp / ($read1_bp + $read2_bp))*100))")
+      # set proportion variables for easy comparison
+      # removing the , 2) to make these integers instead of floats
+      percent_read1=$(python3 -c "print(round(($read1_bp / ($read1_bp + $read2_bp))*100))")
+      percent_read2=$(python3 -c "print(round(($read2_bp / ($read1_bp + $read2_bp))*100))")
 
-    if [ "$percent_read1" -lt "~{min_proportion}" ] ; then
-      fail_log+="; more than ~{min_proportion} percent of the total sequence is found in R2 (BP: $read2_bp; PERCENT: $percent_read2) compared to R1 (BP: $read1_bp; PERCENT: $percent_read1)"
-    fi
-    if [ "$percent_read2" -lt "~{min_proportion}" ] ; then
-      fail_log+="; more than ~{min_proportion} percent of the total sequence is found in R1 (BP: $read1_bp; PERCENT: $percent_read1) compared to R2 (BP: $read2_bp; PERCENT: $percent_read2)"
-    fi
+      if [ "$percent_read1" -lt "~{min_proportion}" ] ; then
+        fail_log+="; more than ~{min_proportion} percent of the total sequence is found in R2 (BP: $read2_bp; PERCENT: $percent_read2) compared to R1 (BP: $read1_bp; PERCENT: $percent_read1)"
+      fi
+      if [ "$percent_read2" -lt "~{min_proportion}" ] ; then
+        fail_log+="; more than ~{min_proportion} percent of the total sequence is found in R1 (BP: $read1_bp; PERCENT: $percent_read1) compared to R2 (BP: $read2_bp; PERCENT: $percent_read2)"
+      fi
 
-    # check total number of basepairs 
-    bp_total=$(expr $read1_bp + $read2_bp)
-    if [ "${bp_total}" -le "~{min_basepairs}" ]; then
-      fail_log+="; the number of basepairs (${bp_total}) is below the minimum of ~{min_basepairs}"
-    fi
+      # check total number of basepairs 
+      bp_total=$(expr $read1_bp + $read2_bp)
+      if [ "${bp_total}" -le "~{min_basepairs}" ]; then
+        fail_log+="; the number of basepairs (${bp_total}) is below the minimum of ~{min_basepairs}"
+      fi
 
-    #checks four and five: estimated genome length and coverage
-    # estimate genome length if theiaprok AND expected_genome_length was not provided
-    if ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) && [[ -z "~{expected_genome_length}" ]]; then
-      # First Pass; assuming average depth
-      mash sketch -o test -k 31 -m 3 -r ~{read1} ~{read2} > mash-output.txt 2>&1 || true
-      # check if the mash file was generated (successful run)
-      if [ ! -f test.msh ]; then
-        fail_log+="; mash failed - cannot estimate genome length and coverage"
-        estimated_coverage=0
-        estimated_genome_length=0
-        rm mash-output.txt
-      else
-        grep "Estimated genome size:" mash-output.txt | \
-          awk '{if($4){printf("%5.0f\n", $4)}} END {if (!NR) print "0"}' > genome_length_output
-        grep "Estimated coverage:" mash-output.txt | \
-          awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
-        rm -rf test.msh
-        rm -rf mash-output.txt
-        estimated_genome_length=`head -n1 genome_length_output`
-        estimated_coverage=`head -n1 coverage_output`
-  
-        # Check if second pass is needed in theiaprok
-        if [ "{~workflow_series}" == "theiaprok" ]; then
-          if [ ${estimated_genome_length} -gt "~{max_genome_length}" ] || [ ${estimated_genome_length} -lt "~{min_genome_length}" ] ; then
-            # Probably high coverage, try increasing number of kmer copies to 10
-            M="-m 10"
-            if [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
-              # Probably low coverage, try decreasing the number of kmer copies to 1
-              M="-m 1"
+      #checks four and five: estimated genome length and coverage
+      # estimate genome length if theiaprok AND expected_genome_length was not provided
+      if ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) && [[ -z "~{expected_genome_length}" ]]; then
+        # First Pass; assuming average depth
+        mash sketch -o test -k 31 -m 3 -r ~{read1} ~{read2} > mash-output.txt 2>&1 || true
+        # check if the mash file was generated (successful run)
+        if [ ! -f test.msh ]; then
+          fail_log+="; mash failed - cannot estimate genome length and coverage"
+          estimated_coverage=0
+          estimated_genome_length=0
+          rm mash-output.txt
+        else
+          grep "Estimated genome size:" mash-output.txt | \
+            awk '{if($4){printf("%5.0f\n", $4)}} END {if (!NR) print "0"}' > genome_length_output
+          grep "Estimated coverage:" mash-output.txt | \
+            awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+          rm -rf test.msh
+          rm -rf mash-output.txt
+          estimated_genome_length=`head -n1 genome_length_output`
+          estimated_coverage=`head -n1 coverage_output`
+    
+          # Check if second pass is needed in theiaprok
+          if [ "{~workflow_series}" == "theiaprok" ]; then
+            if [ ${estimated_genome_length} -gt "~{max_genome_length}" ] || [ ${estimated_genome_length} -lt "~{min_genome_length}" ] ; then
+              # Probably high coverage, try increasing number of kmer copies to 10
+              M="-m 10"
+              if [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
+                # Probably low coverage, try decreasing the number of kmer copies to 1
+                M="-m 1"
+              fi
+              mash sketch -o test -k 31 ${M} -r ~{read1} ~{read2} > mash-output.txt 2>&1
+              grep "Estimated genome size:" mash-output.txt | \
+                awk '{if($4){printf("%5.0f\n", $4)}} END {if (!NR) print "0"}' > genome_length_output
+              grep "Estimated coverage:" mash-output.txt | \
+                awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+              rm -rf test.msh
+              rm -rf mash-output.txt
+    
+              estimated_genome_length=`head -n1 genome_length_output`
+              estimated_coverage=`head -n1 coverage_output`
             fi
-            mash sketch -o test -k 31 ${M} -r ~{read1} ~{read2} > mash-output.txt 2>&1
-            grep "Estimated genome size:" mash-output.txt | \
-              awk '{if($4){printf("%5.0f\n", $4)}} END {if (!NR) print "0"}' > genome_length_output
-            grep "Estimated coverage:" mash-output.txt | \
-              awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
-            rm -rf test.msh
-            rm -rf mash-output.txt
-  
-            estimated_genome_length=`head -n1 genome_length_output`
-            estimated_coverage=`head -n1 coverage_output`
           fi
         fi
-      fi
-    # estimate coverage if theiacov OR expected_genome_length was provided
-    elif [ "~{workflow_series}" == "theiacov" ] || [ "~{expected_genome_length}" ]; then
-      if [ "~{expected_genome_length}" ]; then
-        estimated_genome_length=~{expected_genome_length} # use user-provided expected_genome_length
-      fi
+      # estimate coverage if theiacov OR expected_genome_length was provided
+      elif [ "~{workflow_series}" == "theiacov" ] || [ "~{expected_genome_length}" ]; then
+        if [ "~{expected_genome_length}" ]; then
+          estimated_genome_length=~{expected_genome_length} # use user-provided expected_genome_length
+        fi
 
-        # coverage is calculated here by N/G where N is number of bases, and G is genome length
-        # this will nearly always be an overestimation
-      if [ $estimated_genome_length -ne 0 ]; then # prevent divided by zero errors
-        estimated_coverage=$(python3 -c "print(round(($read1_bp+$read2_bp)/$estimated_genome_length))")
-      else # they provided 0 for estimated_genome_length, nice
+          # coverage is calculated here by N/G where N is number of bases, and G is genome length
+          # this will nearly always be an overestimation
+        if [ $estimated_genome_length -ne 0 ]; then # prevent divided by zero errors
+          estimated_coverage=$(python3 -c "print(round(($read1_bp+$read2_bp)/$estimated_genome_length))")
+        else # they provided 0 for estimated_genome_length, nice
+          estimated_coverage=0
+        fi
+      else # workflow series was not provided or no est genome length was provided; default to fail
+        estimated_genome_length=0
         estimated_coverage=0
       fi
-    else # workflow series was not provided or no est genome length was provided; default to fail
-      estimated_genome_length=0
-      estimated_coverage=0
-    fi
 
-    # check if estimated genome length is within bounds
-    if [ "${estimated_genome_length}" -ge "~{max_genome_length}" ] && ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) ; then
-      fail_log+="; the estimated genome length (${estimated_genome_length}) is larger than the maximum of ~{max_genome_length} bps"
-    elif [ "${estimated_genome_length}" -le "~{min_genome_length}" ] && ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) ; then
-      fail_log+="; the estimated genome length (${estimated_genome_length}) is smaller than the minimum of ~{min_genome_length} bps"
-    fi
-    if [ "${estimated_coverage}" -lt "~{min_coverage}" ] ; then
-      fail_log+="; the estimated coverage (${estimated_coverage}) is less than the minimum of ~{min_coverage}x"
-    else
-      echo ${estimated_genome_length} | tee EST_GENOME_LENGTH
-      echo "DEBUG: estimated_genome_length: ${estimated_genome_length}" 
-    fi 
+      # check if estimated genome length is within bounds
+      if [ "${estimated_genome_length}" -ge "~{max_genome_length}" ] && ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) ; then
+        fail_log+="; the estimated genome length (${estimated_genome_length}) is larger than the maximum of ~{max_genome_length} bps"
+      elif [ "${estimated_genome_length}" -le "~{min_genome_length}" ] && ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) ; then
+        fail_log+="; the estimated genome length (${estimated_genome_length}) is smaller than the minimum of ~{min_genome_length} bps"
+      fi
+      if [ "${estimated_coverage}" -lt "~{min_coverage}" ] ; then
+        fail_log+="; the estimated coverage (${estimated_coverage}) is less than the minimum of ~{min_coverage}x"
+      else
+        echo ${estimated_genome_length} | tee EST_GENOME_LENGTH
+        echo "DEBUG: estimated_genome_length: ${estimated_genome_length}" 
+      fi 
 
-    # populate metrics values
-    metrics+="\n${read1_num}\t${read2_num}\t${bp_total}\t${estimated_genome_length}"
+      # populate metrics values
+      metrics+="\n${read1_num}\t${read2_num}\t${bp_total}\t${estimated_genome_length}"
+
+    fi
 
     # finish populating failure log
     if [ -z "$fail_log" ]; then
@@ -218,105 +224,112 @@ task check_reads_se {
       cat_reads="cat"
     fi
 
-    # check one: number of reads via fastq-scan
-    read1_num=$($cat_reads ~{read1} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    echo "DEBUG: Number of reads in R1: ${read1_num}"
+    if [[ ! -s "~{read1}" ]]; then
+      echo "DEBUG: CAUTION! the read file is empty!"
+      fail_log+="; the read file is empty"
+    else
+      echo "DEBUG: the read file is not empty, proceeding with checks..."
 
-    if [ "${read1_num}" -le "~{min_reads}" ] ; then
-      fail_log+="; the number of reads (${read1_num}) is below the minimum of ~{min_reads}"
-    fi
+      # check one: number of reads via fastq-scan
+      read1_num=$($cat_reads ~{read1} | fastq-scan | grep 'read_total' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      echo "DEBUG: Number of reads in R1: ${read1_num}"
 
-    # checks two and three: number of basepairs and proportion of sequence
+      if [ "${read1_num}" -le "~{min_reads}" ] ; then
+        fail_log+="; the number of reads (${read1_num}) is below the minimum of ~{min_reads}"
+      fi
 
-    # count number of basepairs
-    # using fastq-scan to count the number of basepairs in each fastq
-    read1_bp=$(eval "${cat_reads} ~{read1}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-    echo "DEBUG: Number of basepairs in R1: $read1_bp"
+      # checks two and three: number of basepairs and proportion of sequence
 
-    if [ "${read1_bp}" -le "~{min_basepairs}" ] ; then
-      fail_log+="; the number of basepairs (${read1_bp}) is below the minimum of ~{min_basepairs}"
-    fi  
+      # count number of basepairs
+      # using fastq-scan to count the number of basepairs in each fastq
+      read1_bp=$(eval "${cat_reads} ~{read1}" | fastq-scan | grep 'total_bp' | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
+      echo "DEBUG: Number of basepairs in R1: $read1_bp"
 
-    #checks four and five: estimated genome length and coverage
-    if [ "~{skip_mash}" == "false" ]; then
-      # estimate genome length if theiaprok AND expected_genome_length was not provided
-      if ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) && [[ -z "~{expected_genome_length}" ]]; then
-        # First Pass; assuming average depth
-        mash sketch -o test -k 31 -m 3 -r ~{read1} > mash-output.txt 2>&1 || true
-        if [ ! -f test.msh ]; then
-          fail_log+="; mash failed - cannot estimate genome length and coverage"
-          estimated_coverage=0
-          estimated_genome_length=0
-          rm mash-output.txt
-        else
-          grep "Estimated genome size:" mash-output.txt | \
-            awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_length_output
-          grep "Estimated coverage:" mash-output.txt | \
-            awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
-          
-          # remove mash outputs
-          rm -rf test.msh
-          rm -rf mash-output.txt
-          
-          estimated_genome_length=`head -n1 genome_length_output`
-          estimated_coverage=`head -n1 coverage_output`
-  
-          # Check if second pass is needed
-          if [ "~{workflow_series}" == "theiaprok" ]; then
-            if [ ${estimated_genome_length} -gt "~{max_genome_length}" ] || [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
-              # Probably high coverage, try increasing number of kmer copies to 10
-              M="-m 10"
-              if [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
-                # Probably low coverage, try decreasing the number of kmer copies to 1
-                M="-m 1"
-              fi
-      
-              mash sketch -o test -k 31 ${M} -r ~{read1} > mash-output.txt 2>&1
-              grep "Estimated genome size:" mash-output.txt | \
-                awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_length_output
-              grep "Estimated coverage:" mash-output.txt | \
-                awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
-                
-              # remove mash outputs
-              rm -rf test.msh
-              rm -rf mash-output.txt
-            fi
-              
+      if [ "${read1_bp}" -le "~{min_basepairs}" ] ; then
+        fail_log+="; the number of basepairs (${read1_bp}) is below the minimum of ~{min_basepairs}"
+      fi  
+
+      #checks four and five: estimated genome length and coverage
+      if [ "~{skip_mash}" == "false" ]; then
+        # estimate genome length if theiaprok AND expected_genome_length was not provided
+        if ( [ "~{workflow_series}" == "theiaprok" ] || [ "~{workflow_series}" == "theiaeuk" ] ) && [[ -z "~{expected_genome_length}" ]]; then
+          # First Pass; assuming average depth
+          mash sketch -o test -k 31 -m 3 -r ~{read1} > mash-output.txt 2>&1 || true
+          if [ ! -f test.msh ]; then
+            fail_log+="; mash failed - cannot estimate genome length and coverage"
+            estimated_coverage=0
+            estimated_genome_length=0
+            rm mash-output.txt
+          else
+            grep "Estimated genome size:" mash-output.txt | \
+              awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_length_output
+            grep "Estimated coverage:" mash-output.txt | \
+              awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+            
+            # remove mash outputs
+            rm -rf test.msh
+            rm -rf mash-output.txt
+            
             estimated_genome_length=`head -n1 genome_length_output`
             estimated_coverage=`head -n1 coverage_output`
-          fi
-        fi
     
-      # estimate coverage if theiacov OR expected_genome_length was provided
-      elif [ "~{workflow_series}" == "theiacov" ] || [ "~{expected_genome_length}" ]; then
-        if [ "~{expected_genome_length}" ]; then
-          estimated_genome_length=~{expected_genome_length} # use user-provided expected_genome_length
-        fi
+            # Check if second pass is needed
+            if [ "~{workflow_series}" == "theiaprok" ]; then
+              if [ ${estimated_genome_length} -gt "~{max_genome_length}" ] || [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
+                # Probably high coverage, try increasing number of kmer copies to 10
+                M="-m 10"
+                if [ ${estimated_genome_length} -lt "~{min_genome_length}" ]; then
+                  # Probably low coverage, try decreasing the number of kmer copies to 1
+                  M="-m 1"
+                fi
+        
+                mash sketch -o test -k 31 ${M} -r ~{read1} > mash-output.txt 2>&1
+                grep "Estimated genome size:" mash-output.txt | \
+                  awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_length_output
+                grep "Estimated coverage:" mash-output.txt | \
+                  awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+                  
+                # remove mash outputs
+                rm -rf test.msh
+                rm -rf mash-output.txt
+              fi
+                
+              estimated_genome_length=`head -n1 genome_length_output`
+              estimated_coverage=`head -n1 coverage_output`
+            fi
+          fi
+      
+        # estimate coverage if theiacov OR expected_genome_length was provided
+        elif [ "~{workflow_series}" == "theiacov" ] || [ "~{expected_genome_length}" ]; then
+          if [ "~{expected_genome_length}" ]; then
+            estimated_genome_length=~{expected_genome_length} # use user-provided expected_genome_length
+          fi
 
-        # coverage is calculated here by N/G where N is number of bases, and G is genome length
-        # this will nearly always be an overestimation
-        if [ $estimated_genome_length -ne 0 ]; then # prevent divided by zero errors
-          estimated_coverage=$(python3 -c "print(round(($read1_bp)/$estimated_genome_length))")
-        else # they provided 0 for estimated_genome_length, nice
+          # coverage is calculated here by N/G where N is number of bases, and G is genome length
+          # this will nearly always be an overestimation
+          if [ $estimated_genome_length -ne 0 ]; then # prevent divided by zero errors
+            estimated_coverage=$(python3 -c "print(round(($read1_bp)/$estimated_genome_length))")
+          else # they provided 0 for estimated_genome_length, nice
+            estimated_coverage=0
+          fi
+        else # workflow series was not provided; default to fail
+          estimated_genome_length=0
           estimated_coverage=0
         fi
-      else # workflow series was not provided; default to fail
-        estimated_genome_length=0
-        estimated_coverage=0
-      fi
-      if [ "${estimated_genome_length}" -ge "~{max_genome_length}" ] ; then
-        fail_log+="; the estimated genome length (${estimated_genome_length}) is larger than the maximum of ~{max_genome_length} bps"
-      elif [ "${estimated_genome_length}" -le "~{min_genome_length}" ] ; then
-        fail_log+="; the estimated genome length (${estimated_genome_length}) is smaller than the minimum of ~{min_genome_length} bps"
-      fi
-      if [ "${estimated_coverage}" -lt "~{min_coverage}" ] ; then
-        fail_log+="; the estimated coverage (${estimated_coverage}) is less than the minimum of ~{min_coverage}x"
-      else
-        echo $estimated_genome_length | tee EST_GENOME_LENGTH 
-      fi
-    fi 
+        if [ "${estimated_genome_length}" -ge "~{max_genome_length}" ] ; then
+          fail_log+="; the estimated genome length (${estimated_genome_length}) is larger than the maximum of ~{max_genome_length} bps"
+        elif [ "${estimated_genome_length}" -le "~{min_genome_length}" ] ; then
+          fail_log+="; the estimated genome length (${estimated_genome_length}) is smaller than the minimum of ~{min_genome_length} bps"
+        fi
+        if [ "${estimated_coverage}" -lt "~{min_coverage}" ] ; then
+          fail_log+="; the estimated coverage (${estimated_coverage}) is less than the minimum of ~{min_coverage}x"
+        else
+          echo $estimated_genome_length | tee EST_GENOME_LENGTH 
+        fi
+      fi 
 
-    metrics+="\n${read1_num}\t${read1_bp}\t${estimated_genome_length}"
+      metrics+="\n${read1_num}\t${read1_bp}\t${estimated_genome_length}"
+    fi
 
     # finish populating failure log
     if [ -z "$fail_log" ]; then

--- a/tasks/quality_control/comparisons/task_screen.wdl
+++ b/tasks/quality_control/comparisons/task_screen.wdl
@@ -38,7 +38,7 @@ task check_reads {
       cat_reads="cat"
     fi
 
-    if [[ $($cat_reads ~{read1} | wc -l) -eq 0 || $($cat_reads ~{read2} | wc -l) -eq 0 ]]; then
+    if [[ $($cat_reads ~{read1} | head -n1 | wc -l) -eq 0 || $($cat_reads ~{read2} | head -n1 |wc -l) -eq 0 ]]; then
       echo "DEBUG: CAUTION! one of the read files is empty!"
       fail_log+="; one or both of the read files are empty"
     else
@@ -224,7 +224,7 @@ task check_reads_se {
       cat_reads="cat"
     fi
 
-    if [[ $($cat_reads ~{read1} | wc -l) -eq 0 ]]; then
+    if [[ $($cat_reads ~{read1} | head -n1 | wc -l) -eq 0 ]]; then
       echo "DEBUG: CAUTION! the read file is empty!"
       fail_log+="; the read file is empty"
     else

--- a/tasks/quality_control/comparisons/task_screen.wdl
+++ b/tasks/quality_control/comparisons/task_screen.wdl
@@ -38,7 +38,7 @@ task check_reads {
       cat_reads="cat"
     fi
 
-    if [[ ! -s "~{read1}" || ! -s "~{read2}" ]]; then
+    if [[ $($cat_reads ~{read1} | wc -l) -eq 0 || $($cat_reads ~{read2} | wc -l) -eq 0 ]]; then
       echo "DEBUG: CAUTION! one of the read files is empty!"
       fail_log+="; one or both of the read files are empty"
     else
@@ -224,7 +224,7 @@ task check_reads_se {
       cat_reads="cat"
     fi
 
-    if [[ ! -s "~{read1}" ]]; then
+    if [[ $($cat_reads ~{read1} | wc -l) -eq 0 ]]; then
       echo "DEBUG: CAUTION! the read file is empty!"
       fail_log+="; the read file is empty"
     else


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #1030

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
- checks if at least one of the files is empty. If so, it skips to the end and doesn't try to do math. Otherwise, math is done.

Diff seems way worse than what actually changed; all preexisting code after the "is empty" check is indented and put into an else.


## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

This PR may lead to different results in pre-existing outputs: **Yes**
failures will now be green

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs
<!-- Have any inputs been added or altered? If so, list out the changes. -->

### ⬅️ Outputs
<!-- Have any outputs been added or altered? If so, list out the changes. -->

## :test_tube: Testing
<!-- Please describe how you tested this PR. -->

- tested locally with empty files; successfully ended w/ "FAIL; one or both read files are empty" message
- tested [theiaprok here](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/8705883c-57ad-4f90-a71b-77ad5d352f47) with real files; successfully continued w/ "PASS" message

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
