### PR TITLE
[TheiaCov] Output mapped reads to target organism for {kraken, metabuli}

### DIFF
--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -604,7 +604,9 @@ kraken_report_dehosted	File	Full Kraken report after host removal	NCBI_Scrub_PE,
 kraken_report_dehosted	String	Full Kraken report after host removal	Freyja_FASTQ
 kraken_target_organism	String	Percent of target organism read data detected using the Kraken2 software	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_dehosted	String	Percent of target organism read data detected using the Kraken2 software after host removal	NCBI_Scrub_PE, NCBI_Scrub_SE, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_dehosted_reads	String	Number of reads assigned to the target organism clade detected using the Kraken2 software after host removal	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_name	String	The name of the target organism; e.g., "Monkeypox" or "Human immunodeficiency virus"	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_reads	String	Number of reads assigned to the target organism clade detected using the Kraken2 software	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version	String	Version of Kraken software used	Freyja_FASTQ, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version_dehosted	String	Version of Kraken2 software used	NCBI_Scrub_PE, NCBI_Scrub_SE
 krona_docker	String	The docker image of Krona	Kraken_PE, Kraken_SE, TheiaMeta_Illumina_PE
@@ -720,7 +722,9 @@ metabuli_report_dehosted	String	Classification report from Metabuli after removi
 metabuli_status	String	Status of Metabuli analysis	Metabuli, TheiaViral_ONT
 metabuli_target_organism	String	Percent of reads classified to target organism for Metabuli analysis	TheiaCoV_ONT
 metabuli_target_organism_dehosted	String	Percent of reads classified to target organism for Metabuli analysis after removing human reads	TheiaCoV_ONT
+metabuli_target_organism_dehosted_reads	String	Number of reads classified to target organism for Metabuli analysis after removing human reads	TheiaCoV_ONT
 metabuli_target_organism_name	String	Name of the target organism for Metabuli analysis	TheiaCoV_ONT
+metabuli_target_organism_reads	String	Number of reads classified to target organism for Metabuli analysis	TheiaCoV_ONT
 metabuli_version	String	Version of Metabuli used	Freyja_FASTQ, Metabuli, TheiaCoV_ONT, TheiaProk_ONT, TheiaViral_ONT
 metabuli_wf_analysis_date	String	Analysis date for Metabuli workflow	Metabuli
 metabuli_wf_version	String	Version of Metabuli workflow	Metabuli

--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -604,9 +604,9 @@ kraken_report_dehosted	File	Full Kraken report after host removal	NCBI_Scrub_PE,
 kraken_report_dehosted	String	Full Kraken report after host removal	Freyja_FASTQ
 kraken_target_organism	String	Percent of target organism read data detected using the Kraken2 software	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_dehosted	String	Percent of target organism read data detected using the Kraken2 software after host removal	NCBI_Scrub_PE, NCBI_Scrub_SE, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
-kraken_target_organism_dehosted_reads	String	Number of reads assigned to the target organism clade detected using the Kraken2 software after host removal	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_dehosted_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software after host removal	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_name	String	The name of the target organism; e.g., "Monkeypox" or "Human immunodeficiency virus"	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
-kraken_target_organism_reads	String	Number of reads assigned to the target organism clade detected using the Kraken2 software	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version	String	Version of Kraken software used	Freyja_FASTQ, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version_dehosted	String	Version of Kraken2 software used	NCBI_Scrub_PE, NCBI_Scrub_SE
 krona_docker	String	The docker image of Krona	Kraken_PE, Kraken_SE, TheiaMeta_Illumina_PE
@@ -722,9 +722,9 @@ metabuli_report_dehosted	String	Classification report from Metabuli after removi
 metabuli_status	String	Status of Metabuli analysis	Metabuli, TheiaViral_ONT
 metabuli_target_organism	String	Percent of reads classified to target organism for Metabuli analysis	TheiaCoV_ONT
 metabuli_target_organism_dehosted	String	Percent of reads classified to target organism for Metabuli analysis after removing human reads	TheiaCoV_ONT
-metabuli_target_organism_dehosted_reads	String	Number of reads classified to target organism for Metabuli analysis after removing human reads	TheiaCoV_ONT
+metabuli_target_organism_dehosted_reads	String	Total mapped reads to the target organism clade for Metabuli analysis after removing human reads	TheiaCoV_ONT
 metabuli_target_organism_name	String	Name of the target organism for Metabuli analysis	TheiaCoV_ONT
-metabuli_target_organism_reads	String	Number of reads classified to target organism for Metabuli analysis	TheiaCoV_ONT
+metabuli_target_organism_reads	String	Total mapped reads to the target organism clade for Metabuli analysis	TheiaCoV_ONT
 metabuli_version	String	Version of Metabuli used	Freyja_FASTQ, Metabuli, TheiaCoV_ONT, TheiaProk_ONT, TheiaViral_ONT
 metabuli_wf_analysis_date	String	Analysis date for Metabuli workflow	Metabuli
 metabuli_wf_version	String	Version of Metabuli workflow	Metabuli

--- a/docs/assets/tables/all_outputs.tsv
+++ b/docs/assets/tables/all_outputs.tsv
@@ -604,9 +604,9 @@ kraken_report_dehosted	File	Full Kraken report after host removal	NCBI_Scrub_PE,
 kraken_report_dehosted	String	Full Kraken report after host removal	Freyja_FASTQ
 kraken_target_organism	String	Percent of target organism read data detected using the Kraken2 software	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_dehosted	String	Percent of target organism read data detected using the Kraken2 software after host removal	NCBI_Scrub_PE, NCBI_Scrub_SE, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
-kraken_target_organism_dehosted_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software after host removal	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_dehosted_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software after host removal	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_target_organism_name	String	The name of the target organism; e.g., "Monkeypox" or "Human immunodeficiency virus"	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
-kraken_target_organism_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software	TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
+kraken_target_organism_reads	String	Total mapped reads to the target organism clade detected using the Kraken2 software	TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version	String	Version of Kraken software used	Freyja_FASTQ, TheiaCoV_ClearLabs, TheiaCoV_Illumina_PE, TheiaCoV_Illumina_SE
 kraken_version_dehosted	String	Version of Kraken2 software used	NCBI_Scrub_PE, NCBI_Scrub_SE
 krona_docker	String	The docker image of Krona	Kraken_PE, Kraken_SE, TheiaMeta_Illumina_PE

--- a/tasks/taxon_id/contamination/task_kraken2.wdl
+++ b/tasks/taxon_id/contamination/task_kraken2.wdl
@@ -138,14 +138,27 @@ task kraken2 {
       echo "INFO: Percentage target organism (~{target_organism}):"
       echo $percent_target_organism | tee PERCENT_TARGET_ORGANISM
 
-      reads_target_organism=$(echo "$target_organism_line" | cut -f2)
-      if [ -z "$reads_target_organism" ]; then
-        reads_target_organism="0"
+      # column 2 of the kraken2 report is fragments covered by the clade. In --paired
+      # mode kraken2 counts a read pair as a single fragment, so this is read pairs for
+      # paired-end data and reads for single-end data
+      fragments_target_organism=$(echo "$target_organism_line" | cut -f2)
+      if [ -z "$fragments_target_organism" ]; then
+        fragments_target_organism="0"
+      fi
+      echo "INFO: Fragments assigned to target organism clade (~{target_organism}):"
+      echo $fragments_target_organism | tee FRAGMENTS_TARGET_ORGANISM
+
+      # convert fragments to reads so the value means reads on every platform
+      if [ "$mode" == "--paired" ]; then
+        reads_target_organism=$(( fragments_target_organism * 2 ))
+      else
+        reads_target_organism="$fragments_target_organism"
       fi
       echo "INFO: Reads assigned to target organism clade (~{target_organism}):"
       echo $reads_target_organism | tee READS_TARGET_ORGANISM
     else
       echo "" > PERCENT_TARGET_ORGANISM
+      echo "" > FRAGMENTS_TARGET_ORGANISM
       echo "" > READS_TARGET_ORGANISM
     fi
   >>>

--- a/tasks/taxon_id/contamination/task_kraken2.wdl
+++ b/tasks/taxon_id/contamination/task_kraken2.wdl
@@ -125,17 +125,28 @@ task kraken2 {
       mv "~{samplename}.unclassified#.fastq.gz" ~{samplename}.unclassified_1.fastq.gz
     fi
 
-    # capture target org percentage
+    # capture target org percent_target_organism and reads_target_organism
     if [ ! -z "~{target_organism}" ]; then
       echo "DEBUG: Target org designated: ~{target_organism}"
-      percent_target_organism=$(grep -P "\s~{target_organism}$" $kraken2_report  | cut -f1 | head -n1 )
+      # stage the line
+      target_organism_line=$(grep -P "\s~{target_organism}$" $kraken2_report | head -n1)
+
+      percent_target_organism=$(echo "$target_organism_line" | cut -f1)
       if [ -z "$percent_target_organism" ]; then
         percent_target_organism="0"
       fi
       echo "INFO: Percentage target organism (~{target_organism}):"
       echo $percent_target_organism | tee PERCENT_TARGET_ORGANISM
+
+      reads_target_organism=$(echo "$target_organism_line" | cut -f2)
+      if [ -z "$reads_target_organism" ]; then
+        reads_target_organism="0"
+      fi
+      echo "INFO: Reads assigned to target organism clade (~{target_organism}):"
+      echo $reads_target_organism | tee READS_TARGET_ORGANISM
     else
       echo "" > PERCENT_TARGET_ORGANISM
+      echo "" > READS_TARGET_ORGANISM
     fi
   >>>
   output {
@@ -145,6 +156,7 @@ task kraken2 {
     File? bracken_report = "~{samplename}_bracken_report.txt"
     Float kraken2_percent_human = read_float("PERCENT_HUMAN")
     String kraken2_percent_target_organism = read_string("PERCENT_TARGET_ORGANISM")
+    String kraken2_reads_target_organism = read_string("READS_TARGET_ORGANISM")
     String? kraken2_target_organism = target_organism
     File kraken2_classified_report = "~{samplename}.classifiedreads.txt.gz"
     File kraken2_unclassified_read1 = "~{samplename}.unclassified_1.fastq.gz"

--- a/tasks/taxon_id/contamination/task_kraken2.wdl
+++ b/tasks/taxon_id/contamination/task_kraken2.wdl
@@ -146,7 +146,7 @@ task kraken2 {
         fragments_target_organism="0"
       fi
       echo "INFO: Fragments assigned to target organism clade (~{target_organism}):"
-      echo $fragments_target_organism | tee FRAGMENTS_TARGET_ORGANISM
+      echo $fragments_target_organism
 
       # convert fragments to reads so the value means reads on every platform
       if [ "$mode" == "--paired" ]; then
@@ -158,7 +158,6 @@ task kraken2 {
       echo $reads_target_organism | tee READS_TARGET_ORGANISM
     else
       echo "" > PERCENT_TARGET_ORGANISM
-      echo "" > FRAGMENTS_TARGET_ORGANISM
       echo "" > READS_TARGET_ORGANISM
     fi
   >>>

--- a/tasks/taxon_id/contamination/task_metabuli.wdl
+++ b/tasks/taxon_id/contamination/task_metabuli.wdl
@@ -72,9 +72,11 @@ task metabuli {
 
     # Extract the reads
     echo "" > PERCENT_TARGET_LINEAGE
+    echo "" > READS_TARGET_LINEAGE
     if [[ -n "~{taxon_id}" ]]; then
       echo "DEBUG: Extracting reads"
       awk -F '\t' '$5 == "~{taxon_id}" {print $1}' output_dir/~{samplename}_report.tsv > PERCENT_TARGET_LINEAGE
+      awk -F '\t' '$5 == "~{taxon_id}" {print $1}' output_dir/~{samplename}_report.tsv > READS_TARGET_LINEAGE
       if [[ -s PERCENT_TARGET_LINEAGE ]]; then
         echo "DEBUG: Taxon ID ~{taxon_id} found in report, proceeding with read extraction"
         echo "DEBUG: ~{taxon_id} comprises $(cat PERCENT_TARGET_LINEAGE)% of reads"
@@ -121,6 +123,7 @@ task metabuli {
 
       else
         echo "0" > PERCENT_TARGET_LINEAGE
+        echo "0" > READS_TARGET_LINEAGE
         echo "ERROR: Taxon ID ~{taxon_id} not found in report, skipping read extraction"
         metabuli_status="FAIL; taxon not recovered"
       fi
@@ -139,6 +142,7 @@ task metabuli {
     String metabuli_docker = docker
     String metabuli_database = metabuli_db
     String metabuli_percent_target_lineage = read_string("PERCENT_TARGET_LINEAGE")
+    String metabuli_reads_target_lineage = read_string("READS_TARGET_LINEAGE")
     Float metabuli_percent_human = read_float("PERCENT_HUMAN")
   }
   runtime {

--- a/tasks/taxon_id/contamination/task_metabuli.wdl
+++ b/tasks/taxon_id/contamination/task_metabuli.wdl
@@ -76,7 +76,7 @@ task metabuli {
     if [[ -n "~{taxon_id}" ]]; then
       echo "DEBUG: Extracting reads"
       awk -F '\t' '$5 == "~{taxon_id}" {print $1}' output_dir/~{samplename}_report.tsv > PERCENT_TARGET_LINEAGE
-      awk -F '\t' '$5 == "~{taxon_id}" {print $1}' output_dir/~{samplename}_report.tsv > READS_TARGET_LINEAGE
+      awk -F '\t' '$5 == "~{taxon_id}" {print $2}' output_dir/~{samplename}_report.tsv > READS_TARGET_LINEAGE
       if [[ -s PERCENT_TARGET_LINEAGE ]]; then
         echo "DEBUG: Taxon ID ~{taxon_id} found in report, proceeding with read extraction"
         echo "DEBUG: ~{taxon_id} comprises $(cat PERCENT_TARGET_LINEAGE)% of reads"

--- a/workflows/theiacov/wf_theiacov_clearlabs.wdl
+++ b/workflows/theiacov/wf_theiacov_clearlabs.wdl
@@ -179,10 +179,12 @@ workflow theiacov_clearlabs {
     String kraken_version = kraken2_raw.kraken2_version
     Float kraken_human = kraken2_raw.kraken2_percent_human
     String kraken_target_organism = kraken2_raw.kraken2_percent_target_organism
+    String kraken_target_organism_reads = kraken2_raw.kraken2_reads_target_organism
     String kraken_target_organism_name = organism_parameters.kraken_target_organism
     File kraken_report = kraken2_raw.kraken2_report
     Float kraken_human_dehosted = kraken2_dehosted.kraken2_percent_human
     String kraken_target_organism_dehosted = kraken2_dehosted.kraken2_percent_target_organism
+    String kraken_target_organism_dehosted_reads = kraken2_dehosted.kraken2_reads_target_organism
     File kraken_report_dehosted = kraken2_dehosted.kraken2_report
     # Read Alignment - Artic consensus outputs
     File aligned_bam = consensus.trim_sorted_bam

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -316,13 +316,13 @@ workflow theiacov_illumina_pe {
     String? bracken_version = read_QC_trim.bracken_version
     Float? kraken_human = read_QC_trim.kraken2_human
     String? kraken_target_organism = read_QC_trim.kraken2_target_organism
-    String? kraken_reads_target_organism = read_QC_trim.kraken2_reads_target_organism
+    String? kraken_target_organism_reads = read_QC_trim.kraken2_reads_target_organism
     String? kraken_target_organism_name = read_QC_trim.kraken2_target_organism_name
     File? kraken_report = read_QC_trim.kraken2_report
     String? bracken_report = read_QC_trim.bracken_report
     Float? kraken_human_dehosted = read_QC_trim.kraken2_human_dehosted
     String? kraken_target_organism_dehosted = read_QC_trim.kraken2_target_organism_dehosted
-    String? kraken_reads_target_organism_dehosted = read_QC_trim.kraken2_reads_target_organism_dehosted
+    String? kraken_target_organism_dehosted_reads = read_QC_trim.kraken2_reads_target_organism_dehosted
     File? kraken_report_dehosted = read_QC_trim.kraken2_report_dehosted
     String? bracken_report_dehosted = read_QC_trim.bracken_report_dehosted
     # Read QC - rasusa outputs

--- a/workflows/theiacov/wf_theiacov_illumina_pe.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_pe.wdl
@@ -316,11 +316,13 @@ workflow theiacov_illumina_pe {
     String? bracken_version = read_QC_trim.bracken_version
     Float? kraken_human = read_QC_trim.kraken2_human
     String? kraken_target_organism = read_QC_trim.kraken2_target_organism
+    String? kraken_reads_target_organism = read_QC_trim.kraken2_reads_target_organism
     String? kraken_target_organism_name = read_QC_trim.kraken2_target_organism_name
     File? kraken_report = read_QC_trim.kraken2_report
     String? bracken_report = read_QC_trim.bracken_report
     Float? kraken_human_dehosted = read_QC_trim.kraken2_human_dehosted
     String? kraken_target_organism_dehosted = read_QC_trim.kraken2_target_organism_dehosted
+    String? kraken_reads_target_organism_dehosted = read_QC_trim.kraken2_reads_target_organism_dehosted
     File? kraken_report_dehosted = read_QC_trim.kraken2_report_dehosted
     String? bracken_report_dehosted = read_QC_trim.bracken_report_dehosted
     # Read QC - rasusa outputs

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -252,10 +252,12 @@ workflow theiacov_illumina_se {
     Float? kraken_human = read_QC_trim.kraken2_human
     String? kraken_target_organism = read_QC_trim.kraken2_target_organism
     String? kraken_target_organism_name = read_QC_trim.kraken2_target_organism_name
+    String? kraken_reads_target_organism = read_QC_trim.kraken2_reads_target_organism
     File? kraken_report = read_QC_trim.kraken2_report
     String? bracken_report = read_QC_trim.bracken_report
     Float? kraken_human_dehosted = read_QC_trim.kraken2_human_dehosted
     String? kraken_target_organism_dehosted = read_QC_trim.kraken2_target_organism_dehosted
+    String? kraken_reads_target_organism_dehosted = read_QC_trim.kraken2_reads_target_organism_dehosted
     File? kraken_report_dehosted = read_QC_trim.kraken2_report_dehosted
     File? bracken_report_dehosted = read_QC_trim.bracken_report_dehosted
     # Read QC - rasusa outputs

--- a/workflows/theiacov/wf_theiacov_illumina_se.wdl
+++ b/workflows/theiacov/wf_theiacov_illumina_se.wdl
@@ -252,12 +252,12 @@ workflow theiacov_illumina_se {
     Float? kraken_human = read_QC_trim.kraken2_human
     String? kraken_target_organism = read_QC_trim.kraken2_target_organism
     String? kraken_target_organism_name = read_QC_trim.kraken2_target_organism_name
-    String? kraken_reads_target_organism = read_QC_trim.kraken2_reads_target_organism
+    String? kraken_target_organism_reads = read_QC_trim.kraken2_reads_target_organism
     File? kraken_report = read_QC_trim.kraken2_report
     String? bracken_report = read_QC_trim.bracken_report
     Float? kraken_human_dehosted = read_QC_trim.kraken2_human_dehosted
     String? kraken_target_organism_dehosted = read_QC_trim.kraken2_target_organism_dehosted
-    String? kraken_reads_target_organism_dehosted = read_QC_trim.kraken2_reads_target_organism_dehosted
+    String? kraken_target_organism_dehosted_reads = read_QC_trim.kraken2_reads_target_organism_dehosted
     File? kraken_report_dehosted = read_QC_trim.kraken2_report_dehosted
     File? bracken_report_dehosted = read_QC_trim.bracken_report_dehosted
     # Read QC - rasusa outputs

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -287,12 +287,12 @@ workflow theiacov_ont {
     # Read QC - metabuli outputs raw
     Float? metabuli_human = read_QC_trim.metabuli_percent_human
     String? metabuli_target_organism = read_QC_trim.metabuli_percent_target_organism
-    String? metabuli_reads_target_organism = read_QC_trim.metabuli_reads_target_organism
+    String? metabuli_target_organism_reads = read_QC_trim.metabuli_reads_target_organism
     String? metabuli_report = read_QC_trim.metabuli_report
     # Read QC - metabuli outputs dehosted
     Float? metabuli_human_dehosted = read_QC_trim.metabuli_percent_human_dehosted
     String? metabuli_target_organism_dehosted = read_QC_trim.metabuli_percent_target_organism_dehosted
-    String? metabuli_reads_target_organism_dehosted = read_QC_trim.metabuli_reads_target_organism_dehosted
+    String? metabuli_target_organism_dehosted_reads = read_QC_trim.metabuli_reads_target_organism_dehosted
     String? metabuli_report_dehosted = read_QC_trim.metabuli_report_dehosted
     # Read Alignment - Artic consensus and IRMA Aligned outputs
     String assembly_fasta = select_first([consensus.consensus_seq, flu_track.irma_assembly_fasta, "Assembly could not be generated"])

--- a/workflows/theiacov/wf_theiacov_ont.wdl
+++ b/workflows/theiacov/wf_theiacov_ont.wdl
@@ -287,10 +287,12 @@ workflow theiacov_ont {
     # Read QC - metabuli outputs raw
     Float? metabuli_human = read_QC_trim.metabuli_percent_human
     String? metabuli_target_organism = read_QC_trim.metabuli_percent_target_organism
+    String? metabuli_reads_target_organism = read_QC_trim.metabuli_reads_target_organism
     String? metabuli_report = read_QC_trim.metabuli_report
     # Read QC - metabuli outputs dehosted
     Float? metabuli_human_dehosted = read_QC_trim.metabuli_percent_human_dehosted
     String? metabuli_target_organism_dehosted = read_QC_trim.metabuli_percent_target_organism_dehosted
+    String? metabuli_reads_target_organism_dehosted = read_QC_trim.metabuli_reads_target_organism_dehosted
     String? metabuli_report_dehosted = read_QC_trim.metabuli_report_dehosted
     # Read Alignment - Artic consensus and IRMA Aligned outputs
     String assembly_fasta = select_first([consensus.consensus_seq, flu_track.irma_assembly_fasta, "Assembly could not be generated"])

--- a/workflows/utilities/wf_read_QC_trim_ont.wdl
+++ b/workflows/utilities/wf_read_QC_trim_ont.wdl
@@ -186,10 +186,13 @@ workflow read_QC_trim_ont {
     String metabuli_percent_human = select_first([metabuli_theiacov_raw.metabuli_percent_human, metabuli_theiaprok.metabuli_percent_human, ""])
     String? metabuli_target_organism = ete4_taxon_id.taxon_name
     String metabuli_percent_target_organism = select_first([metabuli_theiacov_raw.metabuli_percent_target_lineage, metabuli_theiaprok.metabuli_percent_target_lineage, ""])
+    String metabuli_reads_target_organism = select_first([metabuli_theiacov_raw.metabuli_reads_target_lineage, metabuli_theiaprok.metabuli_reads_target_lineage, ""])
+
     String? metabuli_taxon_id = ete4_taxon_id.taxon_id
     String metabuli_report = select_first([metabuli_theiacov_raw.metabuli_report, metabuli_theiaprok.metabuli_report, ""])
     Float? metabuli_percent_human_dehosted = metabuli_theiacov_dehosted.metabuli_percent_human
     String? metabuli_percent_target_organism_dehosted = metabuli_theiacov_dehosted.metabuli_percent_target_lineage
+    String? metabuli_reads_target_organism_dehosted = metabuli_theiacov_dehosted.metabuli_reads_target_lineage
     File? metabuli_report_dehosted = metabuli_theiacov_dehosted.metabuli_report
     String metabuli_database = select_first([metabuli_theiacov_raw.metabuli_database, metabuli_theiaprok.metabuli_database, ""])
 

--- a/workflows/utilities/wf_read_QC_trim_pe.wdl
+++ b/workflows/utilities/wf_read_QC_trim_pe.wdl
@@ -296,10 +296,12 @@ workflow read_QC_trim_pe {
     String bracken_version = select_first([kraken2_theiacov_raw.bracken_version, kraken2_standalone.bracken_version, ""])
     Float? kraken2_human =  kraken2_theiacov_raw.kraken2_percent_human
     String? kraken2_target_organism = kraken2_theiacov_raw.kraken2_percent_target_organism
+    String? kraken2_reads_target_organism = kraken2_theiacov_raw.kraken2_reads_target_organism
     String kraken2_report = select_first([kraken2_theiacov_raw.kraken2_report, kraken2_standalone.kraken2_report, ""])
     String? bracken_report = select_first([kraken2_theiacov_raw.bracken_report, kraken2_standalone.bracken_report, ""])
     Float? kraken2_human_dehosted = kraken2_theiacov_dehosted.kraken2_percent_human
     String? kraken2_target_organism_dehosted = kraken2_theiacov_dehosted.kraken2_percent_target_organism
+    String? kraken2_reads_target_organism_dehosted = kraken2_theiacov_dehosted.kraken2_reads_target_organism
     String? kraken2_target_organism_name = target_organism
     File? kraken2_report_dehosted = kraken2_theiacov_dehosted.kraken2_report
     File? bracken_report_dehosted = kraken2_theiacov_dehosted.bracken_report

--- a/workflows/utilities/wf_read_QC_trim_se.wdl
+++ b/workflows/utilities/wf_read_QC_trim_se.wdl
@@ -219,10 +219,12 @@ workflow read_QC_trim_se {
     String bracken_version = select_first([kraken2_theiacov_raw.bracken_version, kraken2_theiaprok.bracken_version, ""])
     Float? kraken2_human = kraken2_theiacov_raw.kraken2_percent_human
     String? kraken2_target_organism = kraken2_theiacov_raw.kraken2_percent_target_organism
+    String? kraken2_reads_target_organism = kraken2_theiacov_raw.kraken2_reads_target_organism
     String kraken2_report = select_first([kraken2_theiacov_raw.kraken2_report, kraken2_theiaprok.kraken2_report, ""])
     String bracken_report = select_first([kraken2_theiacov_raw.bracken_report, kraken2_theiaprok.bracken_report, ""])
     Float? kraken2_human_dehosted = kraken2_theiacov_dehosted.kraken2_percent_human
     String? kraken2_target_organism_dehosted = kraken2_theiacov_dehosted.kraken2_percent_target_organism
+    String? kraken2_reads_target_organism_dehosted = kraken2_theiacov_dehosted.kraken2_reads_target_organism
     String? kraken2_target_organism_name = target_organism
     File? kraken2_report_dehosted = kraken2_theiacov_dehosted.kraken2_report
     File? bracken_report_dehosted = kraken2_theiacov_dehosted.bracken_report


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #

🗑️ This dev branch should <NOT> be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->

This PR extracts the target organism reads from kraken (theiacov_illumina_pe, theiacov_illumina_se) or metabuli (theiacov_ont) and reports them alongside the target organism percentage. This change is needed to provide labs statistics needed for reporting NTC to CDC based on their surveillance guidance. Shelly confirmed the output names and extraction method.  
This scope of work was specifically requested for theiacov and is thus reflected in this PR. 

## :zap: Impacted Workflows/Tasks

### Workflows
Δ `read_QC_trim_ont`

Δ `read_QC_trim_pe`

Δ `read_QC_trim_se`

Δ `theiacov_illumina_pe`

Δ `theiacov_illumina_se`

Δ `theiacov_ont`




### Tasks
Δ `kraken2`

Δ `metabuli`




This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

Extracts 2nd column from kraken and metabuli to report reads mapped to target organism, when target organism is provided. One thing to note is that for PE the extracted fragments is multiplied by 2 since column two in --paired mode for kraken reports read pairs. 

To calculate for a sanity check can do total_raw_reads * kraken_target_organism / 100

### ➡️ Inputs


### ⬅️ Outputs


<details>
<summary>theiacov_illumina_pe +2 -0</summary>

	+ kraken_target_organism_dehosted_reads
	+ kraken_target_organism_reads

</details>

<details>
<summary>read_QC_trim_ont +2 -0</summary>

	+ metabuli_reads_target_organism
	+ metabuli_reads_target_organism_dehosted

</details>

<details>
<summary>theiacov_illumina_se +2 -0</summary>

	+ kraken_target_organism_dehosted_reads
	+ kraken_target_organism_reads

</details>

<details>
<summary>theiacov_ont +2 -0</summary>

	+ metabuli_target_organism_dehosted_reads
	+ metabuli_target_organism_reads

</details>

<details>
<summary>read_QC_trim_se +2 -0</summary>

	+ kraken2_reads_target_organism
	+ kraken2_reads_target_organism_dehosted

</details>

<details>
<summary>read_QC_trim_pe +2 -0</summary>

	+ kraken2_reads_target_organism
	+ kraken2_reads_target_organism_dehosted

</details>

[TheiaProk Illumina PE sanity check](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/dbe1a898-13ff-4ffa-bcd2-442888a2c995)

## :test_tube: Testing
read_QC_trim_se</details>
- [x] <details><summary>[theiacov_clearlabs](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/5421ccd5-5710-49cf-b519-5cf195873e94)</summary>kraken2</details>
- [x] <details><summary>[theiacov_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/63886f0c-de78-46c9-8172-a39608e0c0c2)</summary>kraken2, read_QC_trim_pe</details>
- [x] <details><summary>[theiacov_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/77ff98af-e308-48bc-825b-bc920a599b5a)</summary>kraken2, read_QC_trim_se</details>
- [x] <details><summary>[theiacov_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/2fd0ec68-5d9f-4596-931e-2d9780b75758)</summary>metabuli, read_QC_trim_ont</details>

<!-- Please describe how you tested this PR. -->

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [x] All changed results have been confirmed
- [x] You have tested the changes appropriately
- [x] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
