### PR TITLE
[QC Check] Set 'N/A' values to 0 for IRMA Summary in QC Check

### DIFF
--- a/tasks/quality_control/comparisons/task_qc_check_phb.wdl
+++ b/tasks/quality_control/comparisons/task_qc_check_phb.wdl
@@ -224,6 +224,8 @@ task qc_check_phb {
         if "~{irma_qc_table}":
           # keep default NA false to prevent NA segmented converting to null
           irma_qc_table = pd.read_csv("~{irma_qc_table}", sep = '\t', index_col = "Sample", keep_default_na=False)
+          # set all 'N/A' values to 0 for QC Check task
+          irma_qc_table = irma_qc_table.replace({'N/A': '0'})
           to_rm = set()
           # report segment failures on a metric-by-metric basis, but we iterate segment-by-segment
           seg2qc_note = {}

--- a/tests/bioforklift/inputs/theiaprok_ont.inputs.json
+++ b/tests/bioforklift/inputs/theiaprok_ont.inputs.json
@@ -5,5 +5,5 @@
     "theiaprok_ont.read_QC_trim.metabuli_db": "this.metabuli_db_input",
     "theiaprok_ont.call_ani": "this.call_ani_input",
     "theiaprok_ont.flye_denovo.medaka_model": "r941_min_hac_g507",
-    "theiaprok_ont.samplename": "this.theiaprok_ont_id",
+    "theiaprok_ont.samplename": "this.theiaprok_ont_id"
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
No PR Associated

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR sets 'N/A' values in the IRMA summary to '0' in order to allow QC Check to pass (not fail or error out).
Previously the 'N/A' values would cause issues in the parsing and comparing of QC Check table values and IRMA summary results. No change is made to the IRMA summary. This reassignment only affects the data frame once it is within QC Check.

## :zap: Impacted Workflows/Tasks
<!-- Please list what workflows and/or tasks are impacted by this change -->

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

A replace function was added to the IRMA summary data frame to replace all 'N/A' values with 0.

## :test_tube: Testing
- [ ] <details><summary>[freyja_fastq](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/d127a694-3936-4f58-83b4-e9e8b2abb731)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiacov_clearlabs](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/ae7ae41d-323f-4438-acd8-cefb391cfb6e)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiacov_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/1681818c-40e4-44a4-aae7-1fab078aae5d)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiacov_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/e10b8cb3-cb96-4d78-b4b6-4ff65983ca12)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiacov_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/dc31f44b-64e9-4ec0-af0d-4935d2e2cb72)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiacov_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/3e6667ec-0848-472a-bfc8-66d895e4ac87)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiaeuk_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/72df9988-ad4d-40b4-946a-b1562db603aa)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiaprok_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/96e1e2c9-501f-42eb-b97e-1372b9b8db0a)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiaprok_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/403bdd4d-cb27-41ed-aaf6-92e1be1d2dcc)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiaprok_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/66d53f7f-99ac-4853-9135-61b18f03b1bd)</summary>qc_check_phb</details>
- [ ] <details><summary>[theiaprok_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/0de9e127-dd60-4034-b14f-fcfe16c8f7cc)</summary>qc_check_phb</details>

<!-- Please describe how you tested this PR. -->

Workflows were tested for retained functionality.

QC Check was tested locally using partner data to ensure that the new changes resulted in a completed workflow. Test results outlined below.

<details><summary>Main Functionality</summary>

```
Traceback (most recent call last):
  File "<stdin>", line 237, in <module>
ValueError: could not convert string to float: 'N/A'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 239, in <module>
ValueError: could not convert string to float: 'N/A'
```

</details>

<details><summary>New Functionality</summary>

```
2026-04-17 13:47:50.090 wdl.w:theiacov_illumina_pe done
{
  "dir": "/home/andrew_hale/github/testing_dir/qc_check/20260417_134746_theiacov_illumina_pe",
  "outputs": {
   ........
    "theiacov_illumina_pe.qc_check": "QC_ALERT: vadr_num_alerts (2) was greater than the maximum threshold of 0; pb2_median_coverage (1.0) was less than the minimum threshold of 100.0; pb1_median_coverage (0.0) was less than the minimum threshold of 100.0; pa_median_coverage (1.0) was less than the minimum threshold of 100.0; ha_median_coverage (4.0) was less than the minimum threshold of 100.0; np_median_coverage (0.0) was less than the minimum threshold of 100.0; na_median_coverage (3.0) was less than the minimum threshold of 100.0; mp_median_coverage (27.0) was less than the minimum threshold of 100.0; ns_median_coverage (3.0) was less than the minimum threshold of 100.0; pb2_percent_reference_coverage (0.0) was less than the minimum threshold of 90.0; pb1_percent_reference_coverage (0.0) was less than the minimum threshold of 90.0; pa_percent_reference_coverage (0.0) was less than the minimum threshold of 90.0; ha_percent_reference_coverage (6.92) was less than the minimum threshold of 90.0; np_percent_reference_coverage (0.0) was less than the minimum threshold of 90.0; na_percent_reference_coverage (5.53) was less than the minimum threshold of 90.0; mp_percent_reference_coverage (38.9) was less than the minimum threshold of 90.0; ns_percent_reference_coverage (0.0) was less than the minimum threshold of 90.0",
   ........
  }
}
```

</details>

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] MD5 sums have been updated
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
