### PR TITLE
[CI] Add Sprocket lint workflow

### DIFF
--- a/.github/workflows/sprocket-lint.yml
+++ b/.github/workflows/sprocket-lint.yml
@@ -6,16 +6,12 @@ on:
     paths:
       - "tasks/**"
       - "workflows/**"
-      - "sprocket.toml"
-      - ".sprocketignore"
       - ".github/workflows/sprocket-lint.yml"
   pull_request:
     branches: [main]
     paths:
       - "tasks/**"
       - "workflows/**"
-      - "sprocket.toml"
-      - ".sprocketignore"
       - ".github/workflows/sprocket-lint.yml"
   workflow_dispatch:
 
@@ -23,11 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Check for WDL changes
+  lint:
     runs-on: ubuntu-latest
-    outputs:
-      wdl_files: ${{ steps.filter.outputs.wdl_files }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -42,20 +35,8 @@ jobs:
               - added|modified: "workflows/**/*.wdl"
           list-files: json
 
-  lint:
-    name: Lint ${{ matrix.wdl }}
-    needs: changes
-    if: ${{ needs.changes.outputs.wdl_files != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        wdl: ${{ fromJSON(needs.changes.outputs.wdl_files) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Install latest Sprocket
+        if: steps.filter.outputs.wdl == 'true'
         uses: jaxxstorm/action-install-gh-release@v3
         with:
           repo: stjude-rust-labs/sprocket
@@ -63,4 +44,9 @@ jobs:
           asset-name: sprocket
 
       - name: Lint WDL
-        run: sprocket lint "${{ matrix.wdl }}"
+        if: steps.filter.outputs.wdl == 'true'
+        env:
+          WDL_FILES: ${{ steps.filter.outputs.wdl_files }}
+        run: |
+          mapfile -t wdl_files < <(jq -r '.[]' <<< "$WDL_FILES")
+          sprocket lint "${wdl_files[@]}"

--- a/.github/workflows/sprocket-lint.yml
+++ b/.github/workflows/sprocket-lint.yml
@@ -1,0 +1,66 @@
+name: Sprocket Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tasks/**"
+      - "workflows/**"
+      - "sprocket.toml"
+      - ".sprocketignore"
+      - ".github/workflows/sprocket-lint.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tasks/**"
+      - "workflows/**"
+      - "sprocket.toml"
+      - ".sprocketignore"
+      - ".github/workflows/sprocket-lint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Check for WDL changes
+    runs-on: ubuntu-latest
+    outputs:
+      wdl_files: ${{ steps.filter.outputs.wdl_files }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Find changed WDL files
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            wdl:
+              - added|modified: "tasks/**/*.wdl"
+              - added|modified: "workflows/**/*.wdl"
+          list-files: json
+
+  lint:
+    name: Lint ${{ matrix.wdl }}
+    needs: changes
+    if: ${{ needs.changes.outputs.wdl_files != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        wdl: ${{ fromJSON(needs.changes.outputs.wdl_files) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install latest Sprocket
+        uses: jaxxstorm/action-install-gh-release@v3
+        with:
+          repo: stjude-rust-labs/sprocket
+          tag: latest
+          asset-name: sprocket
+
+      - name: Lint WDL
+        run: sprocket lint "${{ matrix.wdl }}"

--- a/.github/workflows/sprocket-lint.yml
+++ b/.github/workflows/sprocket-lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install latest Sprocket
         if: steps.filter.outputs.wdl == 'true'
-        uses: jaxxstorm/action-install-gh-release@v3
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: stjude-rust-labs/sprocket
           tag: latest

--- a/tasks/quality_control/basic_statistics/task_gene_coverage.wdl
+++ b/tasks/quality_control/basic_statistics/task_gene_coverage.wdl
@@ -65,8 +65,8 @@ task gene_coverage {
     Map[String, Float] depth_by_gene = read_json("DEPTH_DICT.json")
     Map[String, Float] breadth_by_gene = read_json("COVERAGE_DICT.json")
     # deprecated v4.2.0
-    Float sc2_s_gene_depth = read_string("SC2_S_GENE_DEPTH")
-    Float sc2_s_gene_coverage = read_string("SC2_S_GENE_COVERAGE")
+    Float sc2_s_gene_depth = read_float("SC2_S_GENE_DEPTH")
+    Float sc2_s_gene_coverage = read_float("SC2_S_GENE_COVERAGE")
   }
   runtime {
     docker: docker


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary

Added a GitHub Actions workflow that installed the latest stable Sprocket release and linted added or modified WDL files. The workflow passed all changed files to one `sprocket lint` invocation, reported warnings and notes without failing, and failed when Sprocket reported errors.

The repository already contains 234 Sprocket errors, so the workflow scoped linting to changed WDL files rather than permanently failing on unrelated legacy errors or hiding them in a large baseline.

## :zap: Impacted Workflows/Tasks

All WDL tasks and workflows are linted when added or modified.

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **Yes. The installer resolves the latest stable Sprocket release at run time, as required, so lint results may change after a new Sprocket release.**

## :hammer_and_wrench: Changes

### :gear: Algorithm

No task or workflow algorithms changed. CI now detects changed WDL files, installs Sprocket once, and lints the complete changed-file set.

### ➡️ Inputs

No task or workflow inputs changed.

### ⬅️ Outputs

No task or workflow outputs changed.

## :test_tube: Testing

Validated the workflow with `actionlint`, ran the exact multi-file lint script under Ubuntu 24.04 with Bash 5.2 and `jq` 1.7, and confirmed that Sprocket `v0.28.0` returned success for warnings and failure for an error.

I added commit [`8552fcf2`](https://github.com/claymcleod/public_health_bioinformatics/commit/8552fcf2) to correct two existing `read_string` type errors in `task_gene_coverage.wdl` and test the new workflow. The [Sprocket Lint run](https://github.com/theiagen/public_health_bioinformatics/actions/runs/29886063715) successfully detected and linted the changed file.

### Suggested Scenarios for Reviewer to Test

Add a warning-only WDL change and confirm the check passes, then add a syntax error and confirm the check fails.

## :microscope: Final Developer Checklist

- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist

- [ ] All changed results have been confirmed
- [ ] You have tested the changes appropriately
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)