### PR TITLE
[MLST] Update to v2.33.1 

### DIFF
--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -2758,7 +2758,7 @@ trimmomatic	trimmomatic_window_quality	Int	The trimming window quality score	30	
 trimmomatic	trimmomatic_window_size	Int	The window size for trimming	4	Optional	TBProfiler_tNGS	general	
 ts_mlst	cpu	Int	Number of CPUs to allocate to the task	1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 ts_mlst	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
-ts_mlst	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-12-31	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
+ts_mlst	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.33.1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
 ts_mlst	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 ts_mlst	min_percent_coverage	Float	Minimum % breadth of coverage to report an MLST allele	10	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	
 ts_mlst	min_percent_identity	Float	Minimum % identity to known MLST gene to report an MLST allele	95	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	

--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -7,7 +7,7 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/mlst:2.23.0-2024-12-31"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.33.1"
     Int disk_size = 50
     Int cpu = 1
     Int memory = 2


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
No Issue Associated

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
This PR updates MLST to v2.33.1, downgrading the database to data available prior to 2025 per PubMLST licensing. With that there is one missing scheme, `pstuartii`. This scheme is locked behind the API wall and is unavailable. 

## :zap: Impacted Workflows/Tasks

### Tasks
Δ `ts_mlst`

This PR may lead to different results in pre-existing outputs: **Yes**
This could occur due to the downgrading of the database. Previous ST types might not be included in the new version of the database. 

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs

### ⬅️ Outputs

## :test_tube: Testing
- [x] <details><summary>[theiaprok_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/d6da6a83-a746-42cf-ab5b-48557a11682f)</summary>ts_mlst</details>
- [x] <details><summary>[theiaprok_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/7f59c4b7-3265-45fa-b8b3-4746810ddc5d)</summary>ts_mlst</details>
- [x] <details><summary>[theiaprok_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/5129cc71-5065-423d-8dfc-efb51d59092e)</summary>ts_mlst</details>
- [x] <details><summary>[theiaprok_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/0dc26311-74ff-4b14-a600-c6a0e7641a83)</summary>ts_mlst</details>

<!-- Please describe how you tested this PR. -->

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)