### PR TITLE
[Documentation] Remove Escherichia from supported species for AMRSearch

### DIFF
--- a/docs/common_text/amr_search_task.md
+++ b/docs/common_text/amr_search_task.md
@@ -27,7 +27,6 @@ fragment: true
         | _Salmonella_ Typhi           | 90370     |
         | _Streptococcus pneumoniae_   | 1313      |
         | _Klebsiella_                | 570       |
-        | _Escherichia_                | 561       |
         | _Mycobacterium tuberculosis_ | 1773      |
         | _Candida auris_              | 498019    |
         | _Vibrio cholerae_            | 666       |


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!

Please ensure your contributions are formatted following our DOCUMENTATION style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/doc_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
Issue #1100 

<!-- Delete the < > around "NOT" if your branch should be retained after merging -->
🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR removes _Escherichia_ from the supported species table in the AMRSearch documentation as there is not a `.toml` within the library associated with it. This will cause confusion and errors for users if this species and NCBI code are used for AMRSearch. 

It is present in the Pathogen Watch repo, however, we should remove it from ours to reflect actual functionality. 

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] I have checked my updates for any errors or typos.
- [x] I have checked my updates for any rendering issues. If not, please explain why or request help below.
- [x] My updates follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
- [x] All CI checks are passing.

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changes have been confirmed to be accurate
- [x] You have verified all changes render correctly in the documentation by serving it locally.
- [x] The changes adhere to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
- [x] The PR author has addressed all comments
