### PR TITLE
fix: uses typed `read_int`/`read_float` and unquoted `Int` defaults

### DIFF
--- a/tasks/assembly/task_ivar_consensus.wdl
+++ b/tasks/assembly/task_ivar_consensus.wdl
@@ -6,11 +6,11 @@ task consensus {
     String samplename
     File? reference_genome
     Boolean count_orphans = true
-    Int max_depth = "600000"
+    Int max_depth = 600000
     Boolean disable_baq = true
     Boolean all_positions = false
-    Int min_bq = "0"
-    Int min_qual = "20"
+    Int min_bq = 0
+    Int min_qual = 20
     Float? consensus_min_freq 
     Int? consensus_min_depth
     String char_unknown = "N"

--- a/tasks/gene_typing/drug_resistance/task_resfinder.wdl
+++ b/tasks/gene_typing/drug_resistance/task_resfinder.wdl
@@ -232,7 +232,7 @@ task resfinder {
     String resfinder_predicted_resistance_Tmp = read_string("RESFINDER_PREDICTED_RESISTANCE_TMP.txt")
 
     String resfinder_predicted_resistance_quinolone = read_string("RESFINDER_PREDICTED_RESISTANCE_Q.txt")
-    Int resfinder_predicted_resistance_quinolone_mechanisms = read_string("RESFINDER_PREDICTED_RESISTANCE_Q_COUNT.txt")
+    Int resfinder_predicted_resistance_quinolone_mechanisms = read_int("RESFINDER_PREDICTED_RESISTANCE_Q_COUNT.txt")
     
     String resfinder_docker = "~{docker}"
     String resfinder_version = read_string("RESFINDER_VERSION")

--- a/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
+++ b/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl
@@ -7,7 +7,7 @@ task variant_call {
     String organism = "sars-cov-2" # default to sars-cov-2 to maintain previous behavior
     File? reference_genome
     File? reference_gff 
-    Int min_qual = "20"
+    Int min_qual = 20
     Float? variant_min_freq 
     Int? variant_min_depth 
     Int disk_size = 100
@@ -85,7 +85,7 @@ task variant_call {
     fi
   >>>
   output {
-    Int variant_num = read_string("VARIANT_NUM")
+    Int variant_num = read_int("VARIANT_NUM")
     String variant_proportion_intermediate = read_string("PROPORTION_INTERMEDIATE")
     File sample_variants_tsv = "~{samplename}.variants.tsv"
     File sample_variants_vcf = "~{samplename}.variants.vcf"

--- a/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl
+++ b/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl
@@ -81,11 +81,11 @@ task stats_n_coverage {
     File cov_hist = "~{samplename}.cov.hist"
     File cov_stats = "~{samplename}.cov.txt"
     File flagstat = "~{samplename}.flagstat.txt"
-    Float coverage = read_string("COVERAGE")
-    Float depth = read_string("DEPTH")
-    Float meanbaseq = read_string("MEANBASEQ")
-    Float meanmapq = read_string("MEANMAPQ")
-    Float percentage_mapped_reads = read_string("PERCENTAGE_MAPPED_READS")
+    Float coverage = read_float("COVERAGE")
+    Float depth = read_float("DEPTH")
+    Float meanbaseq = read_float("MEANBASEQ")
+    Float meanmapq = read_float("MEANMAPQ")
+    Float percentage_mapped_reads = read_float("PERCENTAGE_MAPPED_READS")
     File metrics_txt = "~{samplename}_metrics.txt"
 
   }

--- a/tasks/quality_control/basic_statistics/task_consensus_qc.wdl
+++ b/tasks/quality_control/basic_statistics/task_consensus_qc.wdl
@@ -43,11 +43,11 @@ task consensus_qc {
     echo $num_total | tee NUM_TOTAL
   >>>
   output {
-    Int number_N = read_string("NUM_N")
-    Int number_ATCG = read_string("NUM_ACTG")
-    Int number_Degenerate = read_string("NUM_DEGENERATE")
-    Int number_Total = read_string("NUM_TOTAL")
-    Float percent_reference_coverage = read_string("PERCENT_REF_COVERAGE")
+    Int number_N = read_int("NUM_N")
+    Int number_ATCG = read_int("NUM_ACTG")
+    Int number_Degenerate = read_int("NUM_DEGENERATE")
+    Int number_Total = read_int("NUM_TOTAL")
+    Float percent_reference_coverage = read_float("PERCENT_REF_COVERAGE")
   }
   runtime {
     docker: docker

--- a/tasks/quality_control/basic_statistics/task_readlength.wdl
+++ b/tasks/quality_control/basic_statistics/task_readlength.wdl
@@ -23,7 +23,7 @@ task readlength {
     echo $result | tee AVERAGE_READ_LENGTH
   >>>
   output {
-    Float average_read_length = read_string("AVERAGE_READ_LENGTH")
+    Float average_read_length = read_float("AVERAGE_READ_LENGTH")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/species_typing/salmonella/task_genotyphi.wdl
+++ b/tasks/species_typing/salmonella/task_genotyphi.wdl
@@ -58,7 +58,7 @@ task genotyphi {
     File genotyphi_mykrobe_json = "./~{samplename}.mykrobe_genotyphi.json"
     String genotyphi_version = read_string("GENOTYPHI_VERSION")
     String genotyphi_species = read_string("SPECIES")
-    Float genotyphi_st_probes_percent_coverage = read_string("SPP_PERCENT")
+    Float genotyphi_st_probes_percent_coverage = read_float("SPP_PERCENT")
     String genotyphi_final_genotype = read_string("FINAL_GENOTYPE")
     String genotyphi_genotype_confidence = read_string("CONFIDENCE")
   }

--- a/tasks/taxon_id/contamination/task_midas.wdl
+++ b/tasks/taxon_id/contamination/task_midas.wdl
@@ -73,8 +73,8 @@ task midas {
     File midas_log = "~{samplename}/species/~{samplename}_log.txt"
     String midas_primary_genus = read_string("PRIMARY_GENUS")
     String midas_secondary_genus = read_string("SECONDARY_GENUS")
-    Float midas_secondary_genus_abundance = read_string("SECONDARY_GENUS_ABUNDANCE")
-    Float midas_secondary_genus_coverage = read_string("SECONDARY_GENUS_COVERAGE")
+    Float midas_secondary_genus_abundance = read_float("SECONDARY_GENUS_ABUNDANCE")
+    Float midas_secondary_genus_coverage = read_float("SECONDARY_GENUS_COVERAGE")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/utilities/data_handling/task_parse_mapping.wdl
+++ b/tasks/utilities/data_handling/task_parse_mapping.wdl
@@ -192,7 +192,7 @@ task retrieve_pe_reads_bam {
     File bam
     String samplename
     String prefix = ""
-    Int sam_flag = "4" # unmapped reads (SAM flag 4)
+    Int sam_flag = 4 # unmapped reads (SAM flag 4)
     String docker = "us-docker.pkg.dev/general-theiagen/staphb/samtools:1.17"
     Int disk_size = 100
     Int cpu = 2


### PR DESCRIPTION
First, several `Int` input declarations used string-quoted defaults like `Int min_qual = "20"` instead of bare integer literals. WDL requires `Int` defaults to be unquoted, and Cromwell only accepted the quoted form through implicit coercion. These are now written as `Int min_qual = 20`.

Second, a number of task outputs declared as `Int` or `Float` were using `read_string()` to read their values from files. The WDL spec provides `read_int()` and `read_float()` for exactly this purpose—they read a file and parse its contents into the declared type directly, rather than relying on implicit string-to-number coercion.