### PR TITLE
[TheiaProk] AMRFinderPlus Update 4.2.7-2026-08-07.1

### DIFF
--- a/docs/assets/tables/all_inputs.tsv
+++ b/docs/assets/tables/all_inputs.tsv
@@ -231,7 +231,7 @@ amrfinderplus_nuc	annotation_format	String	The format of the annotation files		O
 amrfinderplus_nuc	cpu	Int	Number of CPUs to allocate to the task	2	Optional	AMRFinderPlus	runtime	
 amrfinderplus_nuc	detailed_drug_class	Boolean	If set to true, amrfinderplus_amr_classes and amrfinderplus_amr_subclasses outputs will be created	False	Optional	AMRFinderPlus	general	
 amrfinderplus_nuc	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	AMRFinderPlus	runtime	
-amrfinderplus_nuc	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-05-15.1	Optional	AMRFinderPlus	docker	
+amrfinderplus_nuc	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-08-07.1	Optional	AMRFinderPlus	docker	
 amrfinderplus_nuc	gff	File	GFF file provided by Prokka or Bakta when amrfinder_use_gff is set to true. This file is used to determine the location of AMR genes in the genome.		Optional	AMRFinderPlus	general	
 amrfinderplus_nuc	hide_point_mutations	Boolean	If set to true, the output File amrfinderplus_all_report will not include any POINT mutations identified by AMRFinderPlus.	False	Optional	AMRFinderPlus	general	
 amrfinderplus_nuc	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	8	Optional	AMRFinderPlus	runtime	
@@ -244,7 +244,7 @@ amrfinderplus_nuc	use_gff	Boolean	Whether or not to use the GFF and protein FAST
 amrfinderplus_task	cpu	Int	Number of CPUs to allocate to the task	2	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 amrfinderplus_task	detailed_drug_class	Boolean	If set to true, amrfinderplus_amr_classes and amrfinderplus_amr_subclasses outputs will be created	False	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	
 amrfinderplus_task	disk_size	Int	Amount of storage (in GB) to allocate to the task	50	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
-amrfinderplus_task	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-05-15.1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
+amrfinderplus_task	docker	String	The Docker container to use for the task	us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-08-07.1	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	docker	
 amrfinderplus_task	hide_point_mutations	Boolean	If set to true, point mutations are not reported	False	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	
 amrfinderplus_task	memory	Int	Amount of memory/RAM (in GB) to allocate to the task	8	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	runtime	
 amrfinderplus_task	min_percent_coverage	Float	Minimum proportion of reference gene covered for a BLAST-based hit (Methods BLAST or PARTIAL)." Attribute should be a float ranging from 0-1, such as 0.6 (equal to 60% coverage)	0.5	Optional	TheiaProk_FASTA, TheiaProk_Illumina_PE, TheiaProk_Illumina_SE, TheiaProk_ONT	general	

--- a/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
@@ -14,7 +14,7 @@ task amrfinderplus_nuc {
     Float min_percent_coverage = 0.5 # set to mirror v4.0.23 default
     Boolean detailed_drug_class = false
     Int cpu = 2
-    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-05-15.1"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.2.7-2026-08-07.1"
     Int disk_size = 50
     Int memory = 8
     Boolean hide_point_mutations = false


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
No associated Issue

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR updates the database of AMRFinderPlus to the most recent version of 2026-08-07.1.

## :zap: Impacted Workflows/Tasks

### Tasks
Δ `amrfinderplus_nuc`

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **Yes**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->
Yes due to additions to the NCBI hosted database.

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

Docker image update.

### ➡️ Inputs

### ⬅️ Outputs

## :test_tube: Testing
- [x] <details><summary>[amrfinderplus_wf](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/b3b0e169-f3e5-4fc5-8851-d40275591882)</summary>amrfinderplus_nuc</details>
- [x] <details><summary>[theiaprok_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/7230194c-9344-42a5-8b2d-4e1ac33ea0ea)</summary>amrfinderplus_nuc</details>
- [x] <details><summary>[theiaprok_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/ade5a19e-3f56-4572-9099-b7ee935b89fe)</summary>amrfinderplus_nuc</details>
- [x] <details><summary>[theiaprok_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/beab6b89-5580-494d-9a5e-8547d5bd5214)</summary>amrfinderplus_nuc</details>
- [x] <details><summary>[theiaprok_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/b63aa33a-5d30-4d68-a1a2-c4fda16eaba6)</summary>amrfinderplus_nuc</details>

<!-- Please describe how you tested this PR. -->
Tested for functionality with Bioforklift running a max of 15 samples per table with randomly selected samples. 

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the changes appropriately
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] The PR author has addressed all comments
- [x] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)