### PR TITLE
[TheiaProk] Add "POINT_DISRUPT" to hide_point_mutations Exclusion

### DIFF
--- a/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/drug_resistance/task_amrfinderplus.wdl
@@ -106,7 +106,7 @@ task amrfinderplus_nuc {
 
     # remove mutations where Element subtype is "POINT"
     if [[ "~{hide_point_mutations}" == "true" ]]; then
-      awk -F "\t" '$11 != "POINT"' ~{samplename}_amrfinder_all.tsv >> temp.tsv
+      awk -F "\t" '$11 != "POINT" && $11 != "POINT_DISRUPT"' ~{samplename}_amrfinder_all.tsv >> temp.tsv
       mv temp.tsv ~{samplename}_amrfinder_all.tsv
     fi
 


### PR DESCRIPTION
<!--
Thank you for contributing to Theiagen's Public Health Bioinformatics repository!

Please ensure your contributions are formatted following our style guide, which can be found here: <https://theiagen.github.io/public_health_bioinformatics/latest/contributing/code_contribution/>.

As you create the PR, please provide any necessary information as suggested in the comments that will help us test your PR.
-->

<!-- Indicate the issue number if applicable; otherwise, delete -->
This PR closes #1130 

🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
<!-- Please summarize what this PR does -->
This PR adds `POINT_DISRUPT` to the `hide_point_mutations` exclusion which previously just included `POINT`. This is needed as the `POINT_DISRUPT` classification was added in v4.2.4 which populates the same column as `POINT`. 

## :zap: Impacted Workflows/Tasks

### Tasks
Δ `amrfinderplus_nuc`

This PR may lead to different results in pre-existing outputs: **No**

This PR uses an element that could cause duplicate runs to have different results: **No**
<!-- This may be due to using a live database or stochastic data processing. If yes, please describe. -->

## :hammer_and_wrench: Changes
<!-- Describe your changes. -->

Added `POINT_DISRUPT` to the `awk` command within the `hide_point_mutations` conditional. 

### :gear: Algorithm
<!-- Have any changes been made to the algorithm or processing changes under the hood? This can include any changes to the task/workflow algorithm; Docker, software, or database versions; compute resources; etc. If so, please explain. -->

### ➡️ Inputs

### ⬅️ Outputs

## :test_tube: Testing
- [ ] <details><summary>~~amrfinderplus_wf~~</summary>amrfinderplus_nuc</details>
- [ ] <details><summary>[theiaprok_fasta](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/b988e459-03ba-4afa-9c19-84ad87a4432a)</summary>amrfinderplus_nuc</details>
- [ ] <details><summary>[theiaprok_illumina_pe](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/cf6c4f10-fde0-48ba-9a51-9cda7c3138b9)</summary>amrfinderplus_nuc</details>
- [ ] <details><summary>[theiaprok_illumina_se](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/76c7389f-e95f-4d7d-9d13-bc3e7c7b8776)</summary>amrfinderplus_nuc</details>
- [ ] <details><summary>[theiaprok_ont](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/submission_history/71f4fc84-90ca-4637-968e-60acd26cd1c7)</summary>amrfinderplus_nuc</details>

<!-- Please describe how you tested this PR. -->

Workflows above were run with `hide_point_mutations` set to `true` and the AMRFinderPlus all report was parsed to check for occurrences of POINT/POINT_DISRUPT. The samples in TheiaProk_FASTA are known to have POINT_DISRUPT to occur so its absence was checked and confirmed. 

### Suggested Scenarios for Reviewer to Test
<!-- Please list any potential scenarios that the reviewer should test, including edge cases or data types -->

When running tests parse the AMR report to check for `POINT` or `POINT_DISRUPT`.

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [x] Documentation and/or workflow diagrams have been updated if applicable and follow the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)
  - [x] You have updated the "Last Known Changes" field for any affected workflows in the respective workflow documentation page and for the entry in the `docs/assets/tables/all_workflows.tsv` table to be the tag for the next upcoming release. If you do not know the tag, please put "vX.X.X"

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [ ] You have tested the changes appropriately
- [ ] All code adheres to the [style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/code_contribution/)
- [ ] The PR author has addressed all comments
- [ ] The documentation has been updated and adheres to the [documentation style guide](https://theiagen.github.io/public_health_bioinformatics/main/contributing/doc_contribution/)