### PR TITLE
[MLST] Downgrade DB and Revert Version

### DIFF
--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -2809,7 +2809,7 @@ trimmomatic	trimmomatic_window_quality	Int	The trimming window quality score	30	
 trimmomatic	trimmomatic_window_size	Int	The window size for trimming	4	Optional	TBProfiler_tNGS	general	
 ts_mlst	cpu	Int	Number of CPUs to allocate to the task	1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 ts_mlst	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
-ts_mlst	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.33.1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
+ts_mlst	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.23.0-2024-12-31	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
 ts_mlst	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	2	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 ts_mlst	min_percent_coverage	Float	Minimum % breadth of coverage to report an MLST allele	10	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	
 ts_mlst	min_percent_identity	Float	Minimum % identity to known MLST gene to report an MLST allele	95	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	

--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -7,7 +7,7 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.23.0-2026-03-21"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.23.0-2024-12-31"
     Int disk_size = 50
     Int cpu = 1
     Int memory = 2

--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -7,7 +7,7 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.33.1"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mlst:2.23.0-2026-03-21"
     Int disk_size = 50
     Int cpu = 1
     Int memory = 2

--- a/tasks/species_typing/multi/task_ts_mlst.wdl
+++ b/tasks/species_typing/multi/task_ts_mlst.wdl
@@ -26,11 +26,11 @@ task ts_mlst {
     Float min_percent_coverage = 10 # set to mirror v2.23.0-2024-12-31 default
     Float minscore = 50 # set to mirror v2.23.0-2024-12-31 default
   }
-  command <<< 
+  command <<<
     set -euo pipefail
 
     echo $(mlst --version 2>&1) | sed 's/mlst //' | tee VERSION
-    
+
     #create output header
     echo -e "Filename\tPubMLST_Scheme_name\tSequence_Type_(ST)\tAllele_IDs" > ~{samplename}_ts_mlst.tsv
     # If taxon is E. coli and scheme_override is true, common mis-characterizations will be excluded from the scheme list
@@ -49,7 +49,7 @@ task ts_mlst {
         --novel ~{samplename}_novel_mlst_alleles.fasta \
         ~{assembly} \
         >> ~{samplename}_ts_mlst.tsv
-    else 
+    else
       echo "Scheme Override set to false, using default scheme list, mis characterizations involving aeromonas, cfreundii, senterica can occur when running on E. coli"
       mlst \
         --threads ~{cpu} \
@@ -64,7 +64,7 @@ task ts_mlst {
     fi
 
     # There are multiple schemes of importance for some taxa, e.g. E. coli and A. baumannii,
-    # so a secondary scheme may be run if the user specifies to do so. 
+    # so a secondary scheme may be run if the user specifies to do so.
     if [[ "~{run_secondary_scheme}" == "true" ]]; then
       echo "Secondary scheme run is true, running secondary scheme if applicable."
       #create output header
@@ -97,7 +97,7 @@ task ts_mlst {
           --novel ~{samplename}_novel_mlst_alleles_secondary_scheme.fasta \
           ~{assembly} \
           >> ~{samplename}_ts_mlst_secondary_scheme.tsv
-        
+
         # parse ts mlst tsv for relevant outputs
         # if output TSV only contains one line (header line); no ST predicted
         if [ $(wc -l ~{samplename}_ts_mlst_secondary_scheme.tsv | awk '{ print $1 }') -eq 1 ]; then
@@ -127,7 +127,7 @@ task ts_mlst {
         echo "NA" | tee PREDICTED_SECONDARY_MLST
         echo "NA" | tee PUBMLST_SECONDARY_SCHEME
         echo "NA" | tee SECONDARY_ALLELIC_PROFILE.txt
-      fi 
+      fi
     else
       echo "Secondary scheme not run, as run_secondary_scheme is false."
       echo "NA" | tee PREDICTED_SECONDARY_MLST
@@ -154,9 +154,9 @@ task ts_mlst {
         if [ "$predicted_mlst" == "ST-" ]; then
           predicted_mlst="No ST predicted"
         fi
-      fi  
+      fi
     fi
-        
+
     echo "$predicted_mlst" | tee PREDICTED_MLST
     echo "$pubmlst_scheme" | tee PUBMLST_SCHEME
     echo "$allelic_profile" | tee ALLELIC_PROFILE.txt
@@ -175,7 +175,7 @@ task ts_mlst {
     File? ts_mlst_novel_alleles = "~{samplename}_novel_mlst_alleles.fasta"
     # Only present if secondary scheme was run
     String? ts_mlst_predicted_secondary_st = read_string("PREDICTED_SECONDARY_MLST")
-    String? ts_mlst_pubmlst_secondary_scheme = read_string("PUBMLST_SECONDARY_SCHEME") 
+    String? ts_mlst_pubmlst_secondary_scheme = read_string("PUBMLST_SECONDARY_SCHEME")
     String? ts_mlst_secondary_allelic_profile = read_string("SECONDARY_ALLELIC_PROFILE.txt")
     File? ts_mlst_secondary_novel_alleles = "~{samplename}_novel_mlst_alleles_secondary_scheme.fasta"
     String ts_mlst_version = read_string("VERSION")


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository! 

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

Downgrades the MLST version to `v2.23.0` and uses the (legal) database curated up to Dec 31st 2024. [Link to Dockerfile](https://github.com/theiagen/theiagen_docker_builds/pull/36)

## :zap: Impacted Workflows/Tasks

<details open><summary><h3>Tasks</h3></summary>

Δ `ts_mlst`

</details>



This PR may lead to different results in pre-existing outputs: **Yes**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

<details open><summary><h3>➡️ Inputs</h3></summary>


</details>

<details open><summary><h3>⬅️ Outputs</h3></summary>


</details>

## :test_tube: Testing

- [x] [theiaprok_fasta (v4.1.0 default mlst v2.23.0)](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/bd907460-15af-432c-abba-848faf1479a8)
- [x] [theiaprok_fasta (v4.1.0 default mlst v2.23.0 w/ downgraded DB)](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/914de480-8d3e-494c-a5ec-832dde3feadb)
- [x] [theiaprok_fasta (main default mlst v2.23.0 w/ downgraded DB)](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/3b5ea35a-58bf-40fd-af94-9b414f9110ae)

<details><summary><h3>MLST VERSION COMPARISONS</h3></summary>

| column_1 | v4.1.0 mlst (v2.23) | v4.1.0 mlst (v2.23 downgraded) | main mlst (v2.23 downgraded) |
| --- | --- | --- | --- |
| entity:theiaprok_fasta_id | ts_mlst_pubmlst_scheme | ts_mlst_pubmlst_scheme | ts_mlst_pubmlst_scheme |
| 03-98DDCS | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 0398KL | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 155734 | klebsiella | klebsiella | klebsiella |
| 1643273 | senterica_achtman_2 | senterica_achtman_2 | salmonella |
| 19050801924 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 19061904717 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 20012105104 | abaumannii_2 | abaumannii_2 | abaumannii_2 |
| 20072006929 | abaumannii_2 | abaumannii_2 | abaumannii_2 |
| 20111002911 | abaumannii_2 | abaumannii_2 | abaumannii_2 |
| 20120903560 | abaumannii_2 | abaumannii_2 | abaumannii_2 |
| 2022AZMC-0001 |  |  |  |
| 2022AZMC-0002 |  |  |  |
| 2022AZMC-0003 |  |  |  |
| 2022AZMC-0004 |  |  |  |
| 2022AZMC-0005 |  |  |  |
| 21040902942 | abaumannii_2 | abaumannii_2 | abaumannii_2 |
| 21071504615 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 249818 | koxytoca | koxytoca | koxytoca |
| 283104 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 302749 | klebsiella | klebsiella | klebsiella |
| 302752 | kaerogenes | kaerogenes | kaerogenes |
| 302757 | klebsiella | klebsiella | klebsiella |
| 369711 | senterica_achtman_2 | salmonella | salmonella |
| 461023 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 469114 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 472923 | listeria_2 | listeria_2 | listeria_2 |
| 473675 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 480757 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| 482933 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| ERR351995 | spneumoniae | spneumoniae | spneumoniae |
| ERR425403 | spneumoniae | spneumoniae | spneumoniae |
| ERR701871 | spneumoniae | spneumoniae | spneumoniae |
| H8394DDCS | listeria_2 | listeria_2 | listeria_2 |
| H8394KL | listeria_2 | listeria_2 | listeria_2 |
| M17F02683 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| M21F00509 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| M21F01894 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| M21F02113 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| M22F001066 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| M22F00288 | ecoli_achtman_4 | ecoli_achtman_4 | ecoli_achtman_4 |
| neisseria_gonorrhoeae_SRR23168800_FASTA | neisseria | neisseria | neisseria |
| neisseria_gonorrhoeae_SRR23168813_FASTA | neisseria | neisseria | neisseria |
| neisseria_meningitidis_ERR10211614_FASTA | neisseria | neisseria | neisseria |
| neisseria_meningitidis_ERR10211640_FASTA | neisseria | neisseria | neisseria |
| PNUSAS001732 | senterica_achtman_2 | senterica_achtman_2 | senterica_achtman_2 |
| PNUSAS058783 | senterica_achtman_2 | salmonella | senterica_achtman_2 |
| PNUSAS067899 | senterica_achtman_2 | salmonella | senterica_achtman_2 |
| PNUSAS274355 | senterica_achtman_2 | salmonella | salmonella |
| SAL_MB5288AA | senterica_achtman_2 | senterica_achtman_2 | salmonella |
| SAMN24249320 | paeruginosa | paeruginosa | paeruginosa |
| SAMN24249373 | paeruginosa | paeruginosa | paeruginosa |
| SAMN24249374 | paeruginosa | paeruginosa | paeruginosa |
| SAMN31370019 | paeruginosa | paeruginosa | paeruginosa |
| SAMN31384136 | paeruginosa | paeruginosa | paeruginosa |
| SRR7062531 | vcholerae | vcholerae | vcholerae |
| SRR7062631 | vcholerae | vcholerae | vcholerae |
| SRR7232584 | vparahaemolyticus | vparahaemolyticus | vparahaemolyticus |
| staphylococcus_aureus_ERR900841_FASTA | saureus | saureus | saureus |
| staphylococcus_aureus_ERR900847_FASTA | saureus | saureus | saureus |
| TexasAM1 | mycobacteria_2 | mycobacteria_2 | mycobacteria_2 |
| TexasAM2 | mycobacteria_2 | mycobacteria_2 | mycobacteria_2 |

</details>

<!-- Please describe how you tested this PR. -->

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [ ] The workflow/task has been tested and results, including file contents, are as anticipated
- [ ] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [ ] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [ ] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
