### PR TITLE
fix: uses `Int` instead of `String` for `cpu` runtime values

### DIFF
--- a/tasks/alignment/task_bwa.wdl
+++ b/tasks/alignment/task_bwa.wdl
@@ -193,7 +193,7 @@ task bwa_all {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/assembly/task_megahit.wdl
+++ b/tasks/assembly/task_megahit.wdl
@@ -66,7 +66,7 @@ task megahit {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/assembly/task_metaspades.wdl
+++ b/tasks/assembly/task_metaspades.wdl
@@ -36,7 +36,7 @@ task metaspades_pe {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/assembly/task_skesa.wdl
+++ b/tasks/assembly/task_skesa.wdl
@@ -48,7 +48,7 @@ task skesa {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/assembly/task_spades.wdl
+++ b/tasks/assembly/task_spades.wdl
@@ -78,7 +78,7 @@ task spades {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks:  "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl
+++ b/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl
@@ -66,7 +66,7 @@ task snippy_gene_query {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     preemptible: 0
     maxRetries: 3

--- a/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
+++ b/tasks/gene_typing/variant_detection/task_snippy_variants.wdl
@@ -155,7 +155,7 @@ task snippy_variants {
   runtime {
       docker: "~{docker}"
       memory: "~{memory} GB"
-      cpu: "~{cpu}"
+      cpu: cpu
       disks: "local-disk " + disk_size + " SSD"
       preemptible: 0
       maxRetries: 3

--- a/tasks/quality_control/advanced_metrics/task_gambittools.wdl
+++ b/tasks/quality_control/advanced_metrics/task_gambittools.wdl
@@ -64,7 +64,7 @@ task gambitcore {
   runtime {
     docker:  "~{docker}"
     memory:  "~{memory} GB"
-    cpu:   "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl
+++ b/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl
@@ -99,7 +99,7 @@ task cg_pipeline {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/quality_control/basic_statistics/task_quast.wdl
+++ b/tasks/quality_control/basic_statistics/task_quast.wdl
@@ -61,7 +61,7 @@ task quast {
   runtime {
     docker:  "~{docker}"
     memory:  "~{memory} GB"
-    cpu:   "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -161,7 +161,7 @@ task gambit {
   runtime {
     docker: "~{docker}"
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3


### PR DESCRIPTION
We're working on getting [Sprocket](https://github.com/stjude-rust-labs/sprocket) to parse and lint this repository, and we're systematically working through the errors it reports. This PR addresses 11 of those errors.

The `cpu` runtime key was set to `String` values throughout these task files via interpolated strings like `"~{cpu}"`. The WDL 1.0 spec doesn't define what type `cpu` should be, but WDL 1.1 specifies it as `Int` or `Float`, which is what Sprocket enforces. Since Cromwell also supports `Int` natively and only handles `String` values here through implicit coercion, using `Int` directly is the safest choice across engines.

This also normalizes spacing on `cpu` lines in `task_gambittools.wdl` and `task_quast.wdl`.